### PR TITLE
fix(analytics): support hosted telemetry

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,6 +88,34 @@ class DrillRequest(BaseModel):
     api_key: str | None = Field(None, max_length=200)
 
 
+def _resolve_node_mechanism(knowledge_map: dict, node_id: str, fallback: str = "") -> str:
+    if not isinstance(knowledge_map, dict):
+        return fallback
+
+    metadata = knowledge_map.get("metadata") or {}
+    if node_id == "core-thesis":
+        return str(
+            metadata.get("core_thesis")
+            or metadata.get("thesis")
+            or fallback
+        )
+
+    for backbone in knowledge_map.get("backbone") or []:
+        if isinstance(backbone, dict) and backbone.get("id") == node_id:
+            return str(backbone.get("principle") or backbone.get("label") or fallback)
+
+    for cluster in knowledge_map.get("clusters") or []:
+        if not isinstance(cluster, dict):
+            continue
+        if cluster.get("id") == node_id:
+            return str(cluster.get("description") or cluster.get("label") or fallback)
+        for subnode in cluster.get("subnodes") or []:
+            if isinstance(subnode, dict) and subnode.get("id") == node_id:
+                return str(subnode.get("mechanism") or subnode.get("label") or fallback)
+
+    return fallback
+
+
 @app.get("/api/health")
 def health():
     return {
@@ -137,7 +165,8 @@ def extract(req: ExtractRequest):
     except ValueError as err:
         raise HTTPException(status_code=400, detail=str(err))
     except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err))
+        logger.exception("Unexpected failure in /api/extract")
+        raise HTTPException(status_code=500, detail="Unexpected server error during extraction.") from err
 
 
 def _extract_text_from_html(raw_html: str) -> str:
@@ -323,14 +352,17 @@ def drill(req: DrillRequest):
         if isinstance(knowledge_map, str):
             knowledge_map = json.loads(knowledge_map)
 
-        # TODO: Resolve mechanism server-side from knowledge_map/node_id so the answer key
-        # does not live in browser state or travel over the network on every drill turn.
+        node_mechanism = _resolve_node_mechanism(
+            knowledge_map,
+            req.node_id,
+            fallback="",
+        )
         result = drill_chat(
             knowledge_map=knowledge_map,
             concept_id=req.concept_id,
             node_id=req.node_id,
             node_label=req.node_label,
-            node_mechanism=req.node_mechanism,
+            node_mechanism=node_mechanism,
             messages=[msg.model_dump() for msg in req.messages],
             session_phase=req.session_phase,
             probe_count=req.probe_count,

--- a/public/ai-runs-dashboard.html
+++ b/public/ai-runs-dashboard.html
@@ -187,6 +187,6 @@
 
   <div id="analytics-help-tooltip" class="analytics-help-tooltip" role="dialog" aria-live="polite"></div>
 
-  <script type="module" src="/js/learner-analytics.js?v=2"></script>
+  <script type="module" src="/js/learner-analytics.js?v=3"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -226,7 +226,7 @@
   <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 
   <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=15"></script>
+  <script type="module" src="js/app.js?v=16"></script>
 </body>
 
 </html>

--- a/public/internal-ai-runs.html
+++ b/public/internal-ai-runs.html
@@ -133,6 +133,6 @@
     </section>
   </div>
 
-  <script type="module" src="/js/ai-runs-dashboard.js?v=1"></script>
+  <script type="module" src="/js/ai-runs-dashboard.js?v=2"></script>
 </body>
 </html>

--- a/public/js/ai-runs-dashboard.js
+++ b/public/js/ai-runs-dashboard.js
@@ -1,3 +1,5 @@
+import { buildBrowserAiRunsPayload } from './browser-analytics.js';
+
 const metricGrid = document.getElementById('metric-grid');
 const extractPanel = document.getElementById('extract-panel');
 const drillPanel = document.getElementById('drill-panel');
@@ -243,12 +245,22 @@ async function loadDashboard() {
   statusMeta.textContent = 'Fetching analytics payload';
 
   try {
-    const response = await fetch('/api/analytics/ai-runs');
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
+    const browserPayload = buildBrowserAiRunsPayload();
+    let payload = browserPayload;
 
-    const payload = await response.json();
+    if (
+      (browserPayload?.extract?.total_runs || 0) === 0
+      && (browserPayload?.drill?.total_runs || 0) === 0
+    ) {
+      const response = await fetch('/api/analytics/ai-runs');
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      payload = {
+        source: 'server_logs',
+        ...(await response.json()),
+      };
+    }
     metricGrid.innerHTML = createMetricCards(payload);
     renderExtractPanel(payload.extract);
     renderDrillPanel(payload.drill);
@@ -274,14 +286,14 @@ async function loadDashboard() {
 
     const latestTimestamp = payload.drill.latest_run_at || payload.extract.latest_run_at;
     statusChip.textContent = 'Live';
-    statusMeta.textContent = `Last activity: ${fmtTimestamp(latestTimestamp)}`;
+    statusMeta.textContent = `Showing ${payload?.source === 'browser_local_storage' ? 'browser-local telemetry' : 'server analytics'}. Last activity: ${fmtTimestamp(latestTimestamp)}`;
   } catch (error) {
     console.error(error);
     statusChip.textContent = 'Load Failed';
     statusChip.dataset.tone = 'error';
     statusMeta.textContent = 'Could not load AI runs analytics.';
 
-    const errorState = `<div class="empty-state">Analytics payload failed to load. Confirm the backend is running and local logs are present.</div>`;
+    const errorState = `<div class="empty-state">Analytics payload failed to load. Confirm the backend is running or that browser telemetry exists for this browser profile.</div>`;
     metricGrid.innerHTML = '';
     extractPanel.innerHTML = errorState;
     drillPanel.innerHTML = errorState;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -14,6 +14,7 @@ import {
   addTriggerArea, heroInfo, drillUi, chatHistory, chatInput, drillTitle,
   TILE_IDS, tileEls, POLYGON_IDS
 } from './dom.js';
+import { recordExtractRun, recordDrillRun } from './browser-analytics.js';
 
 const App = (() => {
   const THEME_STORAGE_KEY = 'learnops-theme';
@@ -636,6 +637,8 @@ const App = (() => {
         if (concepts.length >= 4) { renderAddTrigger(); return; }
 
         const id = generateId();
+        const extractStartedAt = new Date().toISOString();
+        const extractStartedPerf = performance.now();
 
         const extractOverlay = document.createElement('div');
         extractOverlay.id = 'extract-overlay';
@@ -679,6 +682,7 @@ const App = (() => {
 
           extractOverlay.querySelector('.extract-label').textContent = 'Mapping knowledge...';
           const jsonPayload = await window.AIService.generateKnowledgeMap(sourceText);
+          const durationMs = Math.round(performance.now() - extractStartedPerf);
 
           removeOverlay();
           const concept = {
@@ -690,6 +694,27 @@ const App = (() => {
             sourceUrl: type === 'url' ? url : null,
             graphData: JSON.stringify(jsonPayload)
           };
+          recordExtractRun({
+            timestamp: extractStartedAt,
+            stage: 'extract',
+            status: 'success',
+            model: 'gemini-2.5-flash',
+            prompt_version: 'extract-system-v1.txt',
+            concept_id: id,
+            source_title: name,
+            content_type: type,
+            input_chars: sourceText.length,
+            duration_ms: durationMs,
+            architecture_type: jsonPayload?.metadata?.architecture_type || 'unknown',
+            difficulty: jsonPayload?.metadata?.difficulty || 'unknown',
+            low_density: jsonPayload?.metadata?.low_density === true,
+            backbone_count: Array.isArray(jsonPayload?.backbone) ? jsonPayload.backbone.length : 0,
+            cluster_count: Array.isArray(jsonPayload?.clusters) ? jsonPayload.clusters.length : 0,
+            subnode_count: Array.isArray(jsonPayload?.clusters)
+              ? jsonPayload.clusters.reduce((sum, cluster) => sum + ((cluster?.subnodes || []).length), 0)
+              : 0,
+            run_mode: 'default',
+          });
           contentStore.set(id, sourceText);
           concepts.push(concept);
           saveConcepts(concepts);
@@ -699,6 +724,21 @@ const App = (() => {
           closeDrawer();
         } catch (err) {
           removeOverlay();
+          recordExtractRun({
+            timestamp: extractStartedAt,
+            stage: 'extract',
+            status: 'error',
+            model: 'gemini-2.5-flash',
+            prompt_version: 'extract-system-v1.txt',
+            concept_id: id,
+            source_title: name,
+            content_type: type,
+            input_chars: typeof text === 'string' ? text.length : 0,
+            duration_ms: Math.round(performance.now() - extractStartedPerf),
+            error_type: 'request_failed',
+            reason: err?.message || 'Extraction failed',
+            run_mode: 'default',
+          });
           alert('Extraction Failed: ' + err.message);
         }
       },
@@ -1527,6 +1567,28 @@ const App = (() => {
     return concepts[conceptIdx];
   }
 
+  function resolveNodeType(knowledgeMap, nodeId, fallbackType = null) {
+    if (nodeId === 'core-thesis') return 'core';
+    if ((knowledgeMap?.backbone || []).some((item) => item?.id === nodeId)) return 'backbone';
+    if ((knowledgeMap?.clusters || []).some((cluster) => cluster?.id === nodeId)) return 'cluster';
+    if ((knowledgeMap?.clusters || []).some((cluster) => (cluster?.subnodes || []).some((subnode) => subnode?.id === nodeId))) {
+      return 'subnode';
+    }
+    return fallbackType || 'unknown';
+  }
+
+  function resolveClusterId(knowledgeMap, nodeId) {
+    if (!nodeId || !knowledgeMap?.clusters) return null;
+    const directCluster = (knowledgeMap.clusters || []).find((cluster) => cluster?.id === nodeId);
+    if (directCluster) return directCluster.id;
+    for (const cluster of knowledgeMap.clusters || []) {
+      if ((cluster?.subnodes || []).some((subnode) => subnode?.id === nodeId)) {
+        return cluster.id;
+      }
+    }
+    return null;
+  }
+
   function patchActiveConceptDrillOutcome(result) {
     if (result?.routing !== 'NEXT' || !result?.node_id) {
       console.log(
@@ -1662,6 +1724,8 @@ const App = (() => {
     const concept = getActiveConcept();
     if (!concept || !drillState.node) return;
     const sessionToken = drillState.sessionToken;
+    const turnStartedAt = new Date().toISOString();
+    const turnStartedPerf = performance.now();
 
     drillState.pending = true;
     if (chatInput) chatInput.disabled = true;
@@ -1677,6 +1741,9 @@ const App = (() => {
     const knowledgeMap = typeof concept.graphData === 'string'
       ? JSON.parse(concept.graphData)
       : concept.graphData;
+    const nodeType = resolveNodeType(knowledgeMap, drillState.node.id, drillState.node.type);
+    const clusterId = resolveClusterId(knowledgeMap, drillState.node.id);
+    const nodeLabel = drillState.node.fullLabel || drillState.node.label || concept.name;
 
     const apiKey = localStorage.getItem('gemini_key') || undefined;
     try {
@@ -1686,7 +1753,7 @@ const App = (() => {
         body: JSON.stringify({
           concept_id: concept.id,
           node_id: drillState.node.id,
-          node_label: drillState.node.fullLabel || drillState.node.label || concept.name,
+          node_label: nodeLabel,
           node_mechanism: drillState.node.detail || '',
           knowledge_map: knowledgeMap,
           messages: outboundMessages,
@@ -1716,7 +1783,53 @@ const App = (() => {
         return;
       }
 
-      patchActiveConceptDrillOutcome(data);
+      const graphMutationConcept = patchActiveConceptDrillOutcome(data);
+      const graphMutated = Boolean(graphMutationConcept);
+      const uxRewardEmitted = Boolean(
+        data?.answer_mode === 'attempt'
+        && data?.classification === 'solid'
+        && (data?.response_tier != null ? Number(data.response_tier) >= 4 : true)
+      );
+      recordDrillRun({
+        timestamp: turnStartedAt,
+        stage: 'drill',
+        status: 'success',
+        model: 'gemini-2.5-flash',
+        prompt_version: 'learnops-drill-skill',
+        concept_id: concept.id,
+        node_id: drillState.node.id,
+        node_type: nodeType,
+        cluster_id: clusterId,
+        node_label: nodeLabel,
+        session_phase: sessionPhase,
+        session_start_iso: drillState.sessionStartIso,
+        message_count: outboundMessages.length,
+        latest_learner_chars: userText ? userText.length : 0,
+        answer_mode: data?.answer_mode ?? null,
+        score_eligible: data?.score_eligible ?? null,
+        help_request_reason: data?.help_request_reason ?? null,
+        probe_count_in: drillState.probeCount,
+        probe_count_out: data?.probe_count ?? drillState.probeCount,
+        nodes_drilled_in: drillState.nodesDrilled,
+        nodes_drilled_out: data?.nodes_drilled ?? drillState.nodesDrilled,
+        attempt_turn_count_in: drillState.attemptTurnCount,
+        attempt_turn_count_out: data?.attempt_turn_count ?? drillState.attemptTurnCount,
+        help_turn_count_in: drillState.helpTurnCount,
+        help_turn_count_out: data?.help_turn_count ?? drillState.helpTurnCount,
+        classification: data?.classification ?? null,
+        routing: data?.routing ?? null,
+        response_tier: data?.response_tier ?? null,
+        response_band: data?.response_band ?? null,
+        tier_reason: data?.tier_reason ?? null,
+        force_advanced: data?.force_advanced === true,
+        force_advance_mode: data?.force_advance_mode ?? null,
+        graph_mutated: graphMutated,
+        ux_reward_emitted: uxRewardEmitted,
+        session_terminated: data?.session_terminated === true,
+        termination_reason: data?.termination_reason ?? null,
+        duration_ms: Math.round(performance.now() - turnStartedPerf),
+        run_mode: 'default',
+      });
       drillState.messages = outboundMessages;
       drillState.probeCount = data.probe_count ?? drillState.probeCount;
       drillState.nodesDrilled = data.nodes_drilled ?? drillState.nodesDrilled;
@@ -1745,6 +1858,30 @@ const App = (() => {
       if (sessionToken !== drillState.sessionToken) {
         return;
       }
+      recordDrillRun({
+        timestamp: turnStartedAt,
+        stage: 'drill',
+        status: 'error',
+        model: 'gemini-2.5-flash',
+        prompt_version: 'learnops-drill-skill',
+        concept_id: concept.id,
+        node_id: drillState.node.id,
+        node_type: nodeType,
+        cluster_id: clusterId,
+        node_label: nodeLabel,
+        session_phase: sessionPhase,
+        session_start_iso: drillState.sessionStartIso,
+        message_count: outboundMessages.length,
+        latest_learner_chars: userText ? userText.length : 0,
+        probe_count_in: drillState.probeCount,
+        nodes_drilled_in: drillState.nodesDrilled,
+        attempt_turn_count_in: drillState.attemptTurnCount,
+        help_turn_count_in: drillState.helpTurnCount,
+        duration_ms: Math.round(performance.now() - turnStartedPerf),
+        error_type: 'request_failed',
+        reason: err?.message || 'Drill request failed',
+        run_mode: 'default',
+      });
       drillState.pending = false;
       throw err;
     }

--- a/public/js/browser-analytics.js
+++ b/public/js/browser-analytics.js
@@ -1,0 +1,645 @@
+const EXTRACT_STORAGE_KEY = 'learnops_extract_runs_v1';
+const DRILL_STORAGE_KEY = 'learnops_drill_runs_v1';
+const EXTRACT_LIMIT = 200;
+const DRILL_LIMIT = 2000;
+
+function parseTimestamp(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function latestTimestamp(rows) {
+  let latest = null;
+  for (const row of rows || []) {
+    const current = parseTimestamp(row?.timestamp);
+    if (!current) continue;
+    if (!latest || current > latest) latest = current;
+  }
+  return latest ? latest.toISOString() : null;
+}
+
+function pct(numerator, denominator) {
+  if (!denominator || denominator <= 0) return 0;
+  return (Number(numerator || 0) / Number(denominator || 0)) * 100;
+}
+
+function safeMean(values) {
+  const numeric = (values || [])
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+  if (!numeric.length) return 0;
+  return numeric.reduce((sum, value) => sum + value, 0) / numeric.length;
+}
+
+function topCounter(counter, limit = 5) {
+  return Object.entries(counter || {})
+    .sort((a, b) => Number(b[1]) - Number(a[1]) || String(a[0]).localeCompare(String(b[0])))
+    .slice(0, limit);
+}
+
+function incrementCounter(counter, key) {
+  const safeKey = String(key || 'unknown');
+  counter[safeKey] = (counter[safeKey] || 0) + 1;
+}
+
+function readRows(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((row) => row && typeof row === 'object') : [];
+  } catch (error) {
+    console.warn(`Failed to read analytics storage key ${key}`, error);
+    return [];
+  }
+}
+
+function writeRows(key, rows) {
+  try {
+    localStorage.setItem(key, JSON.stringify(rows));
+  } catch (error) {
+    console.warn(`Failed to write analytics storage key ${key}`, error);
+  }
+}
+
+function appendRow(key, payload, limit) {
+  const rows = readRows(key);
+  rows.push({
+    timestamp: payload?.timestamp || new Date().toISOString(),
+    ...payload,
+  });
+  const trimmed = rows.slice(-limit);
+  writeRows(key, trimmed);
+  return trimmed;
+}
+
+export function loadBrowserExtractRuns() {
+  return readRows(EXTRACT_STORAGE_KEY);
+}
+
+export function loadBrowserDrillRuns() {
+  return readRows(DRILL_STORAGE_KEY);
+}
+
+export function recordExtractRun(payload) {
+  appendRow(EXTRACT_STORAGE_KEY, payload, EXTRACT_LIMIT);
+}
+
+export function recordDrillRun(payload) {
+  appendRow(DRILL_STORAGE_KEY, payload, DRILL_LIMIT);
+}
+
+function buildExtractSummary(rows) {
+  const successRows = rows.filter((row) => row.status === 'success');
+  const errorRows = rows.filter((row) => row.status === 'error');
+  const architecture = {};
+  const difficulty = {};
+  const errorTypes = {};
+  const topSourcesCounter = {};
+
+  successRows.forEach((row) => {
+    incrementCounter(architecture, row.architecture_type || 'unknown');
+    incrementCounter(difficulty, row.difficulty || 'unknown');
+    incrementCounter(topSourcesCounter, row.source_title || 'unknown');
+  });
+  errorRows.forEach((row) => {
+    incrementCounter(errorTypes, row.error_type || 'unknown');
+  });
+
+  return {
+    total_runs: rows.length,
+    success_count: successRows.length,
+    error_count: errorRows.length,
+    success_rate: pct(successRows.length, rows.length),
+    avg_duration_ms: safeMean(successRows.map((row) => row.duration_ms || 0)),
+    avg_cluster_count: safeMean(successRows.map((row) => row.cluster_count || 0)),
+    avg_backbone_count: safeMean(successRows.map((row) => row.backbone_count || 0)),
+    avg_subnode_count: safeMean(successRows.map((row) => row.subnode_count || 0)),
+    low_density_rate: pct(successRows.filter((row) => row.low_density === true).length, successRows.length),
+    latest_run_at: latestTimestamp(rows),
+    latest_success_at: latestTimestamp(successRows),
+    latest_error_at: latestTimestamp(errorRows),
+    architecture_distribution: architecture,
+    difficulty_distribution: difficulty,
+    error_types: errorTypes,
+    top_sources: topCounter(topSourcesCounter),
+  };
+}
+
+function buildDrillSummary(rows) {
+  const successRows = rows.filter((row) => row.status === 'success');
+  const errorRows = rows.filter((row) => row.status === 'error');
+  const turnRows = successRows.filter((row) => row.session_phase === 'turn');
+  const attemptTurns = turnRows.filter((row) => row.answer_mode === 'attempt');
+  const helpTurns = turnRows.filter((row) => row.answer_mode === 'help_request');
+  const classifiedTurns = attemptTurns.filter((row) => row.classification);
+
+  const classification = {};
+  const routing = {};
+  const nodeTypes = {};
+  const answerModes = {};
+  const helpReasons = {};
+  const responseTiers = {};
+  const responseBands = {};
+  const terminations = {};
+  const errorTypes = {};
+  const runModes = {};
+  const byNode = {};
+  const byCluster = {};
+  const byNodeType = {};
+
+  classifiedTurns.forEach((row) => incrementCounter(classification, row.classification || 'none'));
+  turnRows.forEach((row) => {
+    incrementCounter(routing, row.routing || 'none');
+    incrementCounter(nodeTypes, row.node_type || 'unknown');
+    incrementCounter(answerModes, row.answer_mode || 'none');
+    incrementCounter(runModes, row.run_mode || 'default');
+  });
+  helpTurns.forEach((row) => incrementCounter(helpReasons, row.help_request_reason || 'none'));
+  attemptTurns.forEach((row) => {
+    if (row.response_tier != null) incrementCounter(responseTiers, String(row.response_tier));
+    if (row.response_band) incrementCounter(responseBands, row.response_band);
+  });
+  successRows
+    .filter((row) => row.session_terminated)
+    .forEach((row) => incrementCounter(terminations, row.termination_reason || 'none'));
+  errorRows.forEach((row) => incrementCounter(errorTypes, row.error_type || 'unknown'));
+
+  classifiedTurns.forEach((row) => {
+    const nodeId = row.node_id || 'unknown';
+    const clusterId = row.cluster_id || 'none';
+    const nodeType = row.node_type || 'unknown';
+    byNode[nodeId] = byNode[nodeId] || {
+      label: row.node_label || '',
+      turns: 0,
+      solid: 0,
+      misconception: 0,
+      force_advanced: 0,
+    };
+    byCluster[clusterId] = byCluster[clusterId] || {
+      turns: 0,
+      solid: 0,
+      misconception: 0,
+      force_advanced: 0,
+    };
+    byNodeType[nodeType] = byNodeType[nodeType] || {
+      turns: 0,
+      solid: 0,
+      non_solid: 0,
+      force_advanced: 0,
+    };
+
+    byNode[nodeId].turns += 1;
+    byCluster[clusterId].turns += 1;
+    byNodeType[nodeType].turns += 1;
+
+    if (row.classification === 'solid') {
+      byNode[nodeId].solid += 1;
+      byCluster[clusterId].solid += 1;
+      byNodeType[nodeType].solid += 1;
+    } else {
+      byNodeType[nodeType].non_solid += 1;
+    }
+
+    if (row.classification === 'misconception') {
+      byNode[nodeId].misconception += 1;
+      byCluster[clusterId].misconception += 1;
+    }
+
+    if (row.force_advanced === true) {
+      byNode[nodeId].force_advanced += 1;
+      byCluster[clusterId].force_advanced += 1;
+      byNodeType[nodeType].force_advanced += 1;
+    }
+  });
+
+  const solidTurns = classifiedTurns.filter((row) => row.classification === 'solid').length;
+  const nonSolidNext = classifiedTurns.filter((row) => row.routing === 'NEXT' && row.classification !== 'solid').length;
+  const forceAdvanced = classifiedTurns.filter((row) => row.force_advanced === true).length;
+  const attemptForceAdvanced = attemptTurns.filter((row) => row.force_advanced === true).length;
+  const helpForceAdvanced = helpTurns.filter((row) => row.force_advanced === true).length;
+  const oneTurnSolids = classifiedTurns.filter((row) => row.classification === 'solid' && Number(row.probe_count_in || 0) === 0).length;
+  const rewardEmitted = attemptTurns.filter((row) => row.ux_reward_emitted === true).length;
+
+  const sessions = {};
+  turnRows.forEach((row) => {
+    const sessionKey = [
+      String(row.concept_id || 'unknown'),
+      String(row.node_id || 'unknown'),
+      String(row.session_start_iso || 'missing'),
+    ].join('::');
+    sessions[sessionKey] = sessions[sessionKey] || [];
+    sessions[sessionKey].push(row);
+  });
+  const helpOnlySessionCount = Object.values(sessions).filter((sessionRows) => (
+    sessionRows.length && sessionRows.every((row) => row.answer_mode === 'help_request')
+  )).length;
+
+  const hotspotNodes = Object.entries(byNode)
+    .map(([node_id, stats]) => ({
+      node_id,
+      label: stats.label,
+      turns: stats.turns,
+      solid_rate: pct(stats.solid, stats.turns),
+      misconception_rate: pct(stats.misconception, stats.turns),
+      force_advance_rate: pct(stats.force_advanced, stats.turns),
+    }))
+    .filter((row) => row.turns >= 2)
+    .sort((a, b) => b.force_advance_rate - a.force_advance_rate || b.misconception_rate - a.misconception_rate || a.solid_rate - b.solid_rate)
+    .slice(0, 5);
+
+  const hotspotClusters = Object.entries(byCluster)
+    .map(([cluster_id, stats]) => ({
+      cluster_id,
+      turns: stats.turns,
+      solid_rate: pct(stats.solid, stats.turns),
+      misconception_rate: pct(stats.misconception, stats.turns),
+      force_advance_rate: pct(stats.force_advanced, stats.turns),
+    }))
+    .filter((row) => row.turns >= 2 && row.cluster_id !== 'none')
+    .sort((a, b) => b.force_advance_rate - a.force_advance_rate || b.misconception_rate - a.misconception_rate || a.solid_rate - b.solid_rate)
+    .slice(0, 5);
+
+  const nodeTypeBenchmarks = Object.entries(byNodeType)
+    .map(([node_type, stats]) => ({
+      node_type,
+      turns: stats.turns,
+      solid_rate: pct(stats.solid, stats.turns),
+      non_solid_rate: pct(stats.non_solid, stats.turns),
+      force_advance_rate: pct(stats.force_advanced, stats.turns),
+    }))
+    .filter((row) => row.turns > 0)
+    .sort((a, b) => String(a.node_type).localeCompare(String(b.node_type)));
+
+  return {
+    total_runs: rows.length,
+    success_count: successRows.length,
+    error_count: errorRows.length,
+    success_rate: pct(successRows.length, rows.length),
+    turn_count: turnRows.length,
+    attempt_turn_count: attemptTurns.length,
+    help_turn_count: helpTurns.length,
+    classified_turn_count: classifiedTurns.length,
+    avg_duration_ms: safeMean(successRows.map((row) => row.duration_ms || 0)),
+    avg_attempt_learner_chars: safeMean(attemptTurns.map((row) => row.latest_learner_chars || 0)),
+    avg_help_learner_chars: safeMean(helpTurns.map((row) => row.latest_learner_chars || 0)),
+    latest_run_at: latestTimestamp(rows),
+    latest_turn_at: latestTimestamp(turnRows),
+    latest_success_at: latestTimestamp(successRows),
+    latest_error_at: latestTimestamp(errorRows),
+    classification_distribution: classification,
+    routing_distribution: routing,
+    node_type_distribution: nodeTypes,
+    answer_mode_distribution: answerModes,
+    help_request_reason_distribution: helpReasons,
+    run_mode_distribution: runModes,
+    response_tier_distribution: responseTiers,
+    response_band_distribution: responseBands,
+    termination_distribution: terminations,
+    error_types: errorTypes,
+    attempt_rate: pct(attemptTurns.length, turnRows.length),
+    help_request_rate: pct(helpTurns.length, turnRows.length),
+    solid_rate: pct(solidTurns, classifiedTurns.length),
+    non_solid_next_rate: pct(nonSolidNext, classifiedTurns.length),
+    force_advance_rate: pct(forceAdvanced, classifiedTurns.length),
+    attempt_force_advance_rate: pct(attemptForceAdvanced, attemptTurns.length),
+    help_force_advance_rate: pct(helpForceAdvanced, helpTurns.length),
+    one_turn_solid_rate: pct(oneTurnSolids, classifiedTurns.length),
+    reward_emit_rate: pct(rewardEmitted, attemptTurns.length),
+    help_only_session_count: helpOnlySessionCount,
+    hotspot_nodes: hotspotNodes,
+    hotspot_clusters: hotspotClusters,
+    node_type_benchmarks: nodeTypeBenchmarks,
+  };
+}
+
+function buildRecentEvents(extractRows, drillRows, limit = 12) {
+  const events = [];
+
+  extractRows.forEach((row) => {
+    events.push({
+      timestamp: row.timestamp,
+      stage: 'extract',
+      status: row.status,
+      title: row.source_title || row.fixture_title || 'Extraction',
+      summary: row.reason || row.architecture_type || 'Extraction run',
+      run_mode: row.run_mode || 'default',
+      fixture_id: row.fixture_id || null,
+    });
+  });
+
+  drillRows.forEach((row) => {
+    events.push({
+      timestamp: row.timestamp,
+      stage: 'drill',
+      status: row.status,
+      title: row.node_label || row.node_id || 'Drill turn',
+      summary: row.reason || row.classification || row.routing || 'Drill turn',
+      run_mode: row.run_mode || 'default',
+      fixture_id: row.fixture_id || null,
+    });
+  });
+
+  return events
+    .sort((a, b) => {
+      const aTime = parseTimestamp(a.timestamp)?.getTime() || 0;
+      const bTime = parseTimestamp(b.timestamp)?.getTime() || 0;
+      return bTime - aTime;
+    })
+    .slice(0, limit);
+}
+
+function daysBetween(now, timestamp) {
+  const value = parseTimestamp(timestamp);
+  if (!value) return null;
+  return Math.max(Math.floor((now.getTime() - value.getTime()) / 86400000), 0);
+}
+
+function journalOutcome(row, convertedNodeKeys) {
+  const key = `${row.concept_id || ''}::${row.node_id || ''}`;
+  if (row.answer_mode === 'help_request') {
+    return ['Used scaffolding', 'Try this node again from memory.'];
+  }
+  if (row.classification === 'solid' && convertedNodeKeys.has(key)) {
+    return ['Solidified on return', 'Keep your momentum and take the next reachable node.'];
+  }
+  if (row.classification === 'solid') {
+    return ['Verified understanding', 'Advance to the next reachable node.'];
+  }
+  if (row.classification === 'misconception') {
+    return ['Misconception caught', 'Revisit this mechanism soon while the gap is fresh.'];
+  }
+  if (row.classification) {
+    return ['Still in progress', 'Return for one more clean pass.'];
+  }
+  return ['Activity logged', 'Choose one reachable node and reconstruct it from memory.'];
+}
+
+export function buildBrowserAiRunsPayload() {
+  const extractRows = loadBrowserExtractRuns();
+  const drillRows = loadBrowserDrillRuns();
+
+  return {
+    source: 'browser_local_storage',
+    extract: buildExtractSummary(extractRows),
+    drill: buildDrillSummary(drillRows),
+    recent_events: buildRecentEvents(extractRows, drillRows),
+    paths: {
+      extract_log: 'browser_local_storage',
+      drill_log: 'browser_local_storage',
+    },
+  };
+}
+
+export function buildBrowserLearnerSummaryPayload(conceptIds = null) {
+  const conceptFilter = Array.isArray(conceptIds) && conceptIds.length
+    ? new Set(conceptIds.map((value) => String(value)))
+    : null;
+  const allRows = loadBrowserDrillRuns();
+  const turnRows = allRows.filter((row) => (
+    row.status === 'success'
+    && row.session_phase === 'turn'
+    && (!conceptFilter || conceptFilter.has(String(row.concept_id || '')))
+  ));
+
+  const now = new Date();
+  const recentWindow = new Date(now.getTime() - (14 * 86400000));
+  const dueThresholdDays = 3;
+
+  const attemptTurns = turnRows.filter((row) => row.answer_mode === 'attempt');
+  const helpTurns = turnRows.filter((row) => row.answer_mode === 'help_request');
+  const recentTurns = turnRows.filter((row) => {
+    const value = parseTimestamp(row.timestamp);
+    return value && value >= recentWindow;
+  });
+
+  const sessionKeys = new Set(
+    turnRows.map((row) => [
+      String(row.concept_id || 'unknown'),
+      String(row.node_id || 'unknown'),
+      String(row.session_start_iso || 'missing'),
+    ].join('::'))
+  );
+
+  const activeDays = Array.from(new Set(
+    turnRows
+      .map((row) => parseTimestamp(row.timestamp))
+      .filter(Boolean)
+      .map((date) => date.toISOString().slice(0, 10))
+  )).sort();
+
+  const activeDaysLast7 = new Set(
+    turnRows
+      .map((row) => parseTimestamp(row.timestamp))
+      .filter((date) => date && date >= new Date(now.getTime() - (7 * 86400000)))
+      .map((date) => date.toISOString().slice(0, 10))
+  );
+
+  const activeDaysLast14 = new Set(
+    turnRows
+      .map((row) => parseTimestamp(row.timestamp))
+      .filter((date) => date && date >= recentWindow)
+      .map((date) => date.toISOString().slice(0, 10))
+  );
+
+  const groupedRows = {};
+  turnRows.forEach((row) => {
+    const key = `${String(row.concept_id || '')}::${String(row.node_id || '')}`;
+    groupedRows[key] = groupedRows[key] || [];
+    groupedRows[key].push(row);
+  });
+
+  const nodeHistory = [];
+  const conversionHistory = [];
+  const convertedNodeKeys = new Set();
+
+  Object.entries(groupedRows).forEach(([key, rows]) => {
+    const orderedRows = [...rows].sort((a, b) => {
+      const aTime = parseTimestamp(a.timestamp)?.getTime() || 0;
+      const bTime = parseTimestamp(b.timestamp)?.getTime() || 0;
+      return aTime - bTime;
+    });
+    const [conceptId, nodeId] = key.split('::');
+    const history = {
+      concept_id: conceptId,
+      node_id: nodeId,
+      node_label: orderedRows[orderedRows.length - 1]?.node_label || nodeId,
+      cluster_id: orderedRows[orderedRows.length - 1]?.cluster_id || null,
+      node_type: orderedRows[orderedRows.length - 1]?.node_type || 'unknown',
+      attempt_count: 0,
+      help_count: 0,
+      solid_count: 0,
+      non_solid_count: 0,
+      misconception_count: 0,
+      last_attempt_at: null,
+      last_help_at: null,
+      last_turn_at: null,
+      latest_classification: null,
+    };
+
+    let seenNonSolidAt = null;
+    let seenNonSolidLabel = null;
+
+    orderedRows.forEach((row) => {
+      history.last_turn_at = row.timestamp || history.last_turn_at;
+
+      if (row.answer_mode === 'help_request') {
+        history.help_count += 1;
+        history.last_help_at = row.timestamp || history.last_help_at;
+        return;
+      }
+
+      if (row.answer_mode !== 'attempt') return;
+
+      history.attempt_count += 1;
+      history.last_attempt_at = row.timestamp || history.last_attempt_at;
+      history.latest_classification = row.classification || history.latest_classification;
+
+      if (row.classification === 'solid') {
+        history.solid_count += 1;
+        if (seenNonSolidAt && !convertedNodeKeys.has(key)) {
+          conversionHistory.push({
+            concept_id: conceptId,
+            node_id: nodeId,
+            node_label: history.node_label,
+            converted_at: row.timestamp,
+            last_non_solid_at: seenNonSolidAt,
+            previous_gap_type: seenNonSolidLabel,
+          });
+          convertedNodeKeys.add(key);
+        }
+      } else if (row.classification) {
+        history.non_solid_count += 1;
+        seenNonSolidAt = row.timestamp;
+        seenNonSolidLabel = row.classification;
+        if (row.classification === 'misconception') {
+          history.misconception_count += 1;
+        }
+      }
+    });
+
+    history.days_since_attempt = daysBetween(now, history.last_attempt_at);
+    nodeHistory.push(history);
+  });
+
+  const dueNodes = nodeHistory
+    .filter((row) => row.latest_classification && row.latest_classification !== 'solid' && (row.days_since_attempt || 0) >= dueThresholdDays)
+    .map((row) => ({
+      concept_id: row.concept_id,
+      node_id: row.node_id,
+      node_label: row.node_label,
+      days_since_attempt: row.days_since_attempt,
+      latest_classification: row.latest_classification,
+    }))
+    .sort((a, b) => (b.days_since_attempt || 0) - (a.days_since_attempt || 0) || String(a.node_label).localeCompare(String(b.node_label)));
+
+  const conceptSessions = {};
+  const conceptStatsMap = {};
+  turnRows.forEach((row) => {
+    const conceptId = String(row.concept_id || '');
+    conceptSessions[conceptId] = conceptSessions[conceptId] || new Set();
+    conceptSessions[conceptId].add([
+      conceptId,
+      String(row.node_id || 'unknown'),
+      String(row.session_start_iso || 'missing'),
+    ].join('::'));
+
+    const stats = conceptStatsMap[conceptId] || {
+      concept_id: conceptId,
+      turn_count: 0,
+      attempt_turn_count: 0,
+      help_turn_count: 0,
+      solid_attempt_count: 0,
+      latest_activity_at: null,
+      active_days_last_14: new Set(),
+    };
+
+    stats.turn_count += 1;
+    if (!stats.latest_activity_at || (parseTimestamp(row.timestamp)?.getTime() || 0) > (parseTimestamp(stats.latest_activity_at)?.getTime() || 0)) {
+      stats.latest_activity_at = row.timestamp || stats.latest_activity_at;
+    }
+
+    const rowDate = parseTimestamp(row.timestamp);
+    if (rowDate && rowDate >= recentWindow) {
+      stats.active_days_last_14.add(rowDate.toISOString().slice(0, 10));
+    }
+
+    if (row.answer_mode === 'attempt') {
+      stats.attempt_turn_count += 1;
+      if (row.classification === 'solid') stats.solid_attempt_count += 1;
+    } else if (row.answer_mode === 'help_request') {
+      stats.help_turn_count += 1;
+    }
+
+    conceptStatsMap[conceptId] = stats;
+  });
+
+  const conceptStats = Object.values(conceptStatsMap)
+    .map((stats) => ({
+      ...stats,
+      session_count: conceptSessions[stats.concept_id]?.size || 0,
+      active_days_last_14: stats.active_days_last_14.size,
+      attempt_before_help_rate: pct(stats.attempt_turn_count, stats.turn_count),
+      verified_reconstruction_rate: pct(stats.solid_attempt_count, stats.attempt_turn_count),
+    }))
+    .sort((a, b) => (parseTimestamp(b.latest_activity_at)?.getTime() || 0) - (parseTimestamp(a.latest_activity_at)?.getTime() || 0));
+
+  const sessionJournal = [...turnRows]
+    .sort((a, b) => (parseTimestamp(b.timestamp)?.getTime() || 0) - (parseTimestamp(a.timestamp)?.getTime() || 0))
+    .slice(0, 40)
+    .map((row) => {
+      const [outcomeLabel, nextAction] = journalOutcome(row, convertedNodeKeys);
+      return {
+        timestamp: row.timestamp,
+        concept_id: row.concept_id,
+        node_id: row.node_id,
+        node_label: row.node_label || row.node_id || 'Untitled node',
+        cluster_id: row.cluster_id || null,
+        classification: row.classification || null,
+        answer_mode: row.answer_mode || null,
+        help_request_reason: row.help_request_reason || null,
+        outcome_label: outcomeLabel,
+        next_action: nextAction,
+        gap_label: row.classification && row.classification !== 'solid' ? row.classification : null,
+      };
+    });
+
+  return {
+    source: 'browser_local_storage',
+    retrieval_habits: {
+      turn_count: turnRows.length,
+      attempt_turn_count: attemptTurns.length,
+      help_turn_count: helpTurns.length,
+      attempt_before_help_rate: pct(attemptTurns.length, turnRows.length),
+      help_usage_rate: pct(helpTurns.length, turnRows.length),
+      verified_reconstruction_rate_14d: pct(
+        recentTurns.filter((row) => row.answer_mode === 'attempt' && row.classification === 'solid').length,
+        recentTurns.filter((row) => row.answer_mode === 'attempt').length,
+      ),
+    },
+    cadence: {
+      window_days: 14,
+      revisit_due_days: dueThresholdDays,
+      session_count: sessionKeys.size,
+      active_days: activeDays,
+      active_days_last_7: activeDaysLast7.size,
+      active_days_last_14: activeDaysLast14.size,
+      overdue_revisit_count: dueNodes.length,
+      due_nodes: dueNodes.slice(0, 8),
+      latest_activity_at: latestTimestamp(turnRows),
+    },
+    conversion_history: {
+      conversion_count: conversionHistory.length,
+      recent_conversions: conversionHistory
+        .sort((a, b) => (parseTimestamp(b.converted_at)?.getTime() || 0) - (parseTimestamp(a.converted_at)?.getTime() || 0))
+        .slice(0, 24),
+    },
+    session_journal: sessionJournal,
+    node_history: [...nodeHistory].sort((a, b) => (parseTimestamp(b.last_turn_at)?.getTime() || 0) - (parseTimestamp(a.last_turn_at)?.getTime() || 0)),
+    concept_stats: conceptStats,
+    paths: {
+      drill_log: 'browser_local_storage',
+    },
+  };
+}

--- a/public/js/learner-analytics.js
+++ b/public/js/learner-analytics.js
@@ -1,5 +1,6 @@
 import { loadConcepts, getActiveId, setActiveId } from './store.js';
 import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=2';
+import { buildBrowserLearnerSummaryPayload } from './browser-analytics.js';
 
 const conceptSelect = document.getElementById('concept-select');
 const statusChip = document.getElementById('status-chip');
@@ -581,6 +582,7 @@ function renderSessionJournal(payload) {
 async function fetchLearnerHistory(concepts) {
   if (!concepts.length) {
     return {
+      source: 'empty',
       retrieval_habits: {},
       cadence: {},
       conversion_history: { recent_conversions: [] },
@@ -590,12 +592,28 @@ async function fetchLearnerHistory(concepts) {
     };
   }
 
-  const conceptIds = concepts.map((concept) => concept.id).join(',');
-  const response = await fetch(`/api/analytics/learner-runs?concept_ids=${encodeURIComponent(conceptIds)}`);
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
+  const conceptIds = concepts.map((concept) => concept.id);
+  const browserPayload = buildBrowserLearnerSummaryPayload(conceptIds);
+  if ((browserPayload?.retrieval_habits?.turn_count || 0) > 0) {
+    return browserPayload;
   }
-  return response.json();
+
+  try {
+    const response = await fetch(`/api/analytics/learner-runs?concept_ids=${encodeURIComponent(conceptIds.join(','))}`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const payload = await response.json();
+    return {
+      source: 'server_logs',
+      ...payload,
+    };
+  } catch (error) {
+    if ((browserPayload?.retrieval_habits?.turn_count || 0) > 0) {
+      return browserPayload;
+    }
+    throw error;
+  }
 }
 
 function renderEmptyDashboard(message) {
@@ -711,14 +729,17 @@ async function loadDashboard() {
     renderCadence(payload);
     renderSessionJournal(payload);
 
+    const sourceLabel = remoteData?.source === 'browser_local_storage'
+      ? 'browser-local telemetry'
+      : 'server drill history';
     statusChip.textContent = 'Ready';
-    statusMeta.textContent = `Showing "${activeConcept.name}" from local graph truth plus filtered drill history. Last activity: ${fmtTimestamp(payload.cadence.latest_activity_at)}`;
+    statusMeta.textContent = `Showing "${activeConcept.name}" from local graph truth plus ${sourceLabel}. Last activity: ${fmtTimestamp(payload.cadence.latest_activity_at)}`;
   } catch (error) {
     console.error(error);
     statusChip.textContent = 'Load Failed';
     statusChip.dataset.tone = 'error';
     statusMeta.textContent = 'Could not load learner analytics.';
-    const errorState = 'Learner analytics failed to load. Check that your concept data and local logs are available.';
+    const errorState = 'Learner analytics failed to load. Check that your concept data and browser telemetry are available.';
     renderEmptyDashboard(errorState);
     statusChip.textContent = 'Load Failed';
     statusChip.dataset.tone = 'error';


### PR DESCRIPTION
## Context & Intent
- What problem does this solve?
  - The internal and learner analytics dashboards depended on server-side filesystem logs, which work locally but are not durable on Vercel serverless previews. This PR makes the hosted app functional by recording extract/drill telemetry in browser local storage and using that as the primary analytics source in deployed environments.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)?
  - MVP stabilization, with Elliot-driven release hardening around hosted deployment constraints.

## Implementation Details
- Brief overview of technical changes.
  - Added a browser telemetry module that records extraction and drill events to local storage.
  - Wired extraction and drill flows to emit telemetry from the frontend.
  - Updated both analytics dashboards to prefer browser-local telemetry and only fall back to server log endpoints when local browser telemetry is empty.
  - Hardened `/api/extract` to stop leaking raw unexpected error details.
  - Hardened `/api/drill` so the server resolves the node mechanism from the submitted knowledge map instead of trusting the client-supplied answer key.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing).
  - Crosses the frontend analytics layer, the drill/extract UI boundary, and backend API hardening in `main.py`.

## MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [ ] Are there SSRF or error leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

## UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Notes:
- The analytics path now degrades to browser-local telemetry on hosted previews specifically because serverless filesystem logs are ephemeral.
- Preview verification succeeded on Vercel for commit `97c1903`, including the deployed app shell, analytics page assets, and `/api/health`.
- The main app shell still visually labels Analytics as offline in the sidebar even though the analytics pages are deployed; that follow-up is intentionally out of scope for this hardening PR.