### PR TITLE
fix(mobile): solidify drawer sheet

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -145,6 +145,12 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 @media (max-width: 899px) {
   body { flex-direction: column; align-items: center; justify-content: center; }
 
+  #drawer {
+    background-color: var(--surface-card);
+    border-right: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-raised);
+  }
+
   /* Keep header but position hamburger absolutely within card */
   .main-header {
     position: absolute;


### PR DESCRIPTION
The mobile drawer inherited the translucent panel token, which let the underlying card show through in narrow view. Override the drawer surface only on mobile to use the existing opaque card token and raised shadow so the menu reads as a proper sheet without redesigning unrelated controls.