### PR TITLE
fix(drill): restore map close

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -65,6 +65,10 @@
   padding: 28px 40px 0;
   flex-shrink: 0;
 }
+body[data-map-open="true"] .main-header {
+  opacity: 0;
+  pointer-events: none;
+}
 .main-header-left {
   display: flex;
   align-items: center;
@@ -339,6 +343,7 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
   position: absolute;
   top: 24px;
   right: 32px;
+  z-index: 3;
   background: var(--accent-soft);
   border: none;
   border-radius: 50%;
@@ -356,6 +361,11 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 .map-close-btn:hover {
   background: var(--primary-fill);
   color: var(--text-on-primary);
+}
+
+body[data-map-open="true"] .drawer-toggle {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* Map Zones */
@@ -576,13 +586,17 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 /* Mobile adjustments for map and library views */
 @media (max-width: 899px) {
   .map-view { 
-    padding: 56px 24px 24px; 
+    padding: 96px 24px 24px; 
     border-radius: 0; 
     position: fixed; 
     top: 0; left: 0; right: 0; bottom: 0;
     z-index: 2000;
     height: 100dvh;
     box-sizing: border-box;
+  }
+  .map-close-btn {
+    top: 66px;
+    right: 20px;
   }
   .library-view {
     padding: 24px 16px; 
@@ -602,9 +616,8 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
   .library-vault-grid {
     grid-template-columns: 1fr;
   }
-  .map-close-btn { top: 16px; right: 16px; }
   .map-core-thesis { font-size: 17px; }
-  .map-view-shell { gap: 18px; }
+  .map-view-shell { gap: 18px; padding-top: 4px; }
   .map-mode-switch { width: 100%; }
   .map-mode-btn { flex: 1; }
   .graph-layout {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -66,6 +66,13 @@ const App = (() => {
     applyThemePreference(themePreference === 'dark' ? 'light' : 'dark');
   }
 
+  function setMapShellOpen(isOpen) {
+    document.body.dataset.mapOpen = isOpen ? 'true' : 'false';
+    if (!drawerToggle) return;
+    drawerToggle.setAttribute('aria-hidden', String(isOpen));
+    drawerToggle.tabIndex = isOpen ? -1 : 0;
+  }
+
   function getHeroStateLabel(state) {
     switch (state) {
       case 'instantiated': return 'Instantiated';
@@ -1155,7 +1162,9 @@ const App = (() => {
 
     heroCard.style.display = 'none';
     mapView.classList.add('visible');
+    setMapShellOpen(true);
     if (graphContent) graphContent.hidden = false;
+    if (window.innerWidth < 900) closeDrawer();
     setMapMode('study');
     scheduleTutorialRefresh();
   }
@@ -1163,11 +1172,15 @@ const App = (() => {
   function hideMapView() {
     const mapView = document.getElementById('map-view');
     const heroCard = document.querySelector('.hero-card');
+    if (drillState.active || drillState.pending || drillState.node) {
+      cancelDrill();
+    }
     if (currentGraphController) {
       currentGraphController.destroy();
       currentGraphController = null;
     }
     if (mapView) mapView.classList.remove('visible');
+    setMapShellOpen(false);
     if (heroCard) heroCard.style.display = 'flex';
     scheduleTutorialRefresh();
   }
@@ -1217,11 +1230,13 @@ const App = (() => {
 
     if (libraryView) libraryView.classList.remove('visible');
     if (mapView) mapView.classList.remove('visible');
+    setMapShellOpen(false);
     if (currentGraphController) {
       currentGraphController.destroy();
       currentGraphController = null;
     }
     if (heroCard) heroCard.style.display = 'flex';
+    if (window.innerWidth < 900) closeDrawer();
     scheduleTutorialRefresh();
   }
 
@@ -1296,9 +1311,12 @@ const App = (() => {
   function showLibrary() {
     setNavActive('nav-library');
     const libraryView = document.getElementById('library-view');
+    const mapView = document.getElementById('map-view');
     const heroCard = document.querySelector('.hero-card');
     const content = document.getElementById('library-content');
 
+    if (mapView) mapView.classList.remove('visible');
+    setMapShellOpen(false);
     const concepts = loadConcepts().filter(c => c.graphData);
 
     let html = `
@@ -1460,6 +1478,7 @@ const App = (() => {
     probeCount: 0,
     nodesDrilled: 0,
     sessionStartIso: null,
+    sessionToken: 0,
   };
 
   function parseConceptGraphData(concept) {
@@ -1615,6 +1634,7 @@ const App = (() => {
   async function requestDrillTurn(userText) {
     const concept = getActiveConcept();
     if (!concept || !drillState.node) return;
+    const sessionToken = drillState.sessionToken;
 
     drillState.pending = true;
     if (chatInput) chatInput.disabled = true;
@@ -1631,58 +1651,71 @@ const App = (() => {
       ? JSON.parse(concept.graphData)
       : concept.graphData;
 
-    const apiKey = localStorage.getItem('gemini_key') || undefined;
-    const response = await fetch('/api/drill', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        concept_id: concept.id,
-        node_id: drillState.node.id,
-        node_label: drillState.node.fullLabel || drillState.node.label || concept.name,
-        node_mechanism: drillState.node.detail || '',
-        knowledge_map: knowledgeMap,
-        messages: outboundMessages,
-        session_phase: sessionPhase,
-        probe_count: drillState.probeCount,
-        nodes_drilled: drillState.nodesDrilled,
-        session_start_iso: drillState.sessionStartIso,
-        api_key: apiKey,
-      }),
-    });
+    try {
+      const apiKey = localStorage.getItem('gemini_key') || undefined;
+      const response = await fetch('/api/drill', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          concept_id: concept.id,
+          node_id: drillState.node.id,
+          node_label: drillState.node.fullLabel || drillState.node.label || concept.name,
+          node_mechanism: drillState.node.detail || '',
+          knowledge_map: knowledgeMap,
+          messages: outboundMessages,
+          session_phase: sessionPhase,
+          probe_count: drillState.probeCount,
+          nodes_drilled: drillState.nodesDrilled,
+          session_start_iso: drillState.sessionStartIso,
+          api_key: apiKey,
+        }),
+      });
 
-    if (!response.ok) {
-      const err = await response.text().catch(() => '');
-      throw new Error(`Drill request failed: ${response.status}: ${err}`);
-    }
-
-    const data = await response.json();
-    console.log(
-      `[drill] classification=${data?.classification ?? 'null'} routing=${data?.routing ?? 'null'} terminated=${Boolean(data?.session_terminated)}`
-    );
-    console.log('[drill] response', data);
-    hideTypingIndicator();
-
-    patchActiveConceptDrillOutcome(data);
-    drillState.messages = outboundMessages;
-    drillState.probeCount = data.probe_count ?? drillState.probeCount;
-    drillState.nodesDrilled = data.nodes_drilled ?? drillState.nodesDrilled;
-    handleDrillAssistantMessage(data.agent_response || '');
-    if (data.agent_response?.trim()) {
-      drillState.messages.push({ role: 'assistant', content: data.agent_response.trim() });
-    }
-    drillState.pending = false;
-    const completedNodeTurn = data.routing === 'NEXT'
-      || (data.routing === 'SESSION_COMPLETE' && !!data.classification);
-    if (chatInput) {
-      chatInput.disabled = completedNodeTurn || !!data.session_terminated;
-      if (!completedNodeTurn && !data.session_terminated) {
-        chatInput.focus();
+      if (!response.ok) {
+        const err = await response.text().catch(() => '');
+        throw new Error(`Drill request failed: ${response.status}: ${err}`);
       }
-    }
-    if (completedNodeTurn) {
-      currentGraphController?.setInteractionMode?.('post-drill', activeDrillNode);
-    } else {
-      currentGraphController?.setInteractionMode?.('drill-active', activeDrillNode);
+
+      const data = await response.json();
+      console.log(
+        `[drill] classification=${data?.classification ?? 'null'} routing=${data?.routing ?? 'null'} terminated=${Boolean(data?.session_terminated)}`
+      );
+      console.log('[drill] response', data);
+      hideTypingIndicator();
+
+      if (sessionToken !== drillState.sessionToken || !drillState.node) {
+        return;
+      }
+
+      patchActiveConceptDrillOutcome(data);
+      drillState.messages = outboundMessages;
+      drillState.probeCount = data.probe_count ?? drillState.probeCount;
+      drillState.nodesDrilled = data.nodes_drilled ?? drillState.nodesDrilled;
+      handleDrillAssistantMessage(data.agent_response || '');
+      if (data.agent_response?.trim()) {
+        drillState.messages.push({ role: 'assistant', content: data.agent_response.trim() });
+      }
+      drillState.pending = false;
+      const completedNodeTurn = data.routing === 'NEXT'
+        || (data.routing === 'SESSION_COMPLETE' && !!data.classification);
+      if (chatInput) {
+        chatInput.disabled = completedNodeTurn || !!data.session_terminated;
+        if (!completedNodeTurn && !data.session_terminated) {
+          chatInput.focus();
+        }
+      }
+      if (completedNodeTurn) {
+        currentGraphController?.setInteractionMode?.('post-drill', activeDrillNode);
+      } else {
+        currentGraphController?.setInteractionMode?.('drill-active', activeDrillNode);
+      }
+    } catch (err) {
+      hideTypingIndicator();
+      if (sessionToken !== drillState.sessionToken) {
+        return;
+      }
+      drillState.pending = false;
+      throw err;
     }
   }
 
@@ -1707,6 +1740,7 @@ const App = (() => {
     drillState.probeCount = 0;
     drillState.nodesDrilled = 0;
     drillState.sessionStartIso = new Date().toISOString();
+    drillState.sessionToken += 1;
     activeDrillNode = nodeContext?.id || null;
 
     if (drillUi) drillUi.style.display = 'flex';
@@ -1734,8 +1768,10 @@ const App = (() => {
   }
 
   function cancelDrill() {
+    drillState.sessionToken += 1;
     drillState.active = false;
     drillState.messages = [];
+    drillState.node = null;
     drillState.pending = false;
     drillState.probeCount = 0;
     drillState.nodesDrilled = 0;


### PR DESCRIPTION
## Context & Intent
- What problem does this solve?
  The drill shell could trap users because the top-right map close button was visually present but not clickable. On narrow screens, the same header layer also overlapped the Study View / Graph View selector.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)?
  MVP stabilization hot-fix for the drill and graph shell.

## Implementation Details
- Brief overview of technical changes.
  Added explicit map-shell open state so the app header and hamburger stop intercepting pointer events while the map is open. Raised and repositioned the map close button for mobile, added top spacing for the mode switch, and made map close tear down active drill state. Added a drill session token guard so late async drill responses are ignored after exit.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing).
  Frontend-only changes in the map shell and drill state handling.

## MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [x] Are there SSRF or error leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

## UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?