### PR TITLE
fix(nav): enable analytics tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,8 +43,8 @@
       <a id="nav-dashboard" class="sidebar-nav-item active" href="javascript:void(0)"
         onclick="App.showDashboard()">Dashboard</a>
       <a id="nav-library" class="sidebar-nav-item" href="javascript:void(0)" onclick="App.showLibrary()">Library</a>
-      <a id="nav-analytics" class="sidebar-nav-item" href="javascript:void(0)" style="opacity:0.5; cursor:not-allowed;"
-        title="Analytics Module Offline">Analytics</a>
+      <a id="nav-analytics" class="sidebar-nav-item" href="javascript:void(0)"
+        onclick="App.showAnalytics()" title="Open learner analytics">Analytics</a>
       <a id="nav-settings" class="sidebar-nav-item" href="javascript:void(0)" onclick="startSettings()">Settings</a>
       <a id="nav-guide" class="sidebar-nav-item" href="javascript:void(0)" onclick="App.toggleTutorial()">[?] Quick Guide</a>
     </nav>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1275,7 +1275,7 @@ const App = (() => {
 
   function setNavActive(id) {
     currentPrimaryNav = id;
-    ['nav-dashboard', 'nav-library'].forEach((navId) => {
+    ['nav-dashboard', 'nav-library', 'nav-analytics'].forEach((navId) => {
       const el = document.getElementById(navId);
       if (el) el.classList.toggle('active', navId === currentPrimaryNav);
     });
@@ -1440,6 +1440,12 @@ const App = (() => {
     libraryView.classList.add('visible');
     if (window.innerWidth < 900) closeDrawer();
     scheduleTutorialRefresh();
+  }
+
+  function showAnalytics() {
+    setNavActive('nav-analytics');
+    if (window.innerWidth < 900) closeDrawer();
+    window.location.href = '/ai-runs-dashboard.html';
   }
 
   function hideLibrary() {
@@ -2273,7 +2279,7 @@ const App = (() => {
     extract, drill, drillFail, drillPass, consolidate,
     fastForward,
     hideMapView, setMapMode, toggleCluster,
-    showLibrary, hideLibrary, showDashboard,
+    showLibrary, hideLibrary, showDashboard, showAnalytics,
     importStarterMap,
     toggleTheme, runHeroAction
   };


### PR DESCRIPTION
## Context & Intent
- What problem does this solve?
  - The learner analytics page is already deployed, but the main app shell still labels Analytics as offline and blocks clicks. Users cannot reach the analytics experience from the primary navigation.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)?
  - MVP stabilization hotfix following the hosted analytics deployment.

## Implementation Details
- Brief overview of technical changes.
  - Removed the disabled styling/title from the Analytics sidebar item.
  - Added `App.showAnalytics()` to route users to `/ai-runs-dashboard.html`.
  - Included `nav-analytics` in the active nav set for consistent state.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing).
  - Frontend-only navigation hotfix in the main app shell.

## MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [x] Are there SSRF or error leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

## UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Notes:
- This PR is intentionally tiny and only makes the shell truthful about an already-deployed analytics page.