### PR TITLE
fix: Vercel deployment - framework detection + conditional mount

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,7 @@ def drill(req: DrillRequest):
         raise HTTPException(status_code=500, detail=str(err))
 
 
-# Serve the frontend. API routes must be defined above this mount.
-# Path(__file__).parent resolves correctly both locally and on Vercel.
-app.mount("/", StaticFiles(directory=str(Path(__file__).parent / "public"), html=True), name="static")
+# Serve the frontend locally. On Vercel, static files are served by the CDN.
+_public_dir = Path(__file__).parent / "public"
+if _public_dir.is_dir():
+    app.mount("/", StaticFiles(directory=str(_public_dir), html=True), name="static")

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,3 @@
 {
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/api/index.py" }
-  ]
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/index.py" },
-    { "source": "/(.*)", "destination": "/public/$1" }
-  ],
-  "functions": {
-    "api/**/*.py": {
-      "maxDuration": 60
-    }
-  }
+    { "source": "/(.*)", "destination": "/api/index.py" }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
-  "functions": {
-    "api/index.py": {
-      "includeFiles": "{public/**,learnops/**}"
-    }
-  },
+  "outputDirectory": "public",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/api/index.py" }
+    { "source": "/api/(.*)", "destination": "/api/index.py" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
-  "outputDirectory": "public",
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/index.py" }
-  ]
+    { "source": "/api/(.*)", "destination": "/api/index.py" },
+    { "source": "/(.*)", "destination": "/public/$1" }
+  ],
+  "functions": {
+    "api/**/*.py": {
+      "maxDuration": 60
+    }
+  }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,9 @@
 {
+  "functions": {
+    "api/index.py": {
+      "includeFiles": "{public/**,learnops/**}"
+    }
+  },
   "rewrites": [
     { "source": "/(.*)", "destination": "/api/index.py" }
   ]


### PR DESCRIPTION
## Summary
- **Conditional StaticFiles mount**: `public/` doesn't exist in Vercel's function bundle (it's served by CDN). The mount now only activates locally where the directory exists.
- **Framework detection**: Removed manual rewrites and `functions` config. Vercel auto-detects `main.py` as FastAPI, serves `public/` via CDN, and routes API calls through the function.
- Fixes `RuntimeError: Directory '/var/task/public' does not exist` on every deployment since the `public/` reorganization was merged.

## Root cause
PR #3 merged the directory reorganization (commit 6a92ec0) which moved frontend files to `public/` but had an unconditional `StaticFiles` mount. The fix commits were pushed to `feature/graph-feature` *after* that PR was merged, so `main` never received them.

## Test plan
- [ ] Vercel deployment succeeds without errors
- [ ] Static files (index.html, CSS, JS) load correctly from CDN
- [ ] `/api/health` returns 200
- [ ] `/api/extract` and `/api/drill` endpoints work

🤖 Generated with [Claude Code](https://claude.com/claude-code)