### PR TITLE
fix: disable framework detection, bundle public/ into serverless func…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,12 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "functions": {
+    "api/index.py": {
+      "includeFiles": "{public/**,learnops/**}"
+    }
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api/index.py" }
+  ]
 }


### PR DESCRIPTION
…tion

Framework detection excluded public/ from the function bundle and CDN wasn't serving it either, causing 404s. Disable auto-detection with framework: null, use api/index.py as plain serverless function, and explicitly include public/ and learnops/ via includeFiles.