### PR TITLE
dev → main: design system polish, GSD scaffolding, backend/auth cleanup

### DIFF
--- a/.agents/skills/socratink-brain/scripts/validate_wiki.py
+++ b/.agents/skills/socratink-brain/scripts/validate_wiki.py
@@ -39,7 +39,16 @@ REQUIRED_FILES = [
 ]
 
 CURATED_DIRS = ["doctrine", "mechanisms", "records", "sources", "syntheses"]
-PAGE_TYPES = {"doctrine", "mechanism", "decision", "issue", "experiment", "finding", "source", "synthesis"}
+PAGE_TYPES = {
+    "doctrine",
+    "mechanism",
+    "decision",
+    "issue",
+    "experiment",
+    "finding",
+    "source",
+    "synthesis",
+}
 BASIS_VALUES = {"sourced", "inferred"}
 CONFIDENCE_VALUES = {"high", "medium", "low", "speculative"}
 FLAG_VALUES = {"hypothesis", "open-question", "contradiction"}
@@ -69,12 +78,27 @@ SOURCE_KIND_VALUES = {
 REQUIRED_SECTIONS = {
     "doctrine": ["## Principle", "## Evidence", "## Product Implication"],
     "mechanism": ["## Mechanism", "## Evidence", "## Product Implication"],
-    "decision": ["## Decision", "## Evidence", "## Inference", "## Product Implication"],
+    "decision": [
+        "## Decision",
+        "## Evidence",
+        "## Inference",
+        "## Product Implication",
+    ],
     "issue": ["## What Broke", "## Evidence", "## Product Implication"],
-    "experiment": ["## Change", "## Evidence", "## Inference", "## Product Implication"],
+    "experiment": [
+        "## Change",
+        "## Evidence",
+        "## Inference",
+        "## Product Implication",
+    ],
     "finding": ["## Finding", "## Evidence", "## Product Implication"],
     "source": ["## Summary", "## Raw Artifacts", "## Connections"],
-    "synthesis": ["## Pattern", "## Evidence", "## Inference", "## Product Implication"],
+    "synthesis": [
+        "## Pattern",
+        "## Evidence",
+        "## Inference",
+        "## Product Implication",
+    ],
 }
 LOG_COVERAGE_FIELDS = {
     "title",
@@ -87,7 +111,11 @@ LOG_COVERAGE_FIELDS = {
     "current_log_files",
     "missing_instrumentation",
 }
-LOG_COVERAGE_SECTIONS = ["## Current Log Adapters", "## Missing Instrumentation", "## Notes"]
+LOG_COVERAGE_SECTIONS = [
+    "## Current Log Adapters",
+    "## Missing Instrumentation",
+    "## Notes",
+]
 
 
 @dataclass
@@ -124,7 +152,11 @@ def parse_scalar(value: str):
         inner = value[1:-1].strip()
         if not inner:
             return []
-        return [item.strip().strip('"').strip("'") for item in inner.split(",") if item.strip()]
+        return [
+            item.strip().strip('"').strip("'")
+            for item in inner.split(",")
+            if item.strip()
+        ]
     return value.strip('"').strip("'")
 
 
@@ -191,26 +223,43 @@ def validate_required_structure(kb_root: Path, result: Result) -> bool:
     return result.success
 
 
-def validate_page_frontmatter(relpath: str, frontmatter: dict, content: str, result: Result) -> None:
+def validate_page_frontmatter(
+    relpath: str, frontmatter: dict, content: str, result: Result
+) -> None:
     page_type = frontmatter.get("type")
     if page_type not in PAGE_TYPES:
         result.add_issue("warning", f"{relpath} has invalid type '{page_type}'")
         return
 
-    required_fields = {"title", "type", "updated", "related", "basis", "workflow_status", "flags"}
+    required_fields = {
+        "title",
+        "type",
+        "updated",
+        "related",
+        "basis",
+        "workflow_status",
+        "flags",
+    }
     if page_type != "source":
         required_fields.add("sources")
     for field_name in sorted(required_fields - set(frontmatter.keys())):
         result.add_issue("warning", f"{relpath} missing required field '{field_name}'")
 
     if frontmatter.get("basis") not in BASIS_VALUES:
-        result.add_issue("warning", f"{relpath} has invalid basis '{frontmatter.get('basis')}'")
+        result.add_issue(
+            "warning", f"{relpath} has invalid basis '{frontmatter.get('basis')}'"
+        )
 
     if page_type != "source":
         if "confidence" not in frontmatter:
-            result.add_issue("warning", f"{relpath} missing required field 'confidence'")
+            result.add_issue(
+                "warning", f"{relpath} missing required field 'confidence'"
+            )
         elif frontmatter.get("confidence") not in CONFIDENCE_VALUES:
-            result.add_issue("warning", f"{relpath} has invalid confidence '{frontmatter.get('confidence')}'")
+            result.add_issue(
+                "warning",
+                f"{relpath} has invalid confidence '{frontmatter.get('confidence')}'",
+            )
 
     flags = frontmatter.get("flags", [])
     if not isinstance(flags, list):
@@ -221,26 +270,48 @@ def validate_page_frontmatter(relpath: str, frontmatter: dict, content: str, res
 
     workflow_status = frontmatter.get("workflow_status")
     if workflow_status not in WORKFLOW_BY_TYPE[page_type]:
-        result.add_issue("warning", f"{relpath} has invalid workflow_status '{workflow_status}' for type '{page_type}'")
+        result.add_issue(
+            "warning",
+            f"{relpath} has invalid workflow_status '{workflow_status}' for type '{page_type}'",
+        )
 
     if page_type == "decision" and not frontmatter.get("review_after"):
-        result.add_issue("warning", f"{relpath} is a decision record without review_after")
+        result.add_issue(
+            "warning", f"{relpath} is a decision record without review_after"
+        )
 
     if page_type == "source":
         if frontmatter.get("source_kind") not in SOURCE_KIND_VALUES:
-            result.add_issue("warning", f"{relpath} has invalid source_kind '{frontmatter.get('source_kind')}'")
-        for field_name in ("raw_artifacts", "log_surface", "evaluated_sessions", "evaluated_runs"):
+            result.add_issue(
+                "warning",
+                f"{relpath} has invalid source_kind '{frontmatter.get('source_kind')}'",
+            )
+        for field_name in (
+            "raw_artifacts",
+            "log_surface",
+            "evaluated_sessions",
+            "evaluated_runs",
+        ):
             if field_name not in frontmatter:
-                result.add_issue("warning", f"{relpath} source page missing {field_name}")
+                result.add_issue(
+                    "warning", f"{relpath} source page missing {field_name}"
+                )
         if frontmatter.get("log_surface") not in LOG_SURFACE_VALUES:
-            result.add_issue("warning", f"{relpath} has invalid log_surface '{frontmatter.get('log_surface')}'")
+            result.add_issue(
+                "warning",
+                f"{relpath} has invalid log_surface '{frontmatter.get('log_surface')}'",
+            )
 
     for section in REQUIRED_SECTIONS[page_type]:
         if section not in content:
-            result.add_issue("warning", f"{relpath} missing required section '{section}'")
+            result.add_issue(
+                "warning", f"{relpath} missing required section '{section}'"
+            )
 
 
-def validate_source_paths(page: Path, kb_root: Path, wiki_dir: Path, frontmatter: dict, result: Result) -> None:
+def validate_source_paths(
+    page: Path, kb_root: Path, wiki_dir: Path, frontmatter: dict, result: Result
+) -> None:
     relpath = normalize_page_rel(wiki_dir, page)
     page_type = frontmatter.get("type")
 
@@ -249,7 +320,9 @@ def validate_source_paths(page: Path, kb_root: Path, wiki_dir: Path, frontmatter
     if isinstance(sources, list) and isinstance(related, list):
         overlap = sorted(set(sources).intersection(related))
         for entry in overlap:
-            result.add_issue("warning", f"{relpath} has duplicate sources/related entry '{entry}'")
+            result.add_issue(
+                "warning", f"{relpath} has duplicate sources/related entry '{entry}'"
+            )
 
     if isinstance(sources, list):
         for source in sources:
@@ -267,25 +340,40 @@ def validate_source_paths(page: Path, kb_root: Path, wiki_dir: Path, frontmatter
                         f"{relpath} sources entry must point to a source page or repo doc: {source}",
                     )
             if not resolved.exists():
-                result.add_issue("warning", f"{relpath} sources entry does not resolve: {source}")
+                result.add_issue(
+                    "warning", f"{relpath} sources entry does not resolve: {source}"
+                )
 
     if frontmatter.get("type") == "source":
         raw_artifacts = frontmatter.get("raw_artifacts", [])
         if isinstance(raw_artifacts, list):
             for artifact in raw_artifacts:
-                if isinstance(artifact, str) and artifact.startswith("raw/") and not (kb_root / artifact).is_file():
-                    result.add_issue("warning", f"{relpath} raw_artifacts entry does not resolve to a file: {artifact}")
+                if (
+                    isinstance(artifact, str)
+                    and artifact.startswith("raw/")
+                    and not (kb_root / artifact).is_file()
+                ):
+                    result.add_issue(
+                        "warning",
+                        f"{relpath} raw_artifacts entry does not resolve to a file: {artifact}",
+                    )
 
 
-def validate_log_coverage(kb_root: Path, log_coverage_path: Path, result: Result) -> None:
+def validate_log_coverage(
+    kb_root: Path, log_coverage_path: Path, result: Result
+) -> None:
     content = log_coverage_path.read_text(encoding="utf-8")
     frontmatter = extract_frontmatter(content)
 
     for field_name in sorted(LOG_COVERAGE_FIELDS - set(frontmatter.keys())):
-        result.add_issue("warning", f"wiki/log-coverage.md missing required field '{field_name}'")
+        result.add_issue(
+            "warning", f"wiki/log-coverage.md missing required field '{field_name}'"
+        )
 
     if frontmatter.get("type") != "log-coverage":
-        result.add_issue("warning", "wiki/log-coverage.md must have type 'log-coverage'")
+        result.add_issue(
+            "warning", "wiki/log-coverage.md must have type 'log-coverage'"
+        )
 
     list_fields = (
         "expected_chat_surfaces",
@@ -298,51 +386,87 @@ def validate_log_coverage(kb_root: Path, log_coverage_path: Path, result: Result
     for field_name in list_fields:
         value = frontmatter.get(field_name)
         if value is not None and not isinstance(value, list):
-            result.add_issue("warning", f"wiki/log-coverage.md field '{field_name}' must be a list")
+            result.add_issue(
+                "warning", f"wiki/log-coverage.md field '{field_name}' must be a list"
+            )
 
     current_log_files = frontmatter.get("current_log_files", [])
     if isinstance(current_log_files, list):
         for log_file in current_log_files:
-            if isinstance(log_file, str) and log_file and not (kb_root.parent / log_file).is_file():
-                result.add_issue("info", f"wiki/log-coverage.md current_log_files entry not present in this checkout: {log_file}")
+            if (
+                isinstance(log_file, str)
+                and log_file
+                and not (kb_root.parent / log_file).is_file()
+            ):
+                result.add_issue(
+                    "info",
+                    f"wiki/log-coverage.md current_log_files entry not present in this checkout: {log_file}",
+                )
 
     for section in LOG_COVERAGE_SECTIONS:
         if section not in content:
-            result.add_issue("warning", f"wiki/log-coverage.md missing required section '{section}'")
+            result.add_issue(
+                "warning", f"wiki/log-coverage.md missing required section '{section}'"
+            )
 
 
-def validate_active_queue(kb_root: Path, wiki_dir: Path, pages: list[Path], result: Result) -> None:
+def validate_active_queue(
+    kb_root: Path, wiki_dir: Path, pages: list[Path], result: Result
+) -> None:
     active_path = kb_root / "ACTIVE.md"
     if not active_path.exists():
         return
 
     content = active_path.read_text(encoding="utf-8")
     curated_page_rels = {normalize_page_rel(wiki_dir, page) for page in pages}
-    match = re.search(r"^Current promoted items:\s*\n(?P<body>.*?)(?:\n## |\Z)", content, re.DOTALL | re.MULTILINE)
+    match = re.search(
+        r"^Current promoted items:\s*\n(?P<body>.*?)(?:\n## |\Z)",
+        content,
+        re.DOTALL | re.MULTILINE,
+    )
     if not match:
-        result.add_issue("warning", "ACTIVE.md missing 'Current promoted items:' section")
+        result.add_issue(
+            "warning", "ACTIVE.md missing 'Current promoted items:' section"
+        )
         return
 
-    bullets = [line.strip() for line in match.group("body").splitlines() if line.strip().startswith("- ")]
+    bullets = [
+        line.strip()
+        for line in match.group("body").splitlines()
+        if line.strip().startswith("- ")
+    ]
     if len(bullets) > 5:
-        result.add_issue("warning", f"ACTIVE.md has {len(bullets)} promoted items; maximum is 5")
+        result.add_issue(
+            "warning", f"ACTIVE.md has {len(bullets)} promoted items; maximum is 5"
+        )
 
     for bullet in bullets:
         links = re.findall(r"\[[^\]]+\]\(([^)]+)\)", bullet)
         if not links:
-            result.add_issue("warning", f"ACTIVE.md item missing curated wiki link: {bullet}")
+            result.add_issue(
+                "warning", f"ACTIVE.md item missing curated wiki link: {bullet}"
+            )
             continue
         for link in links:
             if not link.startswith("wiki/"):
-                result.add_issue("warning", f"ACTIVE.md item link must start with wiki/: {link}")
+                result.add_issue(
+                    "warning", f"ACTIVE.md item link must start with wiki/: {link}"
+                )
                 continue
             wiki_link = os.path.normpath(link.removeprefix("wiki/"))
             if not (kb_root / link).is_file():
-                result.add_issue("warning", f"ACTIVE.md item link does not resolve: {link}")
+                result.add_issue(
+                    "warning", f"ACTIVE.md item link does not resolve: {link}"
+                )
             elif wiki_link not in curated_page_rels:
-                result.add_issue("warning", f"ACTIVE.md item link must point to a curated wiki page: {link}")
+                result.add_issue(
+                    "warning",
+                    f"ACTIVE.md item link must point to a curated wiki page: {link}",
+                )
         if "docs/project/state.md#current-release-goal" not in bullet:
-            result.add_issue("warning", f"ACTIVE.md item missing release-goal citation: {bullet}")
+            result.add_issue(
+                "warning", f"ACTIVE.md item missing release-goal citation: {bullet}"
+            )
 
 
 def validate_reachability(wiki_dir: Path, pages: list[Path], result: Result) -> None:
@@ -356,7 +480,9 @@ def validate_reachability(wiki_dir: Path, pages: list[Path], result: Result) -> 
         if normalized in page_map:
             root_targets.add(normalized)
         elif not (wiki_dir / normalized).exists() and normalized != "log-coverage.md":
-            result.add_issue("warning", f"wiki/index.md references missing page '{normalized}'")
+            result.add_issue(
+                "warning", f"wiki/index.md references missing page '{normalized}'"
+            )
 
     for page in pages:
         relpath = normalize_page_rel(wiki_dir, page)
@@ -379,7 +505,9 @@ def validate_reachability(wiki_dir: Path, pages: list[Path], result: Result) -> 
 
     for relpath in page_map:
         if relpath not in reachable:
-            result.add_issue("warning", f"Curated page not reachable from wiki/index.md: {relpath}")
+            result.add_issue(
+                "warning", f"Curated page not reachable from wiki/index.md: {relpath}"
+            )
 
     result.stats["indexed_roots"] = len(root_targets)
     result.stats["reachable_pages"] = len(reachable)

--- a/.agents/skills/socratink-brain/scripts/wiki_stats.py
+++ b/.agents/skills/socratink-brain/scripts/wiki_stats.py
@@ -37,8 +37,16 @@ class WikiStats:
     evaluated_runs: int = 0
 
     def report(self) -> str:
-        provenance_rate = (self.provenance_covered_pages / self.provenance_total_pages * 100.0) if self.provenance_total_pages else 0.0
-        raw_reference_rate = (self.referenced_raw_artifacts / self.raw_source_files * 100.0) if self.raw_source_files else 0.0
+        provenance_rate = (
+            (self.provenance_covered_pages / self.provenance_total_pages * 100.0)
+            if self.provenance_total_pages
+            else 0.0
+        )
+        raw_reference_rate = (
+            (self.referenced_raw_artifacts / self.raw_source_files * 100.0)
+            if self.raw_source_files
+            else 0.0
+        )
         lines = [
             "=== Socratink Brain Stats ===",
             "",
@@ -82,7 +90,11 @@ def parse_scalar(value: str):
         inner = value[1:-1].strip()
         if not inner:
             return []
-        return [item.strip().strip('"').strip("'") for item in inner.split(",") if item.strip()]
+        return [
+            item.strip().strip('"').strip("'")
+            for item in inner.split(",")
+            if item.strip()
+        ]
     return value.strip('"').strip("'")
 
 
@@ -111,7 +123,13 @@ def count_raw_files(raw_dir: Path) -> int:
     if not raw_dir.exists():
         return 0
     ignored_names = {"README.md", "CLAUDE.md", ".gitkeep"}
-    return sum(1 for path in raw_dir.rglob("*") if path.is_file() and not path.name.startswith(".") and path.name not in ignored_names)
+    return sum(
+        1
+        for path in raw_dir.rglob("*")
+        if path.is_file()
+        and not path.name.startswith(".")
+        and path.name not in ignored_names
+    )
 
 
 def to_int(value) -> int:
@@ -152,13 +170,19 @@ def gather_stats(kb_root: Path) -> WikiStats:
         raw_artifacts = frontmatter.get("raw_artifacts", [])
         if isinstance(sources, list) and sources:
             stats.provenance_covered_pages += 1
-        elif page_type == "source" and isinstance(raw_artifacts, list) and raw_artifacts:
+        elif (
+            page_type == "source" and isinstance(raw_artifacts, list) and raw_artifacts
+        ):
             stats.provenance_covered_pages += 1
 
         flags = frontmatter.get("flags", [])
         if isinstance(flags, list):
-            stats.contradiction_flags += sum(1 for flag in flags if flag == "contradiction")
-            stats.open_question_flags += sum(1 for flag in flags if flag == "open-question")
+            stats.contradiction_flags += sum(
+                1 for flag in flags if flag == "contradiction"
+            )
+            stats.open_question_flags += sum(
+                1 for flag in flags if flag == "open-question"
+            )
             stats.hypothesis_flags += sum(1 for flag in flags if flag == "hypothesis")
 
         workflow_status = frontmatter.get("workflow_status")

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,89 @@
+# Socratink
+
+## What This Is
+
+Socratink is an AI-powered learning app that extracts structured knowledge maps from raw content (text, URLs, files) and drills truthful recall through Socratic conversation. Learners paste material, the AI structures it into a drillable graph, and they prove understanding by explaining concepts from memory before seeing study material. Built as a vanilla JS/FastAPI web app deployed on Vercel.
+
+## Core Value
+
+AI removes prep friction and increases truthful retrieval reps without replacing the learner's generation step. The struggle is the point — cold recall before recognition.
+
+## Requirements
+
+### Validated
+
+- User can sign up and log in via WorkOS (email, Google, guest, magic auth) — existing
+- User can create concepts by pasting text, providing a URL, or uploading a file — existing
+- AI extracts structured knowledge maps with backbone principles, clusters, and subnodes — existing
+- User can inspect extracted material in Study View (expandable clusters and nodes) — existing
+- User can visualize knowledge map as an interactive graph (Cytoscape.js) — existing
+- User can drill any node via Socratic AI conversation (cold recall first) — existing
+- Node epistemic states track learning progress (locked → primed → drilled → solidified) — existing
+- AI evaluates recall quality and routes to next action (probe, scaffold, reroute, complete) — existing
+- Next best move guidance directs user through the graph after each drill — existing
+- Crystal UI metaphor reflects concept state on dashboard — existing
+- App deploys to Vercel as serverless FastAPI — existing
+
+### Active
+
+- [ ] Migrate auth from WorkOS to Supabase Auth
+- [ ] Migrate data persistence from localStorage to Supabase Postgres
+- [ ] Build guided onboarding for first-run users (one truthful loop)
+- [ ] Instrument analytics to measure user behavior and activation
+- [ ] Make the app work well on mobile devices
+- [ ] Polish UX rough edges across existing flows
+
+### Out of Scope
+
+- Native mobile app — web-first, responsive design only
+- Real-time collaboration — single-learner product
+- Custom AI model training — using Gemini API as-is
+- Gamification / streaks / leaderboards — truthful progress, not engagement tricks
+- Paid features / billing — pre-revenue, validating core loop first
+
+## Context
+
+Socratink is MVP-stage. The core learning loop works: extract → inspect → cold recall → targeted study → next move → return. But it's not ready for real users because data lives in localStorage (vanishes if they clear browser), there's no onboarding to guide first-time users through the loop, and there's no instrumentation to learn from how people actually use it.
+
+The immediate goal is to get the product ready for a small batch of personally-invited users (friends, colleagues, early supporters). The purpose isn't scale — it's learning. Watch how real people use it, measure what matters, and iterate toward retention.
+
+An onboarding research report (`socratink_onboarding_tutorial_research_report.md`) already exists with a clear recommendation: guided task completion (not narrated tours), hybrid coach marks + interactive tasks, and a 6-step first-run storyboard that gets users through one truthful loop in under 2 minutes.
+
+The current auth system (WorkOS) will be replaced by Supabase Auth, and localStorage will be replaced by Supabase Postgres — consolidating auth and storage into one platform.
+
+## Constraints
+
+- **Tech stack**: Vanilla JS frontend (no frameworks, no build step), FastAPI backend, Gemini 2.5 Flash for AI
+- **Deployment**: Vercel serverless — all backend routes through `api/index.py`
+- **AI dependency**: Gemini API for extraction and drill — cost scales with usage
+- **No build step**: Frontend is static files served from `public/` — keep it that way
+- **Architecture invariants**: `setState()` is the only UI control-state entry point; knowledge map is source of truth for drill state; generation before recognition is non-negotiable
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Supabase for auth + storage | Consolidates WorkOS (auth) + localStorage (data) into one platform — simpler stack, persistent data, built-in auth | — Pending |
+| Guided task completion for onboarding | Research report recommends teaching by doing over narrated tours — matches the product's "generation first" philosophy | — Pending |
+| First users are personal invites | Learning from real usage, not chasing scale — small batch to iterate on retention | — Pending |
+| Keep vanilla JS / no build step | Existing architecture works, no reason to add framework complexity for this milestone | — Pending |
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd-transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-04-15 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,140 @@
+# Requirements: Socratink
+
+**Defined:** 2026-04-15
+**Core Value:** AI removes prep friction and increases truthful retrieval reps without replacing the learner's generation step.
+
+## v1 Requirements
+
+Requirements for launch readiness — smooth core loop, persistent data, guided onboarding, session analytics.
+
+### Infrastructure
+
+- [ ] **INFRA-01**: Supabase project created with database schema, RLS policies, and connection pooling configured
+- [ ] **INFRA-02**: Supabase JS client integrated via CDN in frontend (no build step)
+- [ ] **INFRA-03**: Supabase Python client integrated in FastAPI backend
+
+### Authentication
+
+- [ ] **AUTH-01**: User can sign in with Google via Supabase Auth
+- [ ] **AUTH-02**: User can try the app as anonymous guest via Supabase anonymous auth
+- [ ] **AUTH-03**: User session persists across tabs and page refreshes
+- [ ] **AUTH-04**: User can log out from any page
+- [ ] **AUTH-05**: Backend middleware validates Supabase JWT on protected routes
+
+### Data Persistence
+
+- [ ] **DATA-01**: User's concepts (knowledge maps) are stored in Supabase Postgres as JSONB
+- [ ] **DATA-02**: User's drill state (node epistemic states, re-drill counts, timestamps) is persisted in Supabase
+- [ ] **DATA-03**: User can close browser, return later, and find all concepts and drill progress intact
+
+### Onboarding
+
+- [ ] **ONBD-01**: New user sees a welcome message explaining the product's value on first visit
+- [ ] **ONBD-02**: New user is guided through creating their first concept with contextual cues
+- [ ] **ONBD-03**: After first concept creation, coach marks point to drill and explain next steps
+- [ ] **ONBD-04**: After first drill attempt, result screen explains epistemic state (PRIMED/DRILLED) in plain language
+- [ ] **ONBD-05**: After completing first learning loop, user sees a completion moment acknowledging their progress
+- [ ] **ONBD-06**: User can skip or dismiss onboarding at any point without being blocked
+
+### Analytics
+
+- [ ] **ANLY-01**: Session events (start, duration, pages visited) are tracked per user
+- [ ] **ANLY-02**: Analytics events are stored in Supabase Postgres for querying
+
+### Mobile
+
+- [ ] **MOBL-01**: Dashboard, study view, and drill chat are usable on mobile screen widths (down to 375px)
+- [ ] **MOBL-02**: Viewport meta tag and scaling are correct on mobile devices
+
+### UX Polish
+
+- [ ] **UX-01**: AI operations (extraction, drilling) show clear loading states with progress indication
+- [ ] **UX-02**: Errors during AI operations show user-friendly recovery guidance
+- [ ] **UX-03**: Concept epistemic states have clear, jargon-free explanations accessible to new users
+
+## v2 Requirements
+
+Deferred to future release. Tracked but not in current roadmap.
+
+### Authentication
+
+- **AUTH-06**: User can sign up and log in with email and password
+- **AUTH-07**: User can log in via magic link (passwordless email)
+- **AUTH-08**: User can delete their account and all associated data
+
+### Data Persistence
+
+- **DATA-04**: Concepts auto-save on every user action (not just explicit save)
+- **DATA-05**: Migration utility to move existing localStorage data to Supabase
+- **DATA-06**: User can access their concepts from any device (cross-device sync)
+- **DATA-07**: User can export their concept data
+
+### Analytics
+
+- **ANLY-03**: Activation funnel tracked (concept_created → drill_started → drill_completed → return_visit)
+- **ANLY-04**: Time-to-first-loop metric measured per user
+- **ANLY-05**: Drop-off detection (where in the flow users stop)
+- **ANLY-06**: Analytics dashboard for reviewing user behavior patterns
+
+### Mobile
+
+- **MOBL-03**: Touch-optimized drill interface with larger touch targets
+- **MOBL-04**: Simplified mobile graph view (list or reduced visualization)
+- **MOBL-05**: Mobile-specific bottom navigation
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature | Reason |
+|---------|--------|
+| Native mobile app | Web-first, responsive design only |
+| Real-time collaboration | Single-learner product |
+| Gamification (streaks, leaderboards, badges) | Conflicts with truthful progress philosophy |
+| Push notifications | Pre-revenue, small user batch, unnecessary pressure |
+| AI-generated flashcards | Removes learner's generation step — anti-philosophy |
+| Content marketplace | Scope creep, not relevant to core loop |
+| Collaborative study | Not the product's purpose |
+| Custom AI model training | Using Gemini API as-is |
+| Paid features / billing | Pre-revenue, validating core loop first |
+| Email/password auth (v1) | Google + guest sufficient for personal invites |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| INFRA-01 | — | Pending |
+| INFRA-02 | — | Pending |
+| INFRA-03 | — | Pending |
+| AUTH-01 | — | Pending |
+| AUTH-02 | — | Pending |
+| AUTH-03 | — | Pending |
+| AUTH-04 | — | Pending |
+| AUTH-05 | — | Pending |
+| DATA-01 | — | Pending |
+| DATA-02 | — | Pending |
+| DATA-03 | — | Pending |
+| ONBD-01 | — | Pending |
+| ONBD-02 | — | Pending |
+| ONBD-03 | — | Pending |
+| ONBD-04 | — | Pending |
+| ONBD-05 | — | Pending |
+| ONBD-06 | — | Pending |
+| ANLY-01 | — | Pending |
+| ANLY-02 | — | Pending |
+| MOBL-01 | — | Pending |
+| MOBL-02 | — | Pending |
+| UX-01 | — | Pending |
+| UX-02 | — | Pending |
+| UX-03 | — | Pending |
+
+**Coverage:**
+- v1 requirements: 24 total
+- Mapped to phases: 0
+- Unmapped: 24
+
+---
+*Requirements defined: 2026-04-15*
+*Last updated: 2026-04-15 after initial definition*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -26,6 +26,7 @@ Requirements for launch readiness — smooth core loop, persistent data, guided 
 - [ ] **DATA-01**: User's concepts (knowledge maps) are stored in Supabase Postgres as JSONB
 - [ ] **DATA-02**: User's drill state (node epistemic states, re-drill counts, timestamps) is persisted in Supabase
 - [ ] **DATA-03**: User can close browser, return later, and find all concepts and drill progress intact
+- [ ] **DATA-04**: Concepts and drill state auto-save on every mutation (matching current localStorage behavior)
 
 ### Onboarding
 
@@ -64,14 +65,13 @@ Deferred to future release. Tracked but not in current roadmap.
 
 ### Data Persistence
 
-- **DATA-04**: Concepts auto-save on every user action (not just explicit save)
 - **DATA-05**: Migration utility to move existing localStorage data to Supabase
 - **DATA-06**: User can access their concepts from any device (cross-device sync)
 - **DATA-07**: User can export their concept data
 
 ### Analytics
 
-- **ANLY-03**: Activation funnel tracked (concept_created → drill_started → drill_completed → return_visit)
+- **ANLY-03**: Activation funnel tracked (concept_created -> drill_started -> drill_completed -> return_visit)
 - **ANLY-04**: Time-to-first-loop metric measured per user
 - **ANLY-05**: Drop-off detection (where in the flow users stop)
 - **ANLY-06**: Analytics dashboard for reviewing user behavior patterns
@@ -105,36 +105,37 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| INFRA-01 | — | Pending |
-| INFRA-02 | — | Pending |
-| INFRA-03 | — | Pending |
-| AUTH-01 | — | Pending |
-| AUTH-02 | — | Pending |
-| AUTH-03 | — | Pending |
-| AUTH-04 | — | Pending |
-| AUTH-05 | — | Pending |
-| DATA-01 | — | Pending |
-| DATA-02 | — | Pending |
-| DATA-03 | — | Pending |
-| ONBD-01 | — | Pending |
-| ONBD-02 | — | Pending |
-| ONBD-03 | — | Pending |
-| ONBD-04 | — | Pending |
-| ONBD-05 | — | Pending |
-| ONBD-06 | — | Pending |
-| ANLY-01 | — | Pending |
-| ANLY-02 | — | Pending |
-| MOBL-01 | — | Pending |
-| MOBL-02 | — | Pending |
-| UX-01 | — | Pending |
-| UX-02 | — | Pending |
-| UX-03 | — | Pending |
+| INFRA-01 | Phase 1 | Pending |
+| INFRA-02 | Phase 1 | Pending |
+| INFRA-03 | Phase 1 | Pending |
+| AUTH-01 | Phase 2 | Pending |
+| AUTH-02 | Phase 2 | Pending |
+| AUTH-03 | Phase 2 | Pending |
+| AUTH-04 | Phase 2 | Pending |
+| AUTH-05 | Phase 2 | Pending |
+| DATA-01 | Phase 3 | Pending |
+| DATA-02 | Phase 4 | Pending |
+| DATA-03 | Phase 4 | Pending |
+| DATA-04 | Phase 3 | Pending |
+| ONBD-01 | Phase 6 | Pending |
+| ONBD-02 | Phase 6 | Pending |
+| ONBD-03 | Phase 7 | Pending |
+| ONBD-04 | Phase 7 | Pending |
+| ONBD-05 | Phase 7 | Pending |
+| ONBD-06 | Phase 6 | Pending |
+| ANLY-01 | Phase 5 | Pending |
+| ANLY-02 | Phase 5 | Pending |
+| MOBL-01 | Phase 8 | Pending |
+| MOBL-02 | Phase 8 | Pending |
+| UX-01 | Phase 9 | Pending |
+| UX-02 | Phase 9 | Pending |
+| UX-03 | Phase 9 | Pending |
 
 **Coverage:**
-- v1 requirements: 24 total
-- Mapped to phases: 0
-- Unmapped: 24
+- v1 requirements: 25 total
+- Mapped to phases: 25
+- Unmapped: 0
 
 ---
 *Requirements defined: 2026-04-15*
-*Last updated: 2026-04-15 after initial definition*
+*Last updated: 2026-04-15 after roadmap creation*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,140 @@
+# Roadmap: Socratink
+
+## Overview
+
+Socratink's core learning loop works but lives in localStorage and lacks onboarding, analytics, and mobile support. This roadmap takes the app from "works on my laptop" to "ready for personally-invited users" by migrating to Supabase (auth + storage), adding guided onboarding, instrumenting basic analytics, and making the core flow usable on phones. Each phase delivers a verifiable capability, ordered so that downstream phases can build on stable foundations.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Supabase Foundation** - Set up Supabase project, schema, RLS, and client integration for both frontend and backend
+- [ ] **Phase 2: Auth Migration** - Replace WorkOS with Supabase Auth (Google, guest, session persistence, logout, JWT validation)
+- [ ] **Phase 3: Knowledge Map Storage** - Migrate concept/knowledge map persistence from localStorage to Supabase Postgres
+- [ ] **Phase 4: Drill State Storage** - Persist drill state (epistemic states, re-drill counts, timestamps) in a separate Supabase table
+- [ ] **Phase 5: Analytics Foundation** - Instrument session-level user behavior tracking stored in Supabase
+- [ ] **Phase 6: Onboarding Welcome & First Concept** - Guide new users from landing to their first extracted knowledge map
+- [ ] **Phase 7: Onboarding Drill & Completion** - Guide users through their first drill and celebrate loop completion
+- [ ] **Phase 8: Mobile Responsiveness** - Make dashboard, study view, and drill chat usable on mobile screen widths
+- [ ] **Phase 9: UX Polish** - Loading states, error recovery, and jargon-free explanations across all flows
+
+## Phase Details
+
+### Phase 1: Supabase Foundation
+**Goal**: The infrastructure layer exists and both frontend and backend can communicate with Supabase
+**Depends on**: Nothing (first phase)
+**Requirements**: INFRA-01, INFRA-02, INFRA-03
+**Success Criteria** (what must be TRUE):
+  1. Supabase project exists with tables for users, concepts, drill_states, and analytics events
+  2. RLS policies are active on every user-data table and verified with test queries
+  3. Frontend can import and initialize the Supabase JS client from CDN without a build step
+  4. Backend can connect to Supabase Postgres via the Python client using connection pooling
+**Plans**: TBD
+
+### Phase 2: Auth Migration
+**Goal**: Users can sign in, stay signed in, and sign out using Supabase Auth instead of WorkOS
+**Depends on**: Phase 1
+**Requirements**: AUTH-01, AUTH-02, AUTH-03, AUTH-04, AUTH-05
+**Success Criteria** (what must be TRUE):
+  1. User can sign in with their Google account and land on the dashboard
+  2. User can try the app as an anonymous guest without creating an account
+  3. User can close the browser, reopen it, and still be logged in
+  4. User can log out from any page and be returned to the login screen
+  5. Backend rejects API requests that lack a valid Supabase JWT
+**Plans**: TBD
+
+### Phase 3: Knowledge Map Storage
+**Goal**: Users' concepts and knowledge maps survive beyond the browser session
+**Depends on**: Phase 2
+**Requirements**: DATA-01, DATA-04
+**Success Criteria** (what must be TRUE):
+  1. When a user creates a concept via extraction, the resulting knowledge map is saved to Supabase Postgres as JSONB
+  2. When a user returns after closing the browser, all previously created concepts appear on the dashboard
+  3. Each user sees only their own concepts (RLS enforced)
+  4. Every concept mutation auto-saves to Supabase (matching current localStorage behavior — no manual save required)
+**Plans**: TBD
+
+### Phase 4: Drill State Storage
+**Goal**: Users' drill progress persists independently from knowledge maps so they never lose learning state
+**Depends on**: Phase 3
+**Requirements**: DATA-02, DATA-03
+**Success Criteria** (what must be TRUE):
+  1. Node epistemic states (locked, primed, drilled, solidified), re-drill counts, and timestamps are stored in a dedicated drill_states table
+  2. After drilling a node and closing the browser, the user returns to find the node in its correct epistemic state
+  3. Drill state updates do not rewrite the entire knowledge map JSONB (separate table, targeted updates)
+**Plans**: TBD
+
+### Phase 5: Analytics Foundation
+**Goal**: Basic user behavior is recorded so the builder can learn from real usage patterns
+**Depends on**: Phase 2
+**Requirements**: ANLY-01, ANLY-02
+**Success Criteria** (what must be TRUE):
+  1. Session events (start, duration, pages visited) are recorded per authenticated user
+  2. Analytics events are queryable in the Supabase analytics_events table
+  3. Anonymous guest sessions are tracked with the same schema as authenticated sessions
+**Plans**: TBD
+
+### Phase 6: Onboarding Welcome & First Concept
+**Goal**: A new user understands what socratink does and successfully creates their first knowledge map without confusion
+**Depends on**: Phase 3
+**Requirements**: ONBD-01, ONBD-02, ONBD-06
+**Success Criteria** (what must be TRUE):
+  1. A first-time user sees a welcome message explaining what socratink does and how it works
+  2. Contextual cues guide the user through pasting text or a URL and triggering extraction
+  3. User can skip or dismiss the onboarding guidance at any point without getting stuck
+**Plans**: TBD
+**UI hint**: yes
+
+### Phase 7: Onboarding Drill & Completion
+**Goal**: A new user completes their first full learning loop (extract, drill, understand progress) and knows what to do next
+**Depends on**: Phase 6
+**Requirements**: ONBD-03, ONBD-04, ONBD-05
+**Success Criteria** (what must be TRUE):
+  1. After first concept creation, coach marks point the user toward drilling and explain the next step
+  2. After the user completes their first drill, the result screen explains what PRIMED or DRILLED means in plain language
+  3. After completing the first full learning loop, the user sees a completion moment acknowledging their progress
+**Plans**: TBD
+**UI hint**: yes
+
+### Phase 8: Mobile Responsiveness
+**Goal**: The core learning loop (dashboard, study view, drill chat) works on phone-sized screens
+**Depends on**: Phase 4
+**Requirements**: MOBL-01, MOBL-02
+**Success Criteria** (what must be TRUE):
+  1. Dashboard, study view, and drill chat are usable at 375px width without horizontal scrolling or overlapping elements
+  2. Viewport meta tag and scaling prevent unexpected zoom or layout shifts on mobile devices
+  3. Text input in drill chat is usable on mobile (keyboard does not obscure the input area)
+**Plans**: TBD
+**UI hint**: yes
+
+### Phase 9: UX Polish
+**Goal**: The app feels responsive and recoverable -- users never wonder "is it broken?" or "what does that mean?"
+**Depends on**: Phase 7
+**Requirements**: UX-01, UX-02, UX-03
+**Success Criteria** (what must be TRUE):
+  1. AI operations (extraction and drilling) display a clear loading indicator so the user knows work is happening
+  2. When an AI operation fails, the user sees a friendly error message with guidance on what to try next
+  3. Concept epistemic states are labeled with jargon-free descriptions accessible to someone who has never used the app
+**Plans**: TBD
+**UI hint**: yes
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Supabase Foundation | 0/TBD | Not started | - |
+| 2. Auth Migration | 0/TBD | Not started | - |
+| 3. Knowledge Map Storage | 0/TBD | Not started | - |
+| 4. Drill State Storage | 0/TBD | Not started | - |
+| 5. Analytics Foundation | 0/TBD | Not started | - |
+| 6. Onboarding Welcome & First Concept | 0/TBD | Not started | - |
+| 7. Onboarding Drill & Completion | 0/TBD | Not started | - |
+| 8. Mobile Responsiveness | 0/TBD | Not started | - |
+| 9. UX Polish | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,70 @@
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-04-15)
+
+**Core value:** AI removes prep friction and increases truthful retrieval reps without replacing the learner's generation step.
+**Current focus:** Phase 1: Supabase Foundation
+
+## Current Position
+
+Phase: 1 of 9 (Supabase Foundation)
+Plan: 0 of TBD in current phase
+Status: Ready to plan
+Last activity: 2026-04-15 — Roadmap created
+
+Progress: [..........] 0%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: -
+- Total execution time: 0 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| - | - | - | - |
+
+**Recent Trend:**
+- Last 5 plans: -
+- Trend: -
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Supabase for auth + storage (consolidates WorkOS + localStorage into one platform)
+- Separate drill states from knowledge map JSONB (avoid blowup on frequent drill updates)
+- RLS from day one (anon key is public, security depends entirely on RLS policies)
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- Research flag: mobile graph view may need simplified view, not just CSS (Phase 8 design decision)
+- Research flag: Vercel serverless needs Supavisor pooled connection string (Phase 1 setup)
+
+## Deferred Items
+
+Items acknowledged and carried forward from previous milestone close:
+
+| Category | Item | Status | Deferred At |
+|----------|------|--------|-------------|
+| *(none)* | | | |
+
+## Session Continuity
+
+Last session: 2026-04-15
+Stopped at: Roadmap created, ready to plan Phase 1
+Resume file: None

--- a/UX-todo.md
+++ b/UX-todo.md
@@ -1,0 +1,151 @@
+# Socratink UX TODO
+
+Source: Full-product UX audit (2026-04-16) covering Dashboard, concept creation, Study/Graph/Drill, Library, Analytics, Settings, Quick Guide, keyboard, dark mode, mobile.
+
+Severity legend: `[BLOCKER]` `[HIGH]` `[MED]` `[LOW]`
+Classification: `bug` / `contract` (app breaks its own pattern) / `best-practice` / `polish`
+
+---
+
+## Root architectural finding
+
+The token system is decorative, not driving. `--bg`, `--surface`, `--text`, `--primary`, `--success`, `--danger`, etc. are declared in `:root` but dark mode is implemented via selector-scoped overrides writing raw hex/rgb, not by reassigning tokens. Consequence: every component needs parallel dark-mode rules, and any view without them breaks. `--success` and `--danger` tokens are also declared but used by zero elements.
+
+**Fix upstream in `public/css/variables.css` + `public/css/crystal.css`**: move dark colors into `[data-theme="dark"] :root { --bg: …; --surface: …; }` so components consume tokens without knowing the theme. Add `--surface-2` (elevated), `--ring` (focus), `--shadow-sm/-lg`, and wire theme-adaptive `--success`/`--danger` mappings.
+
+This single change resolves findings #1, #4, #8, #14 and most of the dark-mode polish issues.
+
+---
+
+## Top 5 highest-leverage fixes (impact ÷ effort)
+
+- [ ] **1. Rewire dark mode through the token layer.** Move hardcoded dark colors into `[data-theme="dark"] :root { … }` reassignments. Consume only tokens in components. Fixes invisible Analytics select, missing focus ring, dead `--success`/`--danger`, stale hero shadow, and the "Continue with Google" void in one PR.
+- [ ] **2. Consolidate map-view chrome.** Kill the ambiguous top-left `<`. Replace with a proper "← Dashboard" text-back. Make sidebar open/closed state orthogonal to entry vector. Resolves findings #7 and #12.
+- [ ] **3. Fix concept creation end-to-end.** Move form into a center dialog. Lock the shell with `inert` + scrim during extraction. Surface backend failures as retriable errors. In guest mode, honestly communicate "Guest mode uses sample maps; sign in to extract your own."
+- [ ] **4. Make mobile first-class for theme, save, exit.** Add persistent user menu in mobile drawer footer: theme toggle, Save & Sync, Exit Guest, Settings. Currently mobile guest users have no egress path.
+- [ ] **5. Rebuild Analytics `.stat-tile` with `value`/`value--empty`/`string` variants.** "No activity yet" at 28px is the worst typography moment in the app. Pair with a 2-col breakpoint for titles that wrap, and grade the pills with state tokens.
+
+---
+
+## Systemic patterns
+
+### Pattern A — "Decorative tokens, imperative overrides"
+Invisible selects, near-black Google button, unchanging hero shadow, dead `--success`/`--danger`, invisible focus rings. One root cause. Fix in stylesheet architecture, ~6 findings disappear.
+
+### Pattern B — "Language drift between copy and UI"
+Three names for a concept ("Concept" / "Tink" / "socratink"). Settings claims a "green" status that's actually purple. Five different CTAs ("Add to vault" / "Open concept" / "Open Map" / "Start Drill" / "Start With Core Thesis") with zero shared vocabulary. One writer + design-systems pass with a glossary resolves ~4 findings.
+
+### Pattern C — "Shell vs. canvas confusion"
+Sidebar used as canvas (creation form). Chrome buttons behave differently per view. Graph View is a static SVG inside a canvas-sized panel. The app hasn't decided which surface owns which job.
+
+---
+
+## Findings by path
+
+### First-run / empty state
+
+- [ ] `[HIGH]` `contract` — Three names for the same object in one viewport. Sidebar says "Add a New Tink", hero says "Add Concept", empty-state H1 says "Add your first socratink". Pick one noun ("Concept") and propagate. Files: `App.renderAddTrigger` (sidebar), dashboard empty-state template (hero).
+- [ ] `[HIGH]` `bug / a11y` — Focus ring effectively invisible. `.theme-toggle` outline is `none`; `.hero-primary-action` outline is cream on a cream-text purple button. Add `:focus-visible { box-shadow: 0 0 0 3px var(--ring); }` with a `--ring` token.
+- [ ] `[MED]` `best-practice` — First Tab stop is the theme toggle, not a primary action. Reorder so primary CTA is reached within 1–2 Tabs.
+- [ ] `[LOW]` `polish` — Two competing Add paths with unequal weight (solid hero button + transparent sidebar card) both trigger `App.startAddConcept`. Either promote the sidebar one (used more once app has data) or demote the hero one.
+
+### Concept creation
+
+- [ ] `[BLOCKER]` `bug` — Submission silently discards user input. Entered "Photosynthesis" + pasted body → extraction overlay → created concept was "Thermostat Control Loop" (starter seed). No error, no warning. Either disable form in guest mode with a reason, wire to local fallback generator, or surface the backend error as retry prompt.
+- [ ] `[HIGH]` `bug` — Extraction overlay doesn't lock the background. Sidebar form stays clickable during extraction; hero "Add Concept" stays enabled. Double-submit risk. Add full scrim with `backdrop-filter: blur(8px)`, `pointer-events: auto`, and `aria-busy="true"`.
+- [ ] `[HIGH]` `contract` — Creation form lives in a 264px sidebar column. Textarea is ~200px wide for article-length pastes. Move creation into a center-stage dialog (Notion/Readwise pattern).
+- [ ] `[LOW]` `best-practice` — Hero CTA stays active while creation form is open. Toggle to disabled or swap for "Cancel".
+
+### Dashboard with one concept
+
+- [ ] `[MED]` `polish` — Hero card uses stock isometric illustration, not real data. For a mapping app, showing the concept's real mini-map (cluster count, progress, state) would be warm and honest.
+- [ ] `[LOW]` `polish` — Hero shadow is `0 40px 100px rgba(…, 0.05)` — expensive blur, reads flat. Consider `0 8px 24px rgba(…)` for tighter elevation.
+- [ ] `[LOW]` `polish` — Add a secondary "Start Drill" shortcut on the hero card to save returning users a click.
+
+### Entering a concept (Map View)
+
+- [ ] `[HIGH]` `contract` — Two exits with different meanings. Top-left `<` is `.drawer-toggle` (collapses sidebar); top-right `×` is `.map-close-btn` (exits map). Users reading `<` as "back" will collapse the sidebar and think the app broke. Either (a) make top-left a real back-arrow that exits the map, or (b) remove it entirely and rely on `×`.
+- [ ] `[MED]` `contract` — Sidebar auto-collapses when entering via sidebar click; stays open when entering via "Open Map". Same destination, two behaviors. Linear-style: keep sidebar open by default on desktop regardless of entry vector.
+
+### Study View
+
+- [ ] `[MED]` `best-practice` — "Start Drill" under-weighted for the primary action. 13px/700, tucked in top-right cluster. Consider a secondary CTA in chrome + a larger contextual "Start Drill" inside the first cluster or after the Backbone block.
+- [ ] `[LOW]` `polish` — Tag pills don't differentiate semantics. "Feedback Control Loop" (topic) and "Introductory" (level) are both uppercase purple-tinted pills. Use two distinct variants.
+
+### Graph View
+
+- [ ] `[HIGH]` `best-practice` — Graph is a fixed `<svg viewBox="0 0 280 220">` inside a ~470px panel. It's an illustration of a graph, not a rendered graph. Cytoscape.js hint exists in the body but isn't mounted in this view. Ship a real rendered graph that fills the panel, with zoom + node legend.
+- [ ] `[LOW]` `contract` — "Start With Core Thesis" button is a second primary CTA for the same gesture as "Start Drill". Consolidate.
+
+### Drill
+
+- [ ] `[HIGH]` `bug` — Drill error leaks backend detail. Message: "The drill service failed to respond. Check the backend or API key and try again." No error variant, no retry button. Add `.chat-bubble.error` token-backed variant with friendlier copy + retry. Guest mode should ship a local fallback drill.
+- [ ] `[MED]` `contract` — Shell doesn't recognize "drill mode". `×` hard-exits to Dashboard and sidebar nav fires view changes mid-drill with no guard. Intercept view changes while `App.state.currentDrill` is active.
+- [ ] `[MED]` `contract` — Graph reveal state persists after exit. After `← Back` and re-enter via "Open Map", the obfuscated-node reveal carries. If intentional, document it; if not, reset on map exit.
+- [ ] Good — Obfuscated-node reveal pattern ("T·······C·······" → reveals as you progress) is thoughtful and distinctive. Keep it.
+
+### Library
+
+- [ ] `[MED]` `contract` — Card variants diverge between shelves. `.library-card-starter` is transparent/no shadow/264×227; `.library-card-vault` is transparent/shadowed/829px full-row. Same family, different layouts and elevations. Unify to one grid with state-pill differentiation, or give starters a distinct "catalog" treatment.
+- [ ] `[LOW]` `polish` — "Add to vault" is a bare text link. Users expect a button.
+- [ ] `[LOW]` `polish` — Orphan 7th starter card on row 3 (3-col grid, 7 items). Balance to 6 or 9, or add a "Request a starter" CTA to square it.
+
+### Analytics
+
+- [ ] `[BLOCKER]` `bug` — Concept select invisible in dark mode. `.analytics-select` background stays `rgba(255,255,255,0.9)` but color is cream. Selected option unreadable. Move background to a token (`--input-bg`) and swap in the dark ruleset.
+- [ ] `[HIGH]` `contract` — `.stat-tile-value` renders "No activity yet" at 28px, wrapping 3 lines inside a small column. Add a `value--empty` variant that drops to ~14–15px italic muted text.
+- [ ] `[MED]` `polish` — Stat titles wrap to 3 lines on 278px columns ("Re-Drill Conversion", "Return Timing", "Recent Learning Journal"). Reduce title size, tighten to 2 columns, or shorten copy ("Re-Drill Wins", "Overdue Returns", "Journal").
+- [ ] `[MED]` `best-practice` — All pills are lavender. "Solid 0", "Primed 0", "In progress 0", "Misconceptions 0" should differentiate at a glance. Use `--success`/`--warning`/`--danger`/`--info` tokens.
+- [ ] `[LOW]` `polish` — Seven "?" help icons create tooltip-soup. Group into a single "How to read this page" affordance at the top.
+
+### Settings
+
+- [ ] `[MED]` `bug` — Copy references a "green" that isn't in the UI. "A green backend alone does not prove extract or drill is fully working." — actual dot is purple. Either restore green semantically via `--success` or change the copy to match reality.
+- [ ] `[MED]` `best-practice` — Guest mode exposes a Gemini API key input inline on the main Settings surface. For broader audience, move behind an "Advanced" disclosure.
+- [ ] `[LOW]` `polish` — "Continue with Google" in dark mode renders as a near-black void on dark-purple surface. Use Google brand tokens (white for light, `#131314` with visible white border for dark) if real SSO, or a neutral secondary if placeholder.
+- [ ] `[LOW]` `polish` — Three different badge treatments on the same card: "Connected" filled pill, "Server key active" filled pill, `settings-dot.connected` 7×7 dot. Pick one.
+
+### Navigation consistency
+
+- [ ] `[BLOCKER]` `bug` — Mobile (≈375px) hides theme toggle, Save & Sync, Exit Guest via `display: none`, and none are in the drawer. Mobile guest users cannot toggle theme, save their work, or exit guest mode, anywhere. Silent data-loss path. Add to mobile drawer footer.
+- [ ] `[LOW]` `contract` — Hamburger morphs between `≡` and `<`. Users fluent in browser "Back" will misread `<`. Add a tooltip label.
+
+### Theme persistence
+
+- [ ] `[MED]` `polish` — Hero shadow is unchanged between themes (`rgba(44,51,62,0.05) 0 40px 100px` in both) — too soft for dark, too heavy for light. Token-swap via `--shadow-hero`.
+- [ ] Good — Theme persists across route changes (localStorage).
+- [ ] Good — No legacy green (`#22c55e`/`#16a34a`/`#10b981`/`#4dba8a`) rendering anywhere. Remove `--success` token or wire it up.
+
+### Keyboard and focus
+
+- [ ] `[HIGH]` — First Tab stop is `.theme-toggle`. See #8.
+- [ ] `[HIGH]` — Focus outlines are mostly invisible. See #8.
+- [ ] `[MED]` — No focus trap in overlays. Extraction overlay leaves shell tabbable; tour beacons don't trap focus. Add focus management to modal/overlay patterns.
+
+### Back-and-forth / state
+
+- [ ] `[LOW]` `polish` — `#library-view`, `#analytics-view`, `#settings-view` all carry `.library-view` base class. A rule written for `.library-view .library-card` would leak into Analytics/Settings. Rename to unique base classes.
+- [ ] Good — `#card` accumulates no state classes after navigation. No stale-class leakage.
+
+### Quick Guide
+
+- [ ] `[MED]` `contract` — Tour tooltip initially renders at 34×31 at (0, 8) — effectively invisible. Must click a beacon to see content. No auto-open, no "1 of 5" progress, no dismiss control on the tooltip. Auto-open step 1 with visible "Next / Skip" controls and a progress indicator.
+
+---
+
+## Architectural recommendation (post-fixes)
+
+Extract a lightweight design-system layer — `tokens.css` + `components.css` — that any view imports.
+
+- **Tokens**: single source of theme truth (light / dark / high-contrast later).
+- **Components**: one implementation each: `Card`, `StatTile`, `Pill`, `Button` (primary/secondary/ghost), `ChatBubble` (info/error), `Scrim`, `Dialog`.
+
+Today, `library-view` is the shared class for Library + Analytics + Settings — CSS leaks sideways. Once the system layer exists, each route owns only its IA, not the primitives. This is the actual Notion/Linear pattern.
+
+**Do this after fixes 1–5. Do this before building Graph View for real** — an interactive graph will bring its own elevation/ring/focus requirements that will otherwise metastasize into more hardcoded hex values.
+
+---
+
+## Progress log
+
+- 2026-04-16: UX-todo.md created from full-product audit.

--- a/ai_service.py
+++ b/ai_service.py
@@ -11,7 +11,7 @@ from google.genai.errors import APIError
 from google.genai import types
 from pydantic import BaseModel, ConfigDict, Field
 
-MODEL       = "gemini-2.5-flash"
+MODEL = "gemini-2.5-flash"
 EXTRACT_TEMPERATURE = 0.2
 DRILL_TEMPERATURE = 0.2
 REPAIR_REPS_TEMPERATURE = 0.2
@@ -38,6 +38,7 @@ USER_PROMPT = (
     "No preamble, no explanation, no code fences — raw JSON only:\n\n{text}"
 )
 
+
 class DrillEvaluation(BaseModel):
     agent_response: str = Field(description="The conversational text shown to the user")
     generative_commitment: Optional[bool] = Field(
@@ -52,19 +53,30 @@ class DrillEvaluation(BaseModel):
         default=False,
         description="True only when this turn should count as a scored explanatory attempt.",
     )
-    help_request_reason: Optional[Literal["explicit_unknown", "explicit_explain_request", "affective_confusion", "none"]] = Field(
+    help_request_reason: Optional[
+        Literal[
+            "explicit_unknown",
+            "explicit_explain_request",
+            "affective_confusion",
+            "none",
+        ]
+    ] = Field(
         default=None,
         description="Reason for help_request mode. Use null on init.",
     )
-    classification: Optional[Literal["solid", "shallow", "deep", "misconception"]] = Field(
-        default=None,
-        description="Gap classification. null on init phase and before genuine generative attempt.",
+    classification: Optional[Literal["solid", "shallow", "deep", "misconception"]] = (
+        Field(
+            default=None,
+            description="Gap classification. null on init phase and before genuine generative attempt.",
+        )
     )
     gap_description: Optional[str] = Field(
         default=None,
         description="1-sentence description of the delta between user knowledge and mechanism.",
     )
-    routing: Optional[Literal["NEXT", "PROBE", "SCAFFOLD", "REROUTE_PREREQ", "SESSION_COMPLETE"]] = Field(
+    routing: Optional[
+        Literal["NEXT", "PROBE", "SCAFFOLD", "REROUTE_PREREQ", "SESSION_COMPLETE"]
+    ] = Field(
         default=None,
         description="Routing action for the frontend to execute.",
     )
@@ -74,9 +86,11 @@ class DrillEvaluation(BaseModel):
         le=5,
         description="Transient answer-quality tier for genuine attempts only.",
     )
-    response_band: Optional[Literal["spark", "link", "chain", "clear", "tetris"]] = Field(
-        default=None,
-        description="Named band for response_tier.",
+    response_band: Optional[Literal["spark", "link", "chain", "clear", "tetris"]] = (
+        Field(
+            default=None,
+            description="Named band for response_tier.",
+        )
     )
     tier_reason: Optional[str] = Field(
         default=None,
@@ -85,13 +99,21 @@ class DrillEvaluation(BaseModel):
 
 
 class RepairRep(BaseModel):
-    id: str = Field(description="Stable identifier for this rep within the generated set")
+    id: str = Field(
+        description="Stable identifier for this rep within the generated set"
+    )
     kind: Literal["missing_bridge", "next_step", "cause_effect"] = Field(
         description="The causal micro-practice shape."
     )
-    prompt: str = Field(description="Typed causal prompt shown before the answer bridge is revealed.")
-    target_bridge: str = Field(description="Short model bridge revealed only after the learner types.")
-    feedback_cue: str = Field(description="Short comparison cue after the bridge is revealed.")
+    prompt: str = Field(
+        description="Typed causal prompt shown before the answer bridge is revealed."
+    )
+    target_bridge: str = Field(
+        description="Short model bridge revealed only after the learner types."
+    )
+    feedback_cue: str = Field(
+        description="Short comparison cue after the bridge is revealed."
+    )
 
 
 class RepairRepsEvaluation(BaseModel):
@@ -160,7 +182,9 @@ class GeminiServiceError(ValueError):
 def _get_client(api_key: str | None = None):
     key = os.environ.get("GEMINI_API_KEY") or api_key
     if not key:
-        raise MissingAPIKeyError("No Gemini API key configured. Add one in Settings or set GEMINI_API_KEY in .env.")
+        raise MissingAPIKeyError(
+            "No Gemini API key configured. Add one in Settings or set GEMINI_API_KEY in .env."
+        )
     return genai.Client(api_key=key)
 
 
@@ -176,7 +200,9 @@ def _clean_response(text: str | None, context: str = "Gemini") -> str:
     return result
 
 
-def _log_extract_failure(*, reason: str, raw_response: str | None, cleaned_response: str | None = None) -> None:
+def _log_extract_failure(
+    *, reason: str, raw_response: str | None, cleaned_response: str | None = None
+) -> None:
     try:
         EXTRACT_FAILURE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
         with EXTRACT_FAILURE_LOG_PATH.open("a", encoding="utf-8") as log_file:
@@ -238,10 +264,12 @@ def _with_telemetry_context(event: dict, telemetry_context: dict | None) -> dict
 def _serialize_drill_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
     serialized: list[dict[str, str]] = []
     for msg in messages or []:
-        serialized.append({
-            "role": str(msg.get("role", "unknown"))[:20],
-            "content": str(msg.get("content", "")),
-        })
+        serialized.append(
+            {
+                "role": str(msg.get("role", "unknown"))[:20],
+                "content": str(msg.get("content", "")),
+            }
+        )
     return serialized
 
 
@@ -339,8 +367,7 @@ def _prune_context(knowledge_map: dict, target_node_id: str) -> dict:
                 for item in knowledge_map.get("backbone", [])
                 if isinstance(item, dict)
                 and (
-                    target_node_id == "core-thesis"
-                    or item.get("id") == target_node_id
+                    target_node_id == "core-thesis" or item.get("id") == target_node_id
                 )
             ),
             None,
@@ -348,7 +375,11 @@ def _prune_context(knowledge_map: dict, target_node_id: str) -> dict:
         if target_backbone is None and knowledge_map.get("backbone"):
             target_backbone = knowledge_map["backbone"][0]
 
-        dependent_cluster_ids = set(target_backbone.get("dependent_clusters") or []) if isinstance(target_backbone, dict) else set()
+        dependent_cluster_ids = (
+            set(target_backbone.get("dependent_clusters") or [])
+            if isinstance(target_backbone, dict)
+            else set()
+        )
         cluster_shells = [
             {
                 "id": cluster.get("id"),
@@ -379,24 +410,32 @@ def _prune_context(knowledge_map: dict, target_node_id: str) -> dict:
     pruned["backbone"] = [
         item
         for item in knowledge_map.get("backbone", [])
-        if isinstance(item, dict) and target_cluster_id in (item.get("dependent_clusters") or [])
+        if isinstance(item, dict)
+        and target_cluster_id in (item.get("dependent_clusters") or [])
     ]
     pruned["relationships"] = {
         "learning_prerequisites": [
             rel
             for rel in relationships.get("learning_prerequisites", [])
-            if isinstance(rel, dict) and (rel.get("from") == target_cluster_id or rel.get("to") == target_cluster_id)
+            if isinstance(rel, dict)
+            and (
+                rel.get("from") == target_cluster_id
+                or rel.get("to") == target_cluster_id
+            )
         ]
     }
     pruned["frameworks"] = [
         framework
         for framework in frameworks
-        if isinstance(framework, dict) and target_cluster_id in (framework.get("source_clusters") or [])
+        if isinstance(framework, dict)
+        and target_cluster_id in (framework.get("source_clusters") or [])
     ]
     return pruned
 
 
-def _call_gemini_with_retry(client, *, model, contents, config, max_retries=MAX_RETRIES):
+def _call_gemini_with_retry(
+    client, *, model, contents, config, max_retries=MAX_RETRIES
+):
     for attempt in range(max_retries):
         try:
             return client.models.generate_content(
@@ -409,10 +448,16 @@ def _call_gemini_with_retry(client, *, model, contents, config, max_retries=MAX_
                 time.sleep(BACKOFF_BASE ** (attempt + 1))
                 continue
             if err.code == 429:
-                raise GeminiRateLimitError("Gemini rate limit hit. Try again in 60s.") from err
+                raise GeminiRateLimitError(
+                    "Gemini rate limit hit. Try again in 60s."
+                ) from err
             if err.code in (503, 500):
-                raise GeminiServiceError(f"Gemini service unavailable (HTTP {err.code}).") from err
-            raise ValueError(f"Gemini API error (HTTP {err.code}): {err.message}") from err
+                raise GeminiServiceError(
+                    f"Gemini service unavailable (HTTP {err.code})."
+                ) from err
+            raise ValueError(
+                f"Gemini API error (HTTP {err.code}): {err.message}"
+            ) from err
         except Exception as err:
             raise ValueError(f"Unexpected error: {str(err)}") from err
 
@@ -468,7 +513,16 @@ def _has_substantive_attempt(message: str) -> bool:
 
     if "?" in normalized and not any(
         marker in normalized
-        for marker in ("i think", "i guess", "maybe", "but", "it is", "it's", "they are", "this is")
+        for marker in (
+            "i think",
+            "i guess",
+            "maybe",
+            "but",
+            "it is",
+            "it's",
+            "they are",
+            "this is",
+        )
     ):
         return False
 
@@ -487,12 +541,35 @@ def _has_substantive_attempt(message: str) -> bool:
         return False
 
     filler_words = {
-        "i", "im", "i'm", "not", "sure", "don't", "dont", "know", "can", "you",
-        "please", "explain", "this", "that", "it", "me", "help", "understand",
-        "maybe", "think", "kind", "of", "sort", "just",
+        "i",
+        "im",
+        "i'm",
+        "not",
+        "sure",
+        "don't",
+        "dont",
+        "know",
+        "can",
+        "you",
+        "please",
+        "explain",
+        "this",
+        "that",
+        "it",
+        "me",
+        "help",
+        "understand",
+        "maybe",
+        "think",
+        "kind",
+        "of",
+        "sort",
+        "just",
     }
     content_words = [word for word in words if word not in filler_words]
-    return len(content_words) >= 4 and any(word.endswith(("s", "ed", "ing")) for word in content_words)
+    return len(content_words) >= 4 and any(
+        word.endswith(("s", "ed", "ing")) for word in content_words
+    )
 
 
 def _normalize_response_quality(evaluation: DrillEvaluation) -> None:
@@ -534,7 +611,10 @@ def _normalize_response_quality(evaluation: DrillEvaluation) -> None:
         evaluation.tier_reason = None
         return
 
-    tier = evaluation.response_tier or default_tier_by_classification[evaluation.classification]
+    tier = (
+        evaluation.response_tier
+        or default_tier_by_classification[evaluation.classification]
+    )
     tier = max(min_tier_by_classification[evaluation.classification], tier)
     tier = min(max_tier_by_classification[evaluation.classification], tier)
     evaluation.response_tier = tier
@@ -577,18 +657,30 @@ def _normalize_drill_evaluation(
         evaluation.tier_reason = None
         if not substantive_attempt:
             evaluation.routing = "SCAFFOLD"
-            evaluation.help_request_reason = evaluation.help_request_reason or "explicit_unknown"
+            evaluation.help_request_reason = (
+                evaluation.help_request_reason or "explicit_unknown"
+            )
             if not evaluation.gap_description:
-                evaluation.gap_description = "Learner produced zero schema; nudge to guess."
+                evaluation.gap_description = (
+                    "Learner produced zero schema; nudge to guess."
+                )
         else:
             evaluation.routing = "NEXT"
             evaluation.help_request_reason = "none"
         return evaluation
 
-    if not has_classification and (evaluation.answer_mode == "help_request" or inferred_help_request) and not substantive_attempt:
+    if (
+        not has_classification
+        and (evaluation.answer_mode == "help_request" or inferred_help_request)
+        and not substantive_attempt
+    ):
         evaluation.answer_mode = "help_request"
         evaluation.score_eligible = False
-        evaluation.help_request_reason = evaluation.help_request_reason or inferred_help_request_reason or "explicit_unknown"
+        evaluation.help_request_reason = (
+            evaluation.help_request_reason
+            or inferred_help_request_reason
+            or "explicit_unknown"
+        )
         evaluation.classification = None
         evaluation.routing = "SCAFFOLD"
         if not evaluation.gap_description:
@@ -601,7 +693,9 @@ def _normalize_drill_evaluation(
     evaluation.help_request_reason = "none"
 
     if not evaluation.classification:
-        raise ValueError("Gemini returned no classification for a scored drill evaluation turn.")
+        raise ValueError(
+            "Gemini returned no classification for a scored drill evaluation turn."
+        )
 
     if evaluation.classification == "solid":
         evaluation.routing = "NEXT"
@@ -643,18 +737,25 @@ def extract_knowledge_map(
         cleaned = _clean_response(raw_response)
     except ValueError as err:
         _log_extract_failure(reason=str(err), raw_response=raw_response)
-        _log_extract_run(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "extract",
-            "status": "error",
-            "error_type": "empty_response",
-            "reason": str(err),
-            "model": MODEL,
-            "prompt_version": EXTRACT_PROMPT_VERSION,
-            "input_chars": len(raw_text),
-            "raw_response_chars": len(raw_response or ""),
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
+        _log_extract_run(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "extract",
+                    "status": "error",
+                    "error_type": "empty_response",
+                    "reason": str(err),
+                    "model": MODEL,
+                    "prompt_version": EXTRACT_PROMPT_VERSION,
+                    "input_chars": len(raw_text),
+                    "raw_response_chars": len(raw_response or ""),
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
         raise
 
     try:
@@ -665,20 +766,29 @@ def extract_knowledge_map(
             raw_response=raw_response,
             cleaned_response=cleaned,
         )
-        _log_extract_run(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "extract",
-            "status": "error",
-            "error_type": "invalid_json",
-            "reason": f"{err.msg} at line {err.lineno} column {err.colno}",
-            "model": MODEL,
-            "prompt_version": EXTRACT_PROMPT_VERSION,
-            "input_chars": len(raw_text),
-            "raw_response_chars": len(raw_response or ""),
-            "cleaned_response_chars": len(cleaned),
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
-        raise ValueError(f"Gemini returned invalid JSON for extraction: {err.msg}") from err
+        _log_extract_run(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "extract",
+                    "status": "error",
+                    "error_type": "invalid_json",
+                    "reason": f"{err.msg} at line {err.lineno} column {err.colno}",
+                    "model": MODEL,
+                    "prompt_version": EXTRACT_PROMPT_VERSION,
+                    "input_chars": len(raw_text),
+                    "raw_response_chars": len(raw_response or ""),
+                    "cleaned_response_chars": len(cleaned),
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
+        raise ValueError(
+            f"Gemini returned invalid JSON for extraction: {err.msg}"
+        ) from err
 
     try:
         _validate_knowledge_map(knowledge_map)
@@ -688,50 +798,70 @@ def extract_knowledge_map(
             raw_response=raw_response,
             cleaned_response=cleaned,
         )
-        _log_extract_run(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "extract",
-            "status": "error",
-            "error_type": "schema_validation",
-            "reason": str(err),
-            "model": MODEL,
-            "prompt_version": EXTRACT_PROMPT_VERSION,
-            "input_chars": len(raw_text),
-            "raw_response_chars": len(raw_response or ""),
-            "cleaned_response_chars": len(cleaned),
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
+        _log_extract_run(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "extract",
+                    "status": "error",
+                    "error_type": "schema_validation",
+                    "reason": str(err),
+                    "model": MODEL,
+                    "prompt_version": EXTRACT_PROMPT_VERSION,
+                    "input_chars": len(raw_text),
+                    "raw_response_chars": len(raw_response or ""),
+                    "cleaned_response_chars": len(cleaned),
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
         raise
 
-    _log_extract_run(_with_telemetry_context({
-        "timestamp": started_at.isoformat(),
-        "stage": "extract",
-        "status": "success",
-        "model": MODEL,
-        "prompt_version": EXTRACT_PROMPT_VERSION,
-        "input_chars": len(raw_text),
-        "raw_response_chars": len(raw_response or ""),
-        "cleaned_response_chars": len(cleaned),
-        "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        "source_title": (knowledge_map.get("metadata") or {}).get("source_title"),
-        "architecture_type": (knowledge_map.get("metadata") or {}).get("architecture_type"),
-        "difficulty": (knowledge_map.get("metadata") or {}).get("difficulty"),
-        "low_density": (knowledge_map.get("metadata") or {}).get("low_density"),
-        "backbone_count": len(knowledge_map.get("backbone") or []),
-        "cluster_count": len(knowledge_map.get("clusters") or []),
-        "framework_count": len(knowledge_map.get("frameworks") or []),
-        "subnode_count": sum(
-            len(cluster.get("subnodes") or [])
-            for cluster in (knowledge_map.get("clusters") or [])
-            if isinstance(cluster, dict)
-        ),
-    }, telemetry_context))
+    _log_extract_run(
+        _with_telemetry_context(
+            {
+                "timestamp": started_at.isoformat(),
+                "stage": "extract",
+                "status": "success",
+                "model": MODEL,
+                "prompt_version": EXTRACT_PROMPT_VERSION,
+                "input_chars": len(raw_text),
+                "raw_response_chars": len(raw_response or ""),
+                "cleaned_response_chars": len(cleaned),
+                "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
+                "source_title": (knowledge_map.get("metadata") or {}).get(
+                    "source_title"
+                ),
+                "architecture_type": (knowledge_map.get("metadata") or {}).get(
+                    "architecture_type"
+                ),
+                "difficulty": (knowledge_map.get("metadata") or {}).get("difficulty"),
+                "low_density": (knowledge_map.get("metadata") or {}).get("low_density"),
+                "backbone_count": len(knowledge_map.get("backbone") or []),
+                "cluster_count": len(knowledge_map.get("clusters") or []),
+                "framework_count": len(knowledge_map.get("frameworks") or []),
+                "subnode_count": sum(
+                    len(cluster.get("subnodes") or [])
+                    for cluster in (knowledge_map.get("clusters") or [])
+                    if isinstance(cluster, dict)
+                ),
+            },
+            telemetry_context,
+        )
+    )
     return knowledge_map
 
 
-def _validate_repair_reps_result(evaluation: RepairRepsEvaluation, *, expected_count: int) -> None:
+def _validate_repair_reps_result(
+    evaluation: RepairRepsEvaluation, *, expected_count: int
+) -> None:
     if len(evaluation.reps) != expected_count:
-        raise ValueError(f"Repair reps response must include exactly {expected_count} reps.")
+        raise ValueError(
+            f"Repair reps response must include exactly {expected_count} reps."
+        )
 
     seen_ids: set[str] = set()
     for index, rep in enumerate(evaluation.reps, start=1):
@@ -756,7 +886,9 @@ def _parse_repair_reps_response(response) -> RepairRepsEvaluation:
         try:
             strict = _StrictRepairRepsEvaluation.model_validate_json(raw_text)
         except Exception as err:
-            raise ValueError("Gemini returned an invalid structured repair reps response.") from err
+            raise ValueError(
+                "Gemini returned an invalid structured repair reps response."
+            ) from err
         return RepairRepsEvaluation.model_validate(strict.model_dump())
 
     evaluation = getattr(response, "parsed", None)
@@ -766,7 +898,9 @@ def _parse_repair_reps_response(response) -> RepairRepsEvaluation:
         try:
             strict = _StrictRepairRepsEvaluation.model_validate(evaluation)
         except Exception as err:
-            raise ValueError("Gemini returned an invalid structured repair reps response.") from err
+            raise ValueError(
+                "Gemini returned an invalid structured repair reps response."
+            ) from err
         return RepairRepsEvaluation.model_validate(strict.model_dump())
     raise ValueError("Gemini returned an invalid structured repair reps response.")
 
@@ -877,43 +1011,62 @@ def drill_chat(
         "",
     )
 
-    def log_chat_turn(*, status: str, result: dict | None = None, error_type: str | None = None, reason: str | None = None) -> None:
-        _log_drill_chat_turn(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "drill_chat_turn",
-            "status": status,
-            "concept_id": concept_id,
-            "node_id": node_id,
-            "node_type": node_type,
-            "cluster_id": cluster_id,
-            "node_label": node_label,
-            "node_mechanism": node_mechanism,
-            "session_phase": session_phase,
-            "session_start_iso": session_start_iso,
-            "drill_mode": drill_mode,
-            "re_drill_count_in": re_drill_count,
-            "probe_count_in": probe_count,
-            "nodes_drilled_in": nodes_drilled,
-            "attempt_turn_count_in": attempt_turn_count,
-            "help_turn_count_in": help_turn_count,
-            "message_count": len(messages),
-            "messages": _serialize_drill_messages(messages),
-            "latest_learner_message": latest_learner_message,
-            "agent_response": result.get("agent_response") if result else None,
-            "answer_mode": result.get("answer_mode") if result else None,
-            "generative_commitment": result.get("generative_commitment") if result else None,
-            "classification": result.get("classification") if result else None,
-            "routing": result.get("routing") if result else None,
-            "response_tier": result.get("response_tier") if result else None,
-            "response_band": result.get("response_band") if result else None,
-            "score_eligible": result.get("score_eligible") if result else None,
-            "graph_mutated": result.get("graph_mutated") if result else None,
-            "session_terminated": result.get("session_terminated") if result else None,
-            "termination_reason": result.get("termination_reason") if result else None,
-            "error_type": error_type,
-            "reason": reason,
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
+    def log_chat_turn(
+        *,
+        status: str,
+        result: dict | None = None,
+        error_type: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        _log_drill_chat_turn(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "drill_chat_turn",
+                    "status": status,
+                    "concept_id": concept_id,
+                    "node_id": node_id,
+                    "node_type": node_type,
+                    "cluster_id": cluster_id,
+                    "node_label": node_label,
+                    "node_mechanism": node_mechanism,
+                    "session_phase": session_phase,
+                    "session_start_iso": session_start_iso,
+                    "drill_mode": drill_mode,
+                    "re_drill_count_in": re_drill_count,
+                    "probe_count_in": probe_count,
+                    "nodes_drilled_in": nodes_drilled,
+                    "attempt_turn_count_in": attempt_turn_count,
+                    "help_turn_count_in": help_turn_count,
+                    "message_count": len(messages),
+                    "messages": _serialize_drill_messages(messages),
+                    "latest_learner_message": latest_learner_message,
+                    "agent_response": result.get("agent_response") if result else None,
+                    "answer_mode": result.get("answer_mode") if result else None,
+                    "generative_commitment": result.get("generative_commitment")
+                    if result
+                    else None,
+                    "classification": result.get("classification") if result else None,
+                    "routing": result.get("routing") if result else None,
+                    "response_tier": result.get("response_tier") if result else None,
+                    "response_band": result.get("response_band") if result else None,
+                    "score_eligible": result.get("score_eligible") if result else None,
+                    "graph_mutated": result.get("graph_mutated") if result else None,
+                    "session_terminated": result.get("session_terminated")
+                    if result
+                    else None,
+                    "termination_reason": result.get("termination_reason")
+                    if result
+                    else None,
+                    "error_type": error_type,
+                    "reason": reason,
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
 
     if not bypass_session_limits and session_phase == "turn" and session_start_iso:
         session_start = _parse_iso_timestamp(session_start_iso)
@@ -941,52 +1094,61 @@ def drill_chat(
                 "termination_reason": "time_cap",
             }
             log_chat_turn(status="success", result=result)
-            _log_drill_run(_with_telemetry_context({
-                "timestamp": started_at.isoformat(),
-                "stage": "drill",
-                "status": "success",
-                "model": MODEL,
-                "prompt_version": DRILL_PROMPT_VERSION,
-                "concept_id": concept_id,
-                "node_id": node_id,
-                "node_type": node_type,
-                "cluster_id": cluster_id,
-                "node_label": node_label,
-                "session_phase": session_phase,
-                "session_start_iso": session_start_iso,
-                "message_count": len(messages),
-                "latest_learner_chars": 0,
-                "answer_mode": result["answer_mode"],
-                "score_eligible": result["score_eligible"],
-                "help_request_reason": result["help_request_reason"],
-                "probe_count_in": probe_count,
-                "probe_count_out": result["probe_count"],
-                "nodes_drilled_in": nodes_drilled,
-                "nodes_drilled_out": result["nodes_drilled"],
-                "attempt_turn_count_in": attempt_turn_count,
-                "attempt_turn_count_out": result["attempt_turn_count"],
-                "help_turn_count_in": help_turn_count,
-                "help_turn_count_out": result["help_turn_count"],
-                "classification": result["classification"],
-                "routing": result["routing"],
-                "response_tier": result["response_tier"],
-                "response_band": result["response_band"],
-                "tier_reason": result["tier_reason"],
-                "counted_as_probe": False,
-                "force_advance_mode": "none",
-                "graph_mutated": result["graph_mutated"],
-                "ux_reward_emitted": result["ux_reward_emitted"],
-                "session_terminated": result["session_terminated"],
-                "termination_reason": result["termination_reason"],
-                "agent_response_chars": len(result["agent_response"]),
-                "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-            }, telemetry_context))
+            _log_drill_run(
+                _with_telemetry_context(
+                    {
+                        "timestamp": started_at.isoformat(),
+                        "stage": "drill",
+                        "status": "success",
+                        "model": MODEL,
+                        "prompt_version": DRILL_PROMPT_VERSION,
+                        "concept_id": concept_id,
+                        "node_id": node_id,
+                        "node_type": node_type,
+                        "cluster_id": cluster_id,
+                        "node_label": node_label,
+                        "session_phase": session_phase,
+                        "session_start_iso": session_start_iso,
+                        "message_count": len(messages),
+                        "latest_learner_chars": 0,
+                        "answer_mode": result["answer_mode"],
+                        "score_eligible": result["score_eligible"],
+                        "help_request_reason": result["help_request_reason"],
+                        "probe_count_in": probe_count,
+                        "probe_count_out": result["probe_count"],
+                        "nodes_drilled_in": nodes_drilled,
+                        "nodes_drilled_out": result["nodes_drilled"],
+                        "attempt_turn_count_in": attempt_turn_count,
+                        "attempt_turn_count_out": result["attempt_turn_count"],
+                        "help_turn_count_in": help_turn_count,
+                        "help_turn_count_out": result["help_turn_count"],
+                        "classification": result["classification"],
+                        "routing": result["routing"],
+                        "response_tier": result["response_tier"],
+                        "response_band": result["response_band"],
+                        "tier_reason": result["tier_reason"],
+                        "counted_as_probe": False,
+                        "force_advance_mode": "none",
+                        "graph_mutated": result["graph_mutated"],
+                        "ux_reward_emitted": result["ux_reward_emitted"],
+                        "session_terminated": result["session_terminated"],
+                        "termination_reason": result["termination_reason"],
+                        "agent_response_chars": len(result["agent_response"]),
+                        "duration_ms": round(
+                            (time.perf_counter() - started_perf) * 1000, 2
+                        ),
+                    },
+                    telemetry_context,
+                )
+            )
             return result
 
     client = _get_client(api_key)
     pruned_context = _prune_context(knowledge_map, node_id)
     system_prompt_extras = "\n\n### Target Node (ANSWER KEY — NEVER REVEAL)\n"
-    system_prompt_extras += f"Node ID: {node_id}\nNode Label: {node_label}\nMechanism: {node_mechanism}\n"
+    system_prompt_extras += (
+        f"Node ID: {node_id}\nNode Label: {node_label}\nMechanism: {node_mechanism}\n"
+    )
 
     if drill_mode == "cold_attempt":
         system_prompt_extras += "\nMODE: COLD ATTEMPT. Ask an open exploratory question, do not reveal the mechanism. Emphasize it is ok to guess. Enforce minimum generative commitment. If the user produces zero schema or asks for help, provide a tiny hint or nudge to guess. Return null for classification/tier."
@@ -1044,32 +1206,39 @@ def drill_chat(
             error_type=type(err).__name__,
             reason=str(err),
         )
-        _log_drill_run(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "drill",
-            "status": "error",
-            "error_type": type(err).__name__,
-            "reason": str(err),
-            "model": MODEL,
-            "prompt_version": DRILL_PROMPT_VERSION,
-            "concept_id": concept_id,
-            "node_id": node_id,
-            "node_type": node_type,
-            "cluster_id": cluster_id,
-            "node_label": node_label,
-            "session_phase": session_phase,
-            "session_start_iso": session_start_iso,
-            "message_count": len(messages),
-            "latest_learner_chars": len(latest_learner_message),
-            "answer_mode": None,
-            "score_eligible": False,
-            "help_request_reason": None,
-            "probe_count_in": probe_count,
-            "nodes_drilled_in": nodes_drilled,
-            "attempt_turn_count_in": attempt_turn_count,
-            "help_turn_count_in": help_turn_count,
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
+        _log_drill_run(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "drill",
+                    "status": "error",
+                    "error_type": type(err).__name__,
+                    "reason": str(err),
+                    "model": MODEL,
+                    "prompt_version": DRILL_PROMPT_VERSION,
+                    "concept_id": concept_id,
+                    "node_id": node_id,
+                    "node_type": node_type,
+                    "cluster_id": cluster_id,
+                    "node_label": node_label,
+                    "session_phase": session_phase,
+                    "session_start_iso": session_start_iso,
+                    "message_count": len(messages),
+                    "latest_learner_chars": len(latest_learner_message),
+                    "answer_mode": None,
+                    "score_eligible": False,
+                    "help_request_reason": None,
+                    "probe_count_in": probe_count,
+                    "nodes_drilled_in": nodes_drilled,
+                    "attempt_turn_count_in": attempt_turn_count,
+                    "help_turn_count_in": help_turn_count,
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
         raise
 
     evaluation = response.parsed
@@ -1079,32 +1248,39 @@ def drill_chat(
             error_type="invalid_structured_response",
             reason="Gemini returned an invalid structured drill response.",
         )
-        _log_drill_run(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "drill",
-            "status": "error",
-            "error_type": "invalid_structured_response",
-            "reason": "Gemini returned an invalid structured drill response.",
-            "model": MODEL,
-            "prompt_version": DRILL_PROMPT_VERSION,
-            "concept_id": concept_id,
-            "node_id": node_id,
-            "node_type": node_type,
-            "cluster_id": cluster_id,
-            "node_label": node_label,
-            "session_phase": session_phase,
-            "session_start_iso": session_start_iso,
-            "message_count": len(messages),
-            "latest_learner_chars": len(latest_learner_message),
-            "answer_mode": None,
-            "score_eligible": False,
-            "help_request_reason": None,
-            "probe_count_in": probe_count,
-            "nodes_drilled_in": nodes_drilled,
-            "attempt_turn_count_in": attempt_turn_count,
-            "help_turn_count_in": help_turn_count,
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
+        _log_drill_run(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "drill",
+                    "status": "error",
+                    "error_type": "invalid_structured_response",
+                    "reason": "Gemini returned an invalid structured drill response.",
+                    "model": MODEL,
+                    "prompt_version": DRILL_PROMPT_VERSION,
+                    "concept_id": concept_id,
+                    "node_id": node_id,
+                    "node_type": node_type,
+                    "cluster_id": cluster_id,
+                    "node_label": node_label,
+                    "session_phase": session_phase,
+                    "session_start_iso": session_start_iso,
+                    "message_count": len(messages),
+                    "latest_learner_chars": len(latest_learner_message),
+                    "answer_mode": None,
+                    "score_eligible": False,
+                    "help_request_reason": None,
+                    "probe_count_in": probe_count,
+                    "nodes_drilled_in": nodes_drilled,
+                    "attempt_turn_count_in": attempt_turn_count,
+                    "help_turn_count_in": help_turn_count,
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
         raise ValueError("Gemini returned an invalid structured drill response.")
     if not evaluation.agent_response.strip():
         log_chat_turn(
@@ -1112,32 +1288,39 @@ def drill_chat(
             error_type="empty_agent_response",
             reason="Gemini returned an empty drill response.",
         )
-        _log_drill_run(_with_telemetry_context({
-            "timestamp": started_at.isoformat(),
-            "stage": "drill",
-            "status": "error",
-            "error_type": "empty_agent_response",
-            "reason": "Gemini returned an empty drill response.",
-            "model": MODEL,
-            "prompt_version": DRILL_PROMPT_VERSION,
-            "concept_id": concept_id,
-            "node_id": node_id,
-            "node_type": node_type,
-            "cluster_id": cluster_id,
-            "node_label": node_label,
-            "session_phase": session_phase,
-            "session_start_iso": session_start_iso,
-            "message_count": len(messages),
-            "latest_learner_chars": len(latest_learner_message),
-            "answer_mode": None,
-            "score_eligible": False,
-            "help_request_reason": None,
-            "probe_count_in": probe_count,
-            "nodes_drilled_in": nodes_drilled,
-            "attempt_turn_count_in": attempt_turn_count,
-            "help_turn_count_in": help_turn_count,
-            "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-        }, telemetry_context))
+        _log_drill_run(
+            _with_telemetry_context(
+                {
+                    "timestamp": started_at.isoformat(),
+                    "stage": "drill",
+                    "status": "error",
+                    "error_type": "empty_agent_response",
+                    "reason": "Gemini returned an empty drill response.",
+                    "model": MODEL,
+                    "prompt_version": DRILL_PROMPT_VERSION,
+                    "concept_id": concept_id,
+                    "node_id": node_id,
+                    "node_type": node_type,
+                    "cluster_id": cluster_id,
+                    "node_label": node_label,
+                    "session_phase": session_phase,
+                    "session_start_iso": session_start_iso,
+                    "message_count": len(messages),
+                    "latest_learner_chars": len(latest_learner_message),
+                    "answer_mode": None,
+                    "score_eligible": False,
+                    "help_request_reason": None,
+                    "probe_count_in": probe_count,
+                    "nodes_drilled_in": nodes_drilled,
+                    "attempt_turn_count_in": attempt_turn_count,
+                    "help_turn_count_in": help_turn_count,
+                    "duration_ms": round(
+                        (time.perf_counter() - started_perf) * 1000, 2
+                    ),
+                },
+                telemetry_context,
+            )
+        )
         raise ValueError("Gemini returned an empty drill response.")
     evaluation = _normalize_drill_evaluation(
         evaluation,
@@ -1194,7 +1377,8 @@ def drill_chat(
         "attempt_turn_count": new_attempt_turn_count,
         "help_turn_count": new_help_turn_count,
         "graph_mutated": evaluation.routing == "NEXT",
-        "ux_reward_emitted": evaluation.answer_mode == "attempt" and (evaluation.response_tier or 0) >= 4,
+        "ux_reward_emitted": evaluation.answer_mode == "attempt"
+        and (evaluation.response_tier or 0) >= 4,
         "session_terminated": session_terminated,
         "termination_reason": termination_reason,
     }
@@ -1210,46 +1394,51 @@ def drill_chat(
         and result["answer_mode"] == "attempt"
         and result["routing"] in ("PROBE", "SCAFFOLD")
     )
-    _log_drill_run(_with_telemetry_context({
-        "timestamp": started_at.isoformat(),
-        "stage": "drill",
-        "status": "success",
-        "model": MODEL,
-        "prompt_version": DRILL_PROMPT_VERSION,
-        "concept_id": concept_id,
-        "node_id": node_id,
-        "node_type": node_type,
-        "cluster_id": cluster_id,
-        "node_label": node_label,
-        "session_phase": session_phase,
-        "session_start_iso": session_start_iso,
-        "message_count": len(messages),
-        "latest_learner_chars": len(latest_learner_message),
-        "answer_mode": result["answer_mode"],
-        "score_eligible": result["score_eligible"],
-        "help_request_reason": result["help_request_reason"],
-        "probe_count_in": probe_count,
-        "probe_count_out": result["probe_count"],
-        "nodes_drilled_in": nodes_drilled,
-        "nodes_drilled_out": result["nodes_drilled"],
-        "attempt_turn_count_in": attempt_turn_count,
-        "attempt_turn_count_out": result["attempt_turn_count"],
-        "help_turn_count_in": help_turn_count,
-        "help_turn_count_out": result["help_turn_count"],
-        "classification": result["classification"],
-        "routing": result["routing"],
-        "response_tier": result["response_tier"],
-        "response_band": result["response_band"],
-        "tier_reason": result["tier_reason"],
-        "counted_as_probe": counted_as_probe,
-        "force_advanced": force_advanced,
-        "force_advance_mode": "attempt" if force_advanced else "none",
-        "graph_mutated": result["graph_mutated"],
-        "ux_reward_emitted": result["ux_reward_emitted"],
-        "session_terminated": result["session_terminated"],
-        "termination_reason": result["termination_reason"],
-        "agent_response_chars": len(result["agent_response"]),
-        "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
-    }, telemetry_context))
+    _log_drill_run(
+        _with_telemetry_context(
+            {
+                "timestamp": started_at.isoformat(),
+                "stage": "drill",
+                "status": "success",
+                "model": MODEL,
+                "prompt_version": DRILL_PROMPT_VERSION,
+                "concept_id": concept_id,
+                "node_id": node_id,
+                "node_type": node_type,
+                "cluster_id": cluster_id,
+                "node_label": node_label,
+                "session_phase": session_phase,
+                "session_start_iso": session_start_iso,
+                "message_count": len(messages),
+                "latest_learner_chars": len(latest_learner_message),
+                "answer_mode": result["answer_mode"],
+                "score_eligible": result["score_eligible"],
+                "help_request_reason": result["help_request_reason"],
+                "probe_count_in": probe_count,
+                "probe_count_out": result["probe_count"],
+                "nodes_drilled_in": nodes_drilled,
+                "nodes_drilled_out": result["nodes_drilled"],
+                "attempt_turn_count_in": attempt_turn_count,
+                "attempt_turn_count_out": result["attempt_turn_count"],
+                "help_turn_count_in": help_turn_count,
+                "help_turn_count_out": result["help_turn_count"],
+                "classification": result["classification"],
+                "routing": result["routing"],
+                "response_tier": result["response_tier"],
+                "response_band": result["response_band"],
+                "tier_reason": result["tier_reason"],
+                "counted_as_probe": counted_as_probe,
+                "force_advanced": force_advanced,
+                "force_advance_mode": "attempt" if force_advanced else "none",
+                "graph_mutated": result["graph_mutated"],
+                "ux_reward_emitted": result["ux_reward_emitted"],
+                "session_terminated": result["session_terminated"],
+                "termination_reason": result["termination_reason"],
+                "agent_response_chars": len(result["agent_response"]),
+                "duration_ms": round((time.perf_counter() - started_perf) * 1000, 2),
+            },
+            telemetry_context,
+        )
+    )
     log_chat_turn(status="success", result=result)
     return result

--- a/api/index.py
+++ b/api/index.py
@@ -4,5 +4,3 @@ from pathlib import Path
 # Ensure the project root is on the Python path so `main` can be imported
 # regardless of how Vercel sets up the function's working directory.
 sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from main import app  # noqa: E402

--- a/auth/router.py
+++ b/auth/router.py
@@ -514,7 +514,9 @@ def sanitize_return_to_path(return_to: str | None) -> str:
     return candidate
 
 
-def _build_login_redirect(*, return_to: str | None = None, auth_error: str | None = None) -> str:
+def _build_login_redirect(
+    *, return_to: str | None = None, auth_error: str | None = None
+) -> str:
     query = {
         "return_to": sanitize_return_to_path(return_to),
     }
@@ -548,7 +550,9 @@ def _user_agent(request: Request) -> str | None:
     return raw[:500] if raw else None
 
 
-def _apply_session_cookie(response: Response, request: Request, sealed_session: str) -> None:
+def _apply_session_cookie(
+    response: Response, request: Request, sealed_session: str
+) -> None:
     service = _get_auth_service(request)
     response.set_cookie(
         service.cookie_name,
@@ -566,7 +570,9 @@ def _clear_session_cookie(response: Response, request: Request) -> None:
     response.delete_cookie(service.cookie_name, path="/")
 
 
-def _apply_oauth_state_cookie(response: Response, request: Request, signed_state: str) -> None:
+def _apply_oauth_state_cookie(
+    response: Response, request: Request, signed_state: str
+) -> None:
     service = _get_auth_service(request)
     response.set_cookie(
         service.oauth_state_cookie_name,
@@ -611,7 +617,9 @@ def _load_current_session_state(request: Request) -> AuthSessionState:
     try:
         state = service.load_session(sealed_session)
     except AuthConfigurationError:
-        logger.warning("Auth session load failed because auth is not configured correctly.")
+        logger.warning(
+            "Auth session load failed because auth is not configured correctly."
+        )
         state = AuthSessionState(
             auth_enabled=service.enabled,
             authenticated=False,
@@ -669,7 +677,9 @@ def auth_google(request: Request, return_to: str | None = None):
     service = _get_auth_service(request)
     sanitized_return_to = sanitize_return_to_path(return_to)
     try:
-        state_nonce, signed_state = service.build_oauth_state(return_to=sanitized_return_to)
+        state_nonce, signed_state = service.build_oauth_state(
+            return_to=sanitized_return_to
+        )
         authorization_url = service.get_login_url(
             base_url=_base_url(request),
             return_to=state_nonce,
@@ -704,7 +714,9 @@ def auth_callback(
     )
     return_to = verified_return_to or "/"
     if error:
-        logger.info("Auth callback returned error=%s description=%s", error, error_description)
+        logger.info(
+            "Auth callback returned error=%s description=%s", error, error_description
+        )
         response = RedirectResponse(
             url=_build_login_redirect(return_to=return_to, auth_error=error),
             status_code=302,
@@ -743,10 +755,12 @@ def auth_callback(
         )
         _clear_oauth_state_cookie(response, request)
         return response
-    except Exception as err:
+    except Exception:
         logger.exception("Auth callback code exchange failed")
         response = RedirectResponse(
-            url=_build_login_redirect(return_to=return_to, auth_error="authentication_failed"),
+            url=_build_login_redirect(
+                return_to=return_to, auth_error="authentication_failed"
+            ),
             status_code=302,
         )
         _clear_oauth_state_cookie(response, request)
@@ -772,9 +786,13 @@ def logout(request: Request):
 
 @auth_router.post("/api/auth/magic-auth/send")
 def send_magic_auth(request: Request, body: MagicAuthSendRequest):
-    raise HTTPException(status_code=503, detail="Email sign-in is not enabled in this release.")
+    raise HTTPException(
+        status_code=503, detail="Email sign-in is not enabled in this release."
+    )
 
 
 @auth_router.post("/api/auth/magic-auth/verify")
 def verify_magic_auth(request: Request, body: MagicAuthVerifyRequest):
-    raise HTTPException(status_code=503, detail="Email sign-in is not enabled in this release.")
+    raise HTTPException(
+        status_code=503, detail="Email sign-in is not enabled in this release."
+    )

--- a/auth/service.py
+++ b/auth/service.py
@@ -64,6 +64,7 @@ class MagicAuthStartState:
             "email": self.email,
         }
 
+
 @dataclass(slots=True)
 class OAuthState:
     nonce: str
@@ -327,7 +328,9 @@ class WorkOSAuthService:
         )
         return state.nonce, _sign_oauth_state(state, self.cookie_password or "")
 
-    def verify_oauth_state(self, *, state: str | None, signed_cookie: str | None) -> str | None:
+    def verify_oauth_state(
+        self, *, state: str | None, signed_cookie: str | None
+    ) -> str | None:
         self.require_enabled()
         if not state or not signed_cookie:
             return None
@@ -373,7 +376,9 @@ def _sign_oauth_state(payload: OAuthState, secret: str) -> str:
     return json.dumps({"payload": raw, "sig": signature}, separators=(",", ":"))
 
 
-def _verify_oauth_state(token: str, *, secret: str, max_age_seconds: int) -> OAuthState | None:
+def _verify_oauth_state(
+    token: str, *, secret: str, max_age_seconds: int
+) -> OAuthState | None:
     try:
         wrapper = json.loads(token)
         raw = wrapper["payload"]
@@ -413,10 +418,17 @@ def build_auth_service_from_env() -> WorkOSAuthService:
         client_id=_env_value("WORKOS_CLIENT_ID"),
         cookie_password=_env_value("WORKOS_COOKIE_PASSWORD"),
         cookie_name=_env_value("AUTH_COOKIE_NAME", "wos_session") or "wos_session",
-        callback_path=_env_value("AUTH_CALLBACK_PATH", "/auth/callback") or "/auth/callback",
+        callback_path=_env_value("AUTH_CALLBACK_PATH", "/auth/callback")
+        or "/auth/callback",
         cookie_secure=_env_value("AUTH_COOKIE_SECURE", "auto") or "auto",
         cookie_samesite=_env_value("AUTH_COOKIE_SAMESITE", "lax") or "lax",
-        cookie_max_age=int(_env_value("AUTH_COOKIE_MAX_AGE", str(60 * 60 * 24 * 14)) or str(60 * 60 * 24 * 14)),
-        oauth_state_cookie_name=_env_value("AUTH_STATE_COOKIE_NAME", "wos_oauth_state") or "wos_oauth_state",
-        oauth_state_ttl_seconds=int(_env_value("AUTH_STATE_TTL_SECONDS", str(60 * 10)) or str(60 * 10)),
+        cookie_max_age=int(
+            _env_value("AUTH_COOKIE_MAX_AGE", str(60 * 60 * 24 * 14))
+            or str(60 * 60 * 24 * 14)
+        ),
+        oauth_state_cookie_name=_env_value("AUTH_STATE_COOKIE_NAME", "wos_oauth_state")
+        or "wos_oauth_state",
+        oauth_state_ttl_seconds=int(
+            _env_value("AUTH_STATE_TTL_SECONDS", str(60 * 10)) or str(60 * 10)
+        ),
     )

--- a/main.py
+++ b/main.py
@@ -19,7 +19,12 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
-from auth import GUEST_COOKIE_NAME, GUEST_COOKIE_VALUE, auth_router, build_auth_service_from_env
+from auth import (
+    GUEST_COOKIE_NAME,
+    GUEST_COOKIE_VALUE,
+    auth_router,
+    build_auth_service_from_env,
+)
 from ai_service import (
     GeminiRateLimitError,
     GeminiServiceError,
@@ -38,12 +43,14 @@ app.state.auth_service = build_auth_service_from_env()
 logger = logging.getLogger(__name__)
 DRILL_CHAT_LOG_PATH = Path(__file__).parent / "logs/drill-chat-transcripts.jsonl"
 PROTECTED_HTML_PATHS = frozenset({"/", "/index.html"})
-PROTECTED_API_PATHS = frozenset({
-    "/api/drill",
-    "/api/extract",
-    "/api/extract-url",
-    "/api/repair-reps",
-})
+PROTECTED_API_PATHS = frozenset(
+    {
+        "/api/drill",
+        "/api/extract",
+        "/api/extract-url",
+        "/api/repair-reps",
+    }
+)
 
 _cors_origins = os.environ.get(
     "CORS_ORIGINS", "http://localhost:8000,http://127.0.0.1:8000"
@@ -122,7 +129,9 @@ async def require_login_or_guest_entry(request: Request, call_next):
         if not _has_app_entry_session(request):
             if path.startswith("/api/"):
                 return JSONResponse(
-                    {"detail": "Choose Google sign-in or continue as guest before using the app."},
+                    {
+                        "detail": "Choose Google sign-in or continue as guest before using the app."
+                    },
                     status_code=401,
                 )
             return RedirectResponse(
@@ -204,12 +213,14 @@ def _build_drill_chat_event(
         "node_label": req.node_label,
         "drill_session_id": req.drill_session_id,
         "client_turn_index": req.client_turn_index,
-        "session_key": "::".join([
-            req.concept_id,
-            req.node_id,
-            req.session_start_iso or "missing",
-            req.drill_session_id or "missing",
-        ]),
+        "session_key": "::".join(
+            [
+                req.concept_id,
+                req.node_id,
+                req.session_start_iso or "missing",
+                req.drill_session_id or "missing",
+            ]
+        ),
         "session_phase": req.session_phase,
         "drill_mode": req.drill_mode,
         "session_start_iso": req.session_start_iso,
@@ -234,17 +245,15 @@ def _build_drill_chat_event(
     return event
 
 
-def _resolve_node_mechanism(knowledge_map: dict, node_id: str, fallback: str = "") -> str:
+def _resolve_node_mechanism(
+    knowledge_map: dict, node_id: str, fallback: str = ""
+) -> str:
     if not isinstance(knowledge_map, dict):
         return fallback
 
     metadata = knowledge_map.get("metadata") or {}
     if node_id == "core-thesis":
-        return str(
-            metadata.get("core_thesis")
-            or metadata.get("thesis")
-            or fallback
-        )
+        return str(metadata.get("core_thesis") or metadata.get("thesis") or fallback)
 
     for backbone in knowledge_map.get("backbone") or []:
         if isinstance(backbone, dict) and backbone.get("id") == node_id:
@@ -276,7 +285,9 @@ def analytics_ai_runs():
         return build_summary_payload()
     except Exception as err:
         logger.exception("Failed to build AI runs analytics payload")
-        raise HTTPException(status_code=500, detail="Could not build AI runs analytics.") from err
+        raise HTTPException(
+            status_code=500, detail="Could not build AI runs analytics."
+        ) from err
 
 
 @app.get("/api/analytics/learner-runs")
@@ -292,7 +303,9 @@ def analytics_learner_runs(concept_ids: str | None = None):
         return build_learner_summary_payload(parsed_concept_ids)
     except Exception as err:
         logger.exception("Failed to build learner analytics payload")
-        raise HTTPException(status_code=500, detail="Could not build learner analytics.") from err
+        raise HTTPException(
+            status_code=500, detail="Could not build learner analytics."
+        ) from err
 
 
 @app.post("/api/extract")
@@ -312,13 +325,19 @@ def extract(req: ExtractRequest):
         raise HTTPException(status_code=400, detail=str(err))
     except Exception as err:
         logger.exception("Unexpected failure in /api/extract")
-        raise HTTPException(status_code=500, detail="Unexpected server error during extraction.") from err
+        raise HTTPException(
+            status_code=500, detail="Unexpected server error during extraction."
+        ) from err
 
 
 def _extract_text_from_html(raw_html: str) -> str:
-    cleaned = re.sub(r"(?is)<(script|style|noscript|svg|iframe).*?>.*?</\1>", " ", raw_html)
+    cleaned = re.sub(
+        r"(?is)<(script|style|noscript|svg|iframe).*?>.*?</\1>", " ", raw_html
+    )
     cleaned = re.sub(r"(?i)<br\s*/?>", "\n", cleaned)
-    cleaned = re.sub(r"(?i)</(p|div|section|article|li|h1|h2|h3|h4|h5|h6|tr)>", "\n", cleaned)
+    cleaned = re.sub(
+        r"(?i)</(p|div|section|article|li|h1|h2|h3|h4|h5|h6|tr)>", "\n", cleaned
+    )
     cleaned = re.sub(r"(?s)<[^>]+>", " ", cleaned)
     cleaned = unescape(cleaned)
     cleaned = cleaned.replace("\r", "\n")
@@ -405,19 +424,25 @@ def extract_url(req: UrlExtractRequest):
 
             raw_bytes = response.read(2_000_000 + 1)
             if len(raw_bytes) > 2_000_000:
-                raise HTTPException(status_code=413, detail="Page is too large to import.")
+                raise HTTPException(
+                    status_code=413, detail="Page is too large to import."
+                )
 
             charset = response.headers.get_content_charset() or "utf-8"
             raw_text = raw_bytes.decode(charset, errors="replace")
     except HTTPException:
         raise
     except HTTPError as err:
-        raise HTTPException(status_code=502, detail=f"Source page returned HTTP {err.code}.")
+        raise HTTPException(
+            status_code=502, detail=f"Source page returned HTTP {err.code}."
+        )
     except URLError:
         raise HTTPException(status_code=502, detail="Could not fetch that URL.")
     except Exception as err:
         logger.exception("Unexpected failure in /api/extract-url for %s", url)
-        raise HTTPException(status_code=500, detail="Unexpected error while fetching that URL.") from err
+        raise HTTPException(
+            status_code=500, detail="Unexpected error while fetching that URL."
+        ) from err
 
     if "text/plain" in content_type:
         text = raw_text.strip()
@@ -428,7 +453,10 @@ def extract_url(req: UrlExtractRequest):
         text = _extract_text_from_html(raw_text)
 
     if len(text) < 200:
-        raise HTTPException(status_code=422, detail="Could not extract enough readable text from that page.")
+        raise HTTPException(
+            status_code=422,
+            detail="Could not extract enough readable text from that page.",
+        )
 
     return {"url": url, "title": title[:200], "text": text[:500_000]}
 
@@ -473,69 +501,95 @@ def drill(req: DrillRequest):
             },
         )
         response_payload = {"concept_id": req.concept_id, **result}
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="success",
-            result=response_payload,
-        ))
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="success",
+                result=response_payload,
+            )
+        )
         return response_payload
     except MissingAPIKeyError as err:
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="error",
-            error_type=type(err).__name__,
-            error_reason=str(err),
-        ))
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="error",
+                error_type=type(err).__name__,
+                error_reason=str(err),
+            )
+        )
         raise HTTPException(status_code=401, detail=str(err))
     except GeminiRateLimitError as err:
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="error",
-            error_type=type(err).__name__,
-            error_reason=str(err),
-        ))
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="error",
+                error_type=type(err).__name__,
+                error_reason=str(err),
+            )
+        )
         raise HTTPException(status_code=429, detail=str(err))
     except GeminiServiceError as err:
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="error",
-            error_type=type(err).__name__,
-            error_reason=str(err),
-        ))
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="error",
+                error_type=type(err).__name__,
+                error_reason=str(err),
+            )
+        )
         raise HTTPException(status_code=503, detail=str(err))
     except json.JSONDecodeError:
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="error",
-            error_type="JSONDecodeError",
-            error_reason="Invalid knowledge_map JSON.",
-        ))
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="error",
+                error_type="JSONDecodeError",
+                error_reason="Invalid knowledge_map JSON.",
+            )
+        )
         raise HTTPException(status_code=400, detail="Invalid knowledge_map JSON.")
     except ValueError as err:
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="error",
-            error_type=type(err).__name__,
-            error_reason=str(err),
-        ))
-        logger.exception("Drill normalization failed for concept_id=%s node_id=%s", req.concept_id, req.node_id)
-        raise HTTPException(status_code=502, detail="Drill evaluation failed. Please retry.") from err
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="error",
+                error_type=type(err).__name__,
+                error_reason=str(err),
+            )
+        )
+        logger.exception(
+            "Drill normalization failed for concept_id=%s node_id=%s",
+            req.concept_id,
+            req.node_id,
+        )
+        raise HTTPException(
+            status_code=502, detail="Drill evaluation failed. Please retry."
+        ) from err
     except Exception as err:
-        _log_drill_chat(_build_drill_chat_event(
-            req,
-            messages_in=messages_in,
-            status="error",
-            error_type=type(err).__name__,
-            error_reason=str(err),
-        ))
-        logger.exception("Unexpected failure in /api/drill for concept_id=%s node_id=%s", req.concept_id, req.node_id)
-        raise HTTPException(status_code=500, detail="Unexpected server error during drill.") from err
+        _log_drill_chat(
+            _build_drill_chat_event(
+                req,
+                messages_in=messages_in,
+                status="error",
+                error_type=type(err).__name__,
+                error_reason=str(err),
+            )
+        )
+        logger.exception(
+            "Unexpected failure in /api/drill for concept_id=%s node_id=%s",
+            req.concept_id,
+            req.node_id,
+        )
+        raise HTTPException(
+            status_code=500, detail="Unexpected server error during drill."
+        ) from err
 
 
 @app.post("/api/repair-reps")
@@ -572,7 +626,9 @@ def repair_reps(req: RepairRepsRequest):
     except GeminiServiceError as err:
         raise HTTPException(status_code=503, detail=str(err))
     except json.JSONDecodeError as err:
-        raise HTTPException(status_code=400, detail="Invalid knowledge_map JSON.") from err
+        raise HTTPException(
+            status_code=400, detail="Invalid knowledge_map JSON."
+        ) from err
     except ValueError as err:
         reason = str(err)
         if (
@@ -581,11 +637,23 @@ def repair_reps(req: RepairRepsRequest):
             or reason.startswith("knowledge_map")
         ):
             raise HTTPException(status_code=400, detail=reason) from err
-        logger.exception("Repair reps generation failed for concept_id=%s node_id=%s", req.concept_id, req.node_id)
-        raise HTTPException(status_code=502, detail="Repair Reps generation failed. Please retry.") from err
+        logger.exception(
+            "Repair reps generation failed for concept_id=%s node_id=%s",
+            req.concept_id,
+            req.node_id,
+        )
+        raise HTTPException(
+            status_code=502, detail="Repair Reps generation failed. Please retry."
+        ) from err
     except Exception as err:
-        logger.exception("Unexpected failure in /api/repair-reps for concept_id=%s node_id=%s", req.concept_id, req.node_id)
-        raise HTTPException(status_code=500, detail="Unexpected server error during Repair Reps.") from err
+        logger.exception(
+            "Unexpected failure in /api/repair-reps for concept_id=%s node_id=%s",
+            req.concept_id,
+            req.node_id,
+        )
+        raise HTTPException(
+            status_code=500, detail="Unexpected server error during Repair Reps."
+        ) from err
 
 
 app.include_router(auth_router)

--- a/public/css/ai-runs-dashboard.css
+++ b/public/css/ai-runs-dashboard.css
@@ -35,7 +35,7 @@ body.analytics-page {
   justify-content: space-between;
   gap: 24px;
   padding: 28px 30px;
-  border-radius: 26px;
+  border-radius: var(--radius-hero);
 }
 
 .analytics-kicker,
@@ -43,10 +43,15 @@ body.analytics-page {
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
   color: var(--text-sub);
   margin-bottom: 10px;
+}
+.analytics-kicker {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.panel-kicker {
+  letter-spacing: 0.02em;
 }
 
 .analytics-header h1,
@@ -57,7 +62,7 @@ body.analytics-page {
 }
 
 .analytics-header h1 {
-  font-size: clamp(34px, 5vw, 52px);
+  font-size: var(--text-4xl);
   line-height: 0.96;
 }
 
@@ -85,8 +90,7 @@ body.analytics-page {
   color: var(--text-sub);
   font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .analytics-select {
@@ -106,7 +110,7 @@ body.analytics-page {
   justify-content: center;
   min-height: 44px;
   padding: 0 16px;
-  border-radius: 14px;
+  border-radius: var(--radius-btn);
   border: 1px solid var(--accent-border);
   background: var(--primary-fill);
   color: var(--text-on-primary);
@@ -129,7 +133,7 @@ body.analytics-page {
   justify-content: space-between;
   gap: 16px;
   padding: 16px 20px;
-  border-radius: 18px;
+  border-radius: var(--radius-card);
 }
 
 .status-chip {
@@ -192,12 +196,12 @@ body.analytics-page {
 
 .metric-card,
 .analytics-panel {
-  border-radius: 22px;
+  border-radius: var(--radius-card);
 }
 
 .tip-card {
   padding: 18px 18px 20px;
-  border-radius: 22px;
+  border-radius: var(--radius-card);
   background: linear-gradient(180deg, rgba(var(--white-rgb), 0.92), rgba(var(--cream-50-rgb), 0.84));
   border: 1px solid var(--border);
   box-shadow: var(--shadow-card);
@@ -225,8 +229,7 @@ body.analytics-page {
   color: var(--text-sub);
   font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .metric-value {
@@ -291,7 +294,7 @@ body.analytics-page {
 
 .stat-tile {
   padding: 14px;
-  border-radius: 16px;
+  border-radius: var(--radius-card);
   background: rgba(var(--white-rgb), 0.72);
   border: 1px solid rgba(var(--ink-900-rgb), 0.08);
 }
@@ -300,8 +303,7 @@ body.analytics-page {
   color: var(--text-sub);
   font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .stat-tile-value {
@@ -375,7 +377,7 @@ body.analytics-page {
 
 .list-card {
   padding: 14px 16px;
-  border-radius: 16px;
+  border-radius: var(--radius-card);
   background: rgba(var(--white-rgb), 0.72);
   border: 1px solid rgba(var(--ink-900-rgb), 0.08);
 }
@@ -422,7 +424,7 @@ body.analytics-page {
   display: grid;
   gap: 6px;
   padding: 14px 16px;
-  border-radius: 16px;
+  border-radius: var(--radius-card);
   background: rgba(var(--white-rgb), 0.72);
   border: 1px solid rgba(var(--ink-900-rgb), 0.08);
 }
@@ -437,8 +439,7 @@ body.analytics-page {
 .event-stage {
   font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--text-sub);
 }
 
@@ -552,4 +553,18 @@ body.analytics-page {
   .stat-grid {
     grid-template-columns: 1fr;
   }
+}
+
+/* ── Dark mode: swap hardcoded light gradients for theme-aware ones ── */
+body.night .analytics-header,
+body.night .analytics-panel,
+body.night .analytics-status,
+body.night .metric-card,
+body.night .tip-card,
+body[data-theme="dark"] .analytics-header,
+body[data-theme="dark"] .analytics-panel,
+body[data-theme="dark"] .analytics-status,
+body[data-theme="dark"] .metric-card,
+body[data-theme="dark"] .tip-card {
+  background: linear-gradient(180deg, var(--gradient-card-start), var(--gradient-card-end));
 }

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -54,8 +54,7 @@ body[data-drawer-open="true"] #card {
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--text-sub);
   min-height: 14px;
   transition: color var(--theme-transition-ms) var(--theme-transition-ease);
@@ -97,6 +96,34 @@ button:active:not(:disabled) { transform: scale(0.97); opacity: 0.9; box-shadow:
 button:disabled { background-color:var(--locked); cursor:not-allowed; transform:none; opacity:1; }
 .btn-fail { background-color:var(--danger); }
 .btn-pass { background-color:var(--success); }
+
+/* Tier 2 — Secondary (outlined) */
+.btn-secondary {
+  background: transparent;
+  color: var(--primary);
+  border: 1.5px solid var(--accent-border-strong);
+  box-shadow: none;
+}
+.btn-secondary:hover:not(:disabled) {
+  background: var(--accent-soft);
+  border-color: var(--primary);
+  transform: translateY(-1px);
+  box-shadow: none;
+}
+
+/* Tier 3 — Ghost (text only) */
+.btn-ghost {
+  background: none;
+  color: var(--text-sub);
+  border: none;
+  box-shadow: none;
+}
+.btn-ghost:hover:not(:disabled) {
+  color: var(--primary);
+  background: var(--accent-soft);
+  transform: none;
+  box-shadow: none;
+}
 
 /* Touch target minimum — mobile only */
 @media (max-width: 899px) {

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -824,33 +824,34 @@ body[data-theme="dark"] .auth-link {
 }
 
 .btn-start-drill {
-  background: var(--accent-soft);
-  color: var(--primary);
-  border: 1.5px solid var(--accent-border-strong);
+  background: var(--primary-fill);
+  color: var(--text-on-primary);
+  border: none;
   border-radius: var(--radius-btn);
-  padding: 6px 14px;
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.02em;
+  padding: 10px 18px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  width: max-content; 
+  width: max-content;
   max-width: max-content;
   white-space: nowrap;
-  box-shadow: none;
+  box-shadow: var(--accent-shadow-sm);
   transition: all 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
   display: inline-flex;
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
 }
-.btn-start-drill:hover { 
-  background: var(--primary-fill); 
-  color: var(--text-on-primary); 
-  border-color: var(--primary-fill);
-  transform: translateY(-1px); 
-  box-shadow: var(--accent-shadow-sm); 
+.btn-start-drill:hover:not(:disabled) {
+  opacity: 0.95;
+  transform: translateY(-1px);
+  box-shadow: var(--accent-shadow-md);
 }
-.btn-start-drill:active { transform: translateY(0); box-shadow: none; }
+.btn-start-drill:active:not(:disabled) {
+  transform: scale(0.97);
+  box-shadow: var(--accent-shadow-sm);
+}
 
 .btn-consolidate-float,
 .btn-consolidate-float:disabled {

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1,3 +1,20 @@
+/* ── Material Symbols ─────────────────────────────────────── */
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
 /* ── 9. Sidebar + backdrop ────────────────────────────────── */
 #backdrop {
   position:fixed; inset:0;
@@ -171,7 +188,7 @@ body[data-theme="dark"] .auth-link {
   width: auto;
   flex: none;
   padding: 11px 16px;
-  border-radius: 14px;
+  border-radius: var(--radius-btn);
   box-shadow: var(--accent-shadow-sm);
 }
 .hero-primary-action:disabled {
@@ -250,8 +267,19 @@ body[data-theme="dark"] .auth-link {
   color:var(--text-sub); text-decoration:none;
   transition:background-color 0.15s, color 0.15s; cursor:pointer;
 }
+.sidebar-nav-item .material-symbols-outlined {
+  font-size: 20px;
+  color: inherit;
+  flex-shrink: 0;
+}
 .sidebar-nav-item:hover { background:var(--border); color:var(--text); }
-.sidebar-nav-item.active { background:var(--accent-soft); color:var(--primary); }
+.sidebar-nav-item.active {
+  background:var(--accent-soft);
+  color:var(--primary);
+  border-left: 3px solid var(--primary);
+  padding-left: 9px;
+  font-weight: 700;
+}
 
 .sidebar-divider { height:1px; background:var(--border); margin:8px 12px; flex-shrink:0; }
 
@@ -430,7 +458,7 @@ body[data-theme="dark"] .auth-link {
 .overlay-url-input:focus { border-color:var(--primary); }
 .overlay-url-input::placeholder { color:var(--text-sub); }
 .overlay-dropzone {
-  border:2px dashed var(--border); border-radius:10px; padding:24px 16px;
+  border:1.5px solid var(--border); border-radius:var(--radius-btn); padding:24px 16px; background:var(--accent-soft);
   font-size:13px; color:var(--text-sub); cursor:pointer; text-align:center;
   transition:border-color 0.2s, color 0.2s;
 }
@@ -442,12 +470,12 @@ body[data-theme="dark"] .auth-link {
 .overlay-dropfeedback.ok    { color:var(--success); }
 .overlay-footer { display:flex; gap:10px; }
 .overlay-cancel {
-  background:none; border:1px solid var(--border); color:var(--text-sub);
-  border-radius:8px; padding:9px 16px; font-size:13px; font-weight:600;
+  background:none; border:1.5px solid var(--accent-border-strong); color:var(--text-sub);
+  border-radius:var(--radius-btn); padding:9px 16px; font-size:13px; font-weight:600;
   cursor:pointer; flex:none; width:auto;
-  transition:border-color 0.2s, color 0.2s;
+  transition:border-color 0.2s, color 0.2s, background-color 0.2s;
 }
-.overlay-cancel:hover { border-color:var(--text-sub); color:var(--text); }
+.overlay-cancel:hover { border-color:var(--primary); color:var(--text); background:var(--accent-soft); }
 .overlay-extract {
   background:var(--primary-fill); color:var(--text-on-primary); border:none; border-radius:8px;
   padding:9px 16px; font-size:13px; font-weight:600; cursor:pointer; flex:1;
@@ -465,7 +493,7 @@ body[data-theme="dark"] .auth-link {
   background: var(--surface);
   overflow-y: auto;
   padding: 40px 56px;
-  border-radius: var(--radius-hero);
+  border-radius: var(--radius-card);
   margin-top: 16px;
 }
 .library-view.visible {
@@ -520,7 +548,7 @@ body[data-theme="dark"] .auth-link {
 .library-card {
   background: linear-gradient(180deg, var(--gradient-panel-start) 0%, var(--gradient-panel-end) 100%);
   border: 1px solid var(--accent-soft);
-  border-radius: 18px;
+  border-radius: var(--radius-card);
   padding: 20px;
   margin-bottom: 20px;
   box-shadow: var(--shadow-soft);
@@ -573,7 +601,7 @@ body[data-theme="dark"] .auth-link {
 .library-card-starter {
   background: linear-gradient(180deg, var(--gradient-card-start) 0%, var(--gradient-card-end) 100%);
   border: 1px solid var(--accent-soft);
-  border-radius: 18px;
+  border-radius: var(--radius-card);
   padding: 20px 20px 18px;
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
@@ -600,8 +628,7 @@ body[data-theme="dark"] .auth-link {
 .library-card-kicker {
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--primary);
   margin-bottom: 8px;
 }
@@ -667,8 +694,7 @@ body[data-theme="dark"] .auth-link {
 .creation-intro-kicker {
   font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--primary);
   margin-bottom: 6px;
 }
@@ -698,8 +724,8 @@ body[data-theme="dark"] .auth-link {
   white-space: nowrap;
 }
 .creation-section-label {
-  font-size:11px; font-weight:700; letter-spacing:0.6px;
-  text-transform:uppercase; color:var(--text-sub); margin-top:2px;
+  font-size:11px; font-weight:700; letter-spacing:0.02em;
+  color:var(--text-sub); margin-top:2px;
 }
 .creation-name-input {
   width:100%; background:var(--card-bg); border:1px solid var(--border);
@@ -745,12 +771,12 @@ body[data-theme="dark"] .auth-link {
 }
 .creation-footer { display:flex; gap:8px; margin-top:2px; }
 .creation-cancel {
-  background:none; border:1px solid var(--border); color:var(--text-sub);
-  border-radius:8px; padding:8px 12px; font-size:13px; font-weight:600;
+  background:none; border:1.5px solid var(--accent-border-strong); color:var(--text-sub);
+  border-radius:var(--radius-btn); padding:8px 12px; font-size:13px; font-weight:600;
   cursor:pointer; flex:none; width:auto;
-  transition:border-color 0.2s, color 0.2s;
+  transition:border-color 0.2s, color 0.2s, background-color 0.2s;
 }
-.creation-cancel:hover { color:var(--text); border-color:var(--text-sub); }
+.creation-cancel:hover { color:var(--text); border-color:var(--primary); background:var(--accent-soft); }
 .creation-submit {
   background:var(--primary-fill); color:var(--text-on-primary); border:none; border-radius:8px;
   padding:8px 12px; font-size:13px; font-weight:600; cursor:pointer; flex:1;
@@ -798,15 +824,14 @@ body[data-theme="dark"] .auth-link {
 }
 
 .btn-start-drill {
-  background: var(--accent-soft); 
-  color: var(--primary); 
-  border: 1px solid var(--accent-border); 
-  border-radius: 20px;
-  padding: 6px 14px; 
-  font-size: 11px; 
-  font-weight: 800; 
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  background: var(--accent-soft);
+  color: var(--primary);
+  border: 1.5px solid var(--accent-border-strong);
+  border-radius: var(--radius-btn);
+  padding: 6px 14px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
   cursor: pointer;
   width: max-content; 
   max-width: max-content;
@@ -827,12 +852,13 @@ body[data-theme="dark"] .auth-link {
 }
 .btn-start-drill:active { transform: translateY(0); box-shadow: none; }
 
-.btn-consolidate-float {
+.btn-consolidate-float,
+.btn-consolidate-float:disabled {
   position: absolute;
-  background: rgba(var(--surface-overlay-theme-rgb), 0.85); 
+  background: var(--primary-fill);
   backdrop-filter: blur(4px);
-  color: var(--text-on-overlay);
-  border: 1px solid var(--tooltip-border);
+  color: var(--text-on-primary);
+  border: 1px solid var(--accent-border-strong);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -846,7 +872,7 @@ body[data-theme="dark"] .auth-link {
   transform: translate(-50%, -100%);
 }
 .btn-consolidate-float:hover {
-  background: var(--surface-overlay-theme);
+  background: var(--primary-fill-hover);
   border-color: var(--primary);
   box-shadow: var(--accent-shadow-lg);
   transform: translate(-50%, -100%) translateY(-2px) scale(1.05);

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -56,13 +56,6 @@
     overflow-y: auto;
   }
 
-  /* Center hero card when dashboard is the only visible view —
-     use auto margin so the header stays pinned at top */
-  #card.dashboard-only .hero-card {
-    margin-top: auto;
-    margin-bottom: auto;
-  }
-
   /* Hide bottom nav on desktop */
   .bottom-nav {
     display: none !important;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -56,9 +56,11 @@
     overflow-y: auto;
   }
 
-  /* Center hero card when dashboard is the only visible view */
-  #card.dashboard-only {
-    justify-content: center;
+  /* Center hero card when dashboard is the only visible view —
+     use auto margin so the header stays pinned at top */
+  #card.dashboard-only .hero-card {
+    margin-top: auto;
+    margin-bottom: auto;
   }
 
   /* Hide bottom nav on desktop */

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -70,9 +70,12 @@
   padding: 28px 40px 0;
   flex-shrink: 0;
 }
-body[data-map-open="true"] .main-header-right {
-  opacity: 0;
-  pointer-events: none;
+body[data-map-open="true"] .auth-controls,
+body[data-map-open="true"] .dev-skip {
+  display: none !important;
+}
+body:not([data-map-open="true"]) #map-close-btn {
+  display: none !important;
 }
 .main-header-left {
   display: flex;
@@ -669,14 +672,13 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 .map-view {
   display: none;
   flex-direction: column;
-  position: absolute;
-  inset: 0;
   background: var(--surface);
-  z-index: 40;
   overflow-y: auto;
-  padding: 40px 56px;
+  padding: 16px 40px 40px;
   text-align: left;
   border-radius: var(--radius-card);
+  flex: 1;
+  min-height: 0;
 }
 .map-view.visible {
   display: flex;
@@ -688,36 +690,28 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 }
 
 .map-close-btn {
-  position: absolute;
-  top: 24px;
-  right: 32px;
-  z-index: 3;
+  flex: none;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   background: var(--accent-soft);
   border: none;
   border-radius: 50%;
-  width: 32px;
-  height: 32px;
   font-size: 20px;
   line-height: 1;
   color: var(--primary);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s, color 0.2s;
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease;
 }
-.map-close-btn:hover {
+.map-close-btn:hover:not(:disabled) {
   background: var(--primary-fill);
   color: var(--text-on-primary);
-}
-
-body[data-map-open="true"] .main-header-left {
-  position: relative;
-  z-index: 50;
-}
-body[data-map-open="true"] .drawer-toggle {
-  opacity: 1;
-  pointer-events: auto;
+  transform: none;
+  box-shadow: none;
 }
 
 /* Map Zones */
@@ -763,6 +757,63 @@ body[data-map-open="true"] .drawer-toggle {
 .map-fw-state { font-size: 13px; color: var(--text-sub); line-height: 1.4; }
 
 .map-view-shell { display: flex; flex-direction: column; gap: 24px; min-height: 100%; }
+
+.concept-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 8px 0 28px;
+  border-bottom: 1px solid var(--border);
+}
+.concept-header-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1 1 auto;
+}
+.concept-header-kicker {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--primary);
+}
+.concept-header-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 32px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  font-weight: 700;
+}
+.concept-header-summary {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-sub);
+  max-width: 62ch;
+}
+.concept-header-summary:empty { display: none; }
+.concept-header-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 2px;
+}
+.concept-header-tags:empty { display: none; }
+.concept-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: none;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .map-mode-switch {
   display: inline-flex;
   align-items: center;
@@ -1262,21 +1313,13 @@ body[data-map-open="true"] .drawer-toggle {
 
 /* Mobile adjustments for map and library views */
 @media (max-width: 899px) {
-  .map-view { 
-    padding: 96px 24px 24px; 
-    border-radius: 0; 
-    position: fixed; 
-    top: 0; left: 0; right: 0; bottom: 0;
-    z-index: 2000;
-    height: 100dvh;
+  .map-view {
+    padding: 16px 20px 24px;
+    border-radius: 0;
     box-sizing: border-box;
   }
-  .map-close-btn {
-    top: 66px;
-    right: 20px;
-  }
   .library-view {
-    padding: 24px 16px; 
+    padding: 24px 16px;
     border-radius: 0;
   }
   .settings-page-grid {
@@ -1297,30 +1340,40 @@ body[data-map-open="true"] .drawer-toggle {
     grid-template-columns: 1fr;
   }
   .map-core-thesis { font-size: 17px; }
-  .map-view-shell { gap: 12px; padding-top: 0; }
+  .map-view-shell { gap: 16px; padding-top: 0; }
   .map-mode-switch { width: 100%; }
   .map-mode-btn { flex: 1; }
-  
+
   /* Enlarge close button for touch */
   .map-close-btn {
-    top: 12px;
-    right: 12px;
-    width: 44px;
-    height: 44px;
+    width: 40px;
+    height: 40px;
     font-size: 22px;
   }
 
-  /* Stack title + drill button vertically on mobile */
-  .map-zone.zone-1 > div:first-child {
-    flex-direction: column !important;
-    align-items: flex-start !important;
-    margin-right: 0 !important;
-    gap: 12px;
+  /* Concept header stacks vertically on mobile */
+  .concept-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+    padding: 4px 0 20px;
+  }
+  .concept-header-title { font-size: 24px; }
+  .concept-header-summary { font-size: 14px; }
+  .concept-header-actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 10px;
+  }
+  .concept-header-actions .map-mode-switch {
+    width: 100%;
   }
 
   /* Make Start Drill a prominent full-width CTA on mobile */
   .btn-start-drill {
     width: 100%;
+    max-width: none;
     justify-content: center;
     padding: 14px 20px;
     font-size: 13px;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -70,7 +70,7 @@
   padding: 28px 40px 0;
   flex-shrink: 0;
 }
-body[data-map-open="true"] .main-header {
+body[data-map-open="true"] .main-header-right {
   opacity: 0;
   pointer-events: none;
 }
@@ -712,8 +712,8 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 }
 
 body[data-map-open="true"] .drawer-toggle {
-  opacity: 0;
-  pointer-events: none;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* Map Zones */

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -56,6 +56,11 @@
     overflow-y: auto;
   }
 
+  /* Center hero card when dashboard is the only visible view */
+  #card.dashboard-only {
+    justify-content: center;
+  }
+
   /* Hide bottom nav on desktop */
   .bottom-nav {
     display: none !important;
@@ -88,8 +93,7 @@ body[data-map-open="true"] .main-header {
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--text-sub);
 }
 
@@ -102,7 +106,7 @@ body[data-map-open="true"] .main-header {
   gap: 32px;
   background: var(--surface-card);
   border-radius: var(--radius-hero);
-  padding: 52px 56px;
+  padding: 48px 52px;
   margin: 24px 40px 32px;
   box-shadow: var(--shadow-ambient);
   transition: background-color var(--theme-transition-ms) var(--theme-transition-ease);
@@ -143,6 +147,10 @@ body[data-map-open="true"] .main-header {
 /* ─── Night mode — hero card picks up CSS variable overrides ── */
 body.night .hero-card,
 body[data-theme="dark"] .hero-card { background-color: var(--card-bg); }
+body.night .settings-page-card,
+body[data-theme="dark"] .settings-page-card {
+  background: linear-gradient(180deg, var(--gradient-card-start), var(--gradient-card-end));
+}
 body.night #card,
 body[data-theme="dark"] #card { background-color: var(--bg); }
 
@@ -241,7 +249,7 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
     gap: 8px;
     padding: 56px 20px 80px; /* auth controls hidden on mobile so less top padding needed */
     margin: 0;
-    border-radius: 24px;
+    border-radius: var(--radius-hero);
     box-shadow: var(--shadow-card);
     background: var(--surface-card);
     position: relative;
@@ -501,9 +509,9 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 
 /* Section header: label + status dot */
 .settings-section-header { display:flex; align-items:center; gap:7px; margin-bottom:11px; }
-.settings-box h4 { margin:0; font-size:10px; font-weight:700; letter-spacing:0.7px; text-transform:uppercase; color:var(--text-sub); transition:color var(--theme-transition-ms) var(--theme-transition-ease); }
+.settings-box h4 { margin:0; font-size:10px; font-weight:700; letter-spacing:0.02em; color:var(--text-sub); transition:color var(--theme-transition-ms) var(--theme-transition-ease); }
 .settings-dot { width:7px; height:7px; border-radius:50%; flex-shrink:0; background:var(--locked); transition:background-color 0.3s ease, box-shadow 0.3s ease; }
-.settings-dot.connected { background:var(--success); box-shadow:0 0 5px var(--success); }
+.settings-dot.connected { background:var(--primary); box-shadow:0 0 5px var(--accent-glow); }
 .settings-dot.error     { background:var(--danger);  box-shadow:0 0 4px var(--danger); }
 
 /* Input + eye toggle */
@@ -537,7 +545,8 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 .settings-actions { display:flex; gap:8px; margin-top:12px; }
 .settings-test  {
   background:transparent; color:var(--primary);
-  border:1.5px solid var(--primary);
+  border:1.5px solid var(--accent-border-strong);
+  border-radius:var(--radius-btn);
 }
 .settings-test:hover:not(:disabled) { background:var(--accent-soft); opacity:1; }
 .settings-test:disabled { background:transparent; color:var(--locked); border-color:var(--locked); opacity:1; }
@@ -610,7 +619,7 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
   display: grid;
   gap: 14px;
   padding: 22px;
-  border-radius: 22px;
+  border-radius: var(--radius-card);
   background: linear-gradient(180deg, rgba(var(--white-rgb), 0.9), rgba(var(--cream-50-rgb), 0.84));
   border: 1px solid var(--border);
   box-shadow: var(--shadow-card);
@@ -647,8 +656,8 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
 }
 
 .settings-badge.success {
-  background: rgba(67, 178, 103, 0.14);
-  color: var(--success);
+  background: var(--accent-soft);
+  color: var(--primary);
 }
 
 .settings-badge.danger {
@@ -672,7 +681,7 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
   overflow-y: auto;
   padding: 40px 56px;
   text-align: left;
-  border-radius: var(--radius-hero);
+  border-radius: var(--radius-card);
 }
 .map-view.visible {
   display: flex;
@@ -724,7 +733,7 @@ body[data-map-open="true"] .drawer-toggle {
 .map-badge.diff { background: var(--surface-nested); color: var(--text-sub); border: 1px solid var(--border); }
 .map-low-density { font-size: 12px; color: var(--text-sub); font-style: italic; opacity: 0.8; margin-top: 8px; }
 
-.map-section-title { font-size: 13px; font-weight: 700; color: var(--text-sub); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 16px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+.map-section-title { font-size: 13px; font-weight: 700; color: var(--text-sub); letter-spacing: 0.02em; margin-bottom: 16px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
 
 .map-backbone-item { background: var(--surface-card); border-left: 3px solid var(--primary); padding: 12px 16px; border-radius: 0 8px 8px 0; font-size: 14px; font-weight: 500; color: var(--text); margin-bottom: 8px; box-shadow: 0 2px 8px rgba(var(--ink-900-rgb), 0.02); }
 
@@ -818,7 +827,7 @@ body[data-map-open="true"] .drawer-toggle {
 .graph-detail {
   background: var(--surface-card);
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: var(--radius-card);
   box-shadow: var(--shadow-soft);
   min-height: 0;
 }
@@ -964,8 +973,7 @@ body[data-map-open="true"] .drawer-toggle {
   color: var(--primary);
   font-size: 12px;
   font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 .graph-detail-disclosure summary::-webkit-details-marker {
   display: none;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -711,6 +711,10 @@ body[data-theme="dark"] #card { background-color: var(--bg); }
   color: var(--text-on-primary);
 }
 
+body[data-map-open="true"] .main-header-left {
+  position: relative;
+  z-index: 50;
+}
 body[data-map-open="true"] .drawer-toggle {
   opacity: 1;
   pointer-events: auto;

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -109,7 +109,7 @@
   --text-xl:          clamp(1.25rem, 1.1rem + 0.75vw, 1.4rem);
   --text-2xl:         clamp(1.5rem, 1.3rem + 1vw, 1.75rem);
   --text-3xl:         clamp(1.8rem, 1.6rem + 1.25vw, 2.25rem);
-  --text-4xl:         clamp(2.25rem, 1.9rem + 1.75vw, 2.8rem);
+  --text-4xl:         clamp(1.95rem, 1.65rem + 1.5vw, 2.4rem);
 
   /* Shadows */
   --shadow-ambient:   0 40px 100px rgba(44,51,62,0.05), 0 2px 8px rgba(44,51,62,0.04);
@@ -177,8 +177,8 @@
   --crystal-actualized-specular:    rgba(var(--cream-50-rgb), 1);
   --crystal-actualized-glow:        rgba(var(--violet-600-rgb), 0.38);
   /* Radii */
-  --radius-hero:      2.5rem;
-  --radius-card:      1.5rem;
+  --radius-hero:      1.25rem;
+  --radius-card:      1rem;
   --radius-btn:       10px;
   --radius-sm:        0.625rem;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -119,37 +119,39 @@
           <a class="auth-link" id="auth-login-link" href="/login">Save &amp; Sync</a>
           <button class="auth-link auth-link-secondary" id="auth-logout-btn" type="button" hidden>Log Out</button>
         </div>
-        <button class="theme-toggle" id="theme-toggle" type="button" onclick="App.toggleTheme()"
-          aria-label="Switch to dark mode" aria-pressed="false" title="Switch to dark mode">
-          <span class="theme-toggle-icon theme-toggle-icon-sun" aria-hidden="true">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
-              stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="4.5"></circle>
-              <path d="M12 2.5v3"></path>
-              <path d="M12 18.5v3"></path>
-              <path d="M4.9 4.9l2.1 2.1"></path>
-              <path d="M17 17l2.1 2.1"></path>
-              <path d="M2.5 12h3"></path>
-              <path d="M18.5 12h3"></path>
-              <path d="M4.9 19.1L7 17"></path>
-              <path d="M17 7l2.1-2.1"></path>
-            </svg>
-          </span>
-          <span class="theme-toggle-track" aria-hidden="true">
-            <span class="theme-toggle-thumb"></span>
-          </span>
-          <span class="theme-toggle-icon theme-toggle-icon-moon" aria-hidden="true">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
-              stroke-linecap="round" stroke-linejoin="round">
-              <path d="M20.5 15.2A8.8 8.8 0 1 1 12.8 3.5a7.2 7.2 0 0 0 7.7 11.7z"></path>
-              <path d="M18 5.2v2.1"></path>
-              <path d="M16.95 6.25h2.1"></path>
-            </svg>
-          </span>
-        </button>
         <button class="dev-skip" id="dev-btn" style="display:none;" onclick="App.fastForward()">[skip 24h]</button>
       </div>
     </header>
+
+    <!-- Theme toggle — lives outside header so map-open fade doesn't hide it -->
+    <button class="theme-toggle" id="theme-toggle" type="button" onclick="App.toggleTheme()"
+      aria-label="Switch to dark mode" aria-pressed="false" title="Switch to dark mode">
+      <span class="theme-toggle-icon theme-toggle-icon-sun" aria-hidden="true">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
+          stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4.5"></circle>
+          <path d="M12 2.5v3"></path>
+          <path d="M12 18.5v3"></path>
+          <path d="M4.9 4.9l2.1 2.1"></path>
+          <path d="M17 17l2.1 2.1"></path>
+          <path d="M2.5 12h3"></path>
+          <path d="M18.5 12h3"></path>
+          <path d="M4.9 19.1L7 17"></path>
+          <path d="M17 7l2.1-2.1"></path>
+        </svg>
+      </span>
+      <span class="theme-toggle-track" aria-hidden="true">
+        <span class="theme-toggle-thumb"></span>
+      </span>
+      <span class="theme-toggle-icon theme-toggle-icon-moon" aria-hidden="true">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
+          stroke-linecap="round" stroke-linejoin="round">
+          <path d="M20.5 15.2A8.8 8.8 0 1 1 12.8 3.5a7.2 7.2 0 0 0 7.7 11.7z"></path>
+          <path d="M18 5.2v2.1"></path>
+          <path d="M16.95 6.25h2.1"></path>
+        </svg>
+      </span>
+    </button>
 
     <!-- Hero card: concept info left, crystal grid right -->
     <section class="hero-card">

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Inter:wght@400;500;600&display=swap"
     rel="stylesheet">
   <link
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0&icon_names=auto_awesome,memory,psychology,settings&display=block"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0&icon_names=auto_awesome,help,memory,psychology,settings&display=block"
     rel="stylesheet">
   <title>socratink</title>
   <link rel="manifest" href="/manifest.webmanifest?v=1">
@@ -71,12 +71,15 @@
 
     <nav class="sidebar-nav">
       <a id="nav-dashboard" class="sidebar-nav-item active" href="javascript:void(0)"
-        onclick="App.showDashboard()">Dashboard</a>
-      <a id="nav-library" class="sidebar-nav-item" href="javascript:void(0)" onclick="App.showLibrary()">Library</a>
+        onclick="App.showDashboard()"><span class="material-symbols-outlined">auto_awesome</span> Dashboard</a>
+      <a id="nav-library" class="sidebar-nav-item" href="javascript:void(0)"
+        onclick="App.showLibrary()"><span class="material-symbols-outlined">memory</span> Library</a>
       <a id="nav-analytics" class="sidebar-nav-item" href="javascript:void(0)"
-        onclick="App.showAnalytics()" title="Open learner analytics">Analytics</a>
-      <a id="nav-settings" class="sidebar-nav-item" href="javascript:void(0)" onclick="App.showSettings()">Settings</a>
-      <a id="nav-guide" class="sidebar-nav-item" href="javascript:void(0)" onclick="App.toggleTutorial()">[?] Quick Guide</a>
+        onclick="App.showAnalytics()" title="Open learner analytics"><span class="material-symbols-outlined">psychology</span> Analytics</a>
+      <a id="nav-settings" class="sidebar-nav-item" href="javascript:void(0)"
+        onclick="App.showSettings()"><span class="material-symbols-outlined">settings</span> Settings</a>
+      <a id="nav-guide" class="sidebar-nav-item" href="javascript:void(0)"
+        onclick="App.toggleTutorial()"><span class="material-symbols-outlined">help</span> Quick Guide</a>
     </nav>
 
     <div class="sidebar-divider"></div>
@@ -184,7 +187,7 @@
         <button id="btn-consolidate-float" class="btn-consolidate-float" onclick="App.consolidate()"
           style="display:none;" disabled title="Consolidation is coming soon" aria-label="Consolidation coming soon">
           <svg
-            style="display: block; width: 16px; height: 16px; flex-shrink: 0; stroke: #ffffff; fill: none; pointer-events: none;"
+            style="display: block; width: 16px; height: 16px; flex-shrink: 0; stroke: currentColor; fill: none; pointer-events: none;"
             viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
           </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -120,6 +120,7 @@
           <button class="auth-link auth-link-secondary" id="auth-logout-btn" type="button" hidden>Log Out</button>
         </div>
         <button class="dev-skip" id="dev-btn" style="display:none;" onclick="App.fastForward()">[skip 24h]</button>
+        <button class="map-close-btn" id="map-close-btn" type="button" onclick="App.hideMapView()" aria-label="Close concept map">×</button>
       </div>
     </header>
 
@@ -390,13 +391,22 @@
 
     <!-- Map View Panel -->
     <section id="map-view" class="map-view">
-      <button class="map-close-btn" onclick="App.hideMapView()" aria-label="Close map">×</button>
       <div class="map-view-shell">
-        <div class="map-mode-switch" role="tablist" aria-label="Map display mode">
-          <button id="map-mode-study" class="map-mode-btn active" data-map-mode="study" type="button">Study
-            View</button>
-          <button id="map-mode-graph" class="map-mode-btn" data-map-mode="graph" type="button">Graph View</button>
-        </div>
+        <header class="concept-header" id="concept-header">
+          <div class="concept-header-main">
+            <div class="concept-header-kicker" id="concept-header-kicker"></div>
+            <h2 class="concept-header-title" id="concept-header-title"></h2>
+            <p class="concept-header-summary" id="concept-header-summary"></p>
+            <div class="concept-header-tags" id="concept-header-tags"></div>
+          </div>
+          <div class="concept-header-actions">
+            <div class="map-mode-switch" role="tablist" aria-label="Map display mode">
+              <button id="map-mode-study" class="map-mode-btn active" data-map-mode="study" type="button" aria-pressed="true">Study</button>
+              <button id="map-mode-graph" class="map-mode-btn" data-map-mode="graph" type="button" aria-pressed="false">Graph</button>
+            </div>
+            <button class="btn-start-drill" id="concept-start-drill" type="button" onclick="App.startDrillFromMap()" hidden>Start Drill</button>
+          </div>
+        </header>
         <div id="map-content"></div>
         <div id="graph-content" class="graph-content" hidden>
           <div class="graph-layout">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -146,9 +146,6 @@ const App = (() => {
 
   function setMapShellOpen(isOpen) {
     document.body.dataset.mapOpen = isOpen ? 'true' : 'false';
-    if (!drawerToggle) return;
-    drawerToggle.setAttribute('aria-hidden', String(isOpen));
-    drawerToggle.tabIndex = isOpen ? -1 : 0;
   }
 
   function getHeroStateLabel(state) {
@@ -1572,28 +1569,28 @@ const App = (() => {
     const rels = data.relationships || { domain_mechanics: [], learning_prerequisites: [] };
     const fws = data.frameworks || [];
 
-    let html = '<div class="map-zone zone-1">';
-    html += '<div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px; margin-right: 48px;">';
-    html += `<div class="map-header-title" style="margin-bottom: 0;">${escHtml(meta.source_title || concept.name)}</div>`;
-
-    if (concept.state === 'growing' || concept.state === 'fractured') {
-      const btnText = concept.state === 'fractured' ? '✦ Repair (Drill)' : '✦ Start Drill';
-      html += `<button class="btn-start-drill" onclick="App.startDrillFromMap()" title="Interactive Drill Session">${btnText}</button>`;
+    const kickerEl = document.getElementById('concept-header-kicker');
+    const titleEl = document.getElementById('concept-header-title');
+    const summaryEl = document.getElementById('concept-header-summary');
+    const tagsEl = document.getElementById('concept-header-tags');
+    const drillBtn = document.getElementById('concept-start-drill');
+    if (kickerEl) kickerEl.textContent = getHeroStateLabel(concept.state) || 'Concept';
+    if (titleEl) titleEl.textContent = meta.source_title || concept.name || '';
+    if (summaryEl) summaryEl.textContent = meta.core_thesis || '';
+    if (tagsEl) {
+      let tagsHtml = '';
+      if (meta.architecture_type) tagsHtml += `<span class="map-badge arch">${escHtml(meta.architecture_type.replace(/_/g, ' '))}</span>`;
+      if (meta.difficulty) tagsHtml += `<span class="map-badge diff">${escHtml(meta.difficulty)}</span>`;
+      if (meta.low_density) tagsHtml += `<span class="map-low-density">Lightweight map</span>`;
+      tagsEl.innerHTML = tagsHtml;
     }
-    html += '</div>';
-
-    html += `<div class="map-core-thesis">${escHtml(meta.core_thesis || '')}</div>`;
-
-    html += '<div class="map-badges">';
-    if (meta.architecture_type) html += `<div class="map-badge arch">${escHtml(meta.architecture_type.replace(/_/g, ' '))}</div>`;
-    if (meta.difficulty) html += `<div class="map-badge diff">${escHtml(meta.difficulty)}</div>`;
-    html += '</div>';
-
-    if (meta.low_density) {
-      html += '<div class="map-low-density">Lightweight map — source had limited content.</div>';
+    if (drillBtn) {
+      const showDrill = concept.state === 'growing' || concept.state === 'fractured';
+      drillBtn.hidden = !showDrill;
+      drillBtn.textContent = concept.state === 'fractured' ? 'Repair Drill' : 'Start Drill';
     }
 
-    html += '</div>';
+    let html = '';
 
     if (backbone.length > 0) {
       html += '<div class="map-zone zone-2">';

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1726,10 +1726,12 @@ const App = (() => {
     const libraryView = document.getElementById('library-view');
     const analyticsView = document.getElementById('analytics-view');
     const settingsView = document.getElementById('settings-view');
+    const card = document.getElementById('card');
     if (heroCard) heroCard.style.display = 'none';
     if (libraryView) libraryView.classList.remove('visible');
     if (analyticsView) analyticsView.classList.remove('visible');
     if (settingsView) settingsView.classList.remove('visible');
+    if (card) card.classList.remove('dashboard-only');
   }
 
   function setMapMode(mode = 'study') {
@@ -1778,11 +1780,13 @@ const App = (() => {
   function showDashboard() {
     setNavActive('nav-dashboard');
     const heroCard = document.querySelector('.hero-card');
+    const card = document.getElementById('card');
 
     clearSettingsPanel();
     teardownMapView();
     hidePrimaryViews();
     if (heroCard) heroCard.style.display = 'flex';
+    if (card) card.classList.add('dashboard-only');
     if (window.innerWidth < 900) closeDrawer();
     scheduleTutorialRefresh();
   }
@@ -3622,7 +3626,7 @@ const App = (() => {
           statusBox.textContent = data.server_key_configured
             ? 'Backend reachable. Server-managed Gemini access is available.'
             : 'Backend reachable. Add a local Gemini key below or configure one on the server.';
-          statusBox.style.color = 'var(--success)';
+          statusBox.style.color = 'var(--primary)';
         }
       } catch (err) {
         console.warn('Backend health check failed.', err);
@@ -3652,7 +3656,7 @@ const App = (() => {
       }
       localStorage.setItem('gemini_key', nextValue);
       keyStatus.textContent = 'Key saved to this browser.';
-      keyStatus.style.color = 'var(--success)';
+      keyStatus.style.color = 'var(--primary)';
       refreshAiAccessUi({
         backendReachable: backendBadge?.textContent === 'Connected',
         serverKeyConfigured: aiBadge?.textContent === 'Server key active',

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1726,12 +1726,10 @@ const App = (() => {
     const libraryView = document.getElementById('library-view');
     const analyticsView = document.getElementById('analytics-view');
     const settingsView = document.getElementById('settings-view');
-    const card = document.getElementById('card');
     if (heroCard) heroCard.style.display = 'none';
     if (libraryView) libraryView.classList.remove('visible');
     if (analyticsView) analyticsView.classList.remove('visible');
     if (settingsView) settingsView.classList.remove('visible');
-    if (card) card.classList.remove('dashboard-only');
   }
 
   function setMapMode(mode = 'study') {
@@ -1780,13 +1778,11 @@ const App = (() => {
   function showDashboard() {
     setNavActive('nav-dashboard');
     const heroCard = document.querySelector('.hero-card');
-    const card = document.getElementById('card');
 
     clearSettingsPanel();
     teardownMapView();
     hidePrimaryViews();
     if (heroCard) heroCard.style.display = 'flex';
-    if (card) card.classList.add('dashboard-only');
     if (window.innerWidth < 900) closeDrawer();
     scheduleTutorialRefresh();
   }

--- a/scripts/run_tasting_fixture.py
+++ b/scripts/run_tasting_fixture.py
@@ -81,7 +81,9 @@ def resolve_node(knowledge_map: dict, node_id: str | None) -> dict:
                     "type": "subnode",
                 }
 
-    raise KeyError(f"Could not resolve node_id={target_id} from extracted knowledge map.")
+    raise KeyError(
+        f"Could not resolve node_id={target_id} from extracted knowledge map."
+    )
 
 
 def flatten_nodes(knowledge_map: dict) -> list[dict]:
@@ -126,7 +128,9 @@ def flatten_nodes(knowledge_map: dict) -> list[dict]:
 def print_map_summary(knowledge_map: dict) -> None:
     metadata = knowledge_map.get("metadata") or {}
     print("\n== Extraction Summary ==")
-    print(f"Title: {metadata.get('source_title') or metadata.get('title') or 'unknown'}")
+    print(
+        f"Title: {metadata.get('source_title') or metadata.get('title') or 'unknown'}"
+    )
     print(f"Architecture: {metadata.get('architecture_type') or 'unknown'}")
     print(f"Difficulty: {metadata.get('difficulty') or 'unknown'}")
     print(f"Backbone count: {len(knowledge_map.get('backbone') or [])}")
@@ -195,7 +199,9 @@ def render_turn_result(result: DrillTurnResult, answer: dict | None = None) -> N
     print(result.get("agent_response") or "")
 
 
-def scripted_sequence_items(scripted_answers: list[dict], sequence: str | None) -> list[dict]:
+def scripted_sequence_items(
+    scripted_answers: list[dict], sequence: str | None
+) -> list[dict]:
     if not sequence:
         return []
     if sequence.strip().lower() == "all":
@@ -215,7 +221,9 @@ def run_fixture(args: argparse.Namespace) -> int:
     fixture_id = fixture.get("id") or Path(args.fixture).stem
     fixture_title = fixture.get("title") or fixture_id
     scripted_answers = fixture.get("scripted_answers") or []
-    concept_id = f"fixture-{fixture_id}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    concept_id = (
+        f"fixture-{fixture_id}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    )
 
     base_telemetry = {
         "run_mode": "fixture",
@@ -232,7 +240,9 @@ def run_fixture(args: argparse.Namespace) -> int:
     )
     print_map_summary(knowledge_map)
 
-    node = resolve_node(knowledge_map, args.node or fixture.get("preferred_start_node_id"))
+    node = resolve_node(
+        knowledge_map, args.node or fixture.get("preferred_start_node_id")
+    )
     print("\n== Drill Target ==")
     print(f"id: {node['id']}")
     print(f"type: {node['type']}")
@@ -265,7 +275,9 @@ def run_fixture(args: argparse.Namespace) -> int:
     )
     print("\n== Opening Prompt ==")
     print(init_result["agent_response"])
-    state["messages"].append({"role": "assistant", "content": init_result["agent_response"]})
+    state["messages"].append(
+        {"role": "assistant", "content": init_result["agent_response"]}
+    )
 
     auto_answers = scripted_sequence_items(scripted_answers, args.sequence)
     auto_index = 0
@@ -278,7 +290,9 @@ def run_fixture(args: argparse.Namespace) -> int:
             print(f"\n[auto] {chosen.get('label')}: {chosen.get('input')}")
             user_text = chosen.get("input") or ""
         else:
-            print("\nCommands: number = scripted answer, m = manual answer, l = list answers, q = quit")
+            print(
+                "\nCommands: number = scripted answer, m = manual answer, l = list answers, q = quit"
+            )
             command = input("> ").strip()
             if command.lower() == "q":
                 return 0
@@ -324,27 +338,50 @@ def run_fixture(args: argparse.Namespace) -> int:
             telemetry_context=turn_telemetry,
         )
         render_turn_result(result, chosen)
-        state["messages"].append({"role": "assistant", "content": result["agent_response"]})
+        state["messages"].append(
+            {"role": "assistant", "content": result["agent_response"]}
+        )
         state["probe_count"] = result.get("probe_count", state["probe_count"])
         state["nodes_drilled"] = result.get("nodes_drilled", state["nodes_drilled"])
-        state["attempt_turn_count"] = result.get("attempt_turn_count", state["attempt_turn_count"])
-        state["help_turn_count"] = result.get("help_turn_count", state["help_turn_count"])
+        state["attempt_turn_count"] = result.get(
+            "attempt_turn_count", state["attempt_turn_count"]
+        )
+        state["help_turn_count"] = result.get(
+            "help_turn_count", state["help_turn_count"]
+        )
 
         if result.get("routing") == "NEXT" or result.get("session_terminated"):
-            print("\nFixture drill resolved. Start the script again for a fresh sandbox run.")
+            print(
+                "\nFixture drill resolved. Start the script again for a fresh sandbox run."
+            )
             return 0
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run an internal tasting fixture in the terminal.")
-    parser.add_argument("fixture", nargs="?", default="action-potential-core", help="Fixture id or path to a fixture JSON file.")
-    parser.add_argument("--list", action="store_true", help="List available fixtures and exit.")
-    parser.add_argument("--node", help="Override the fixture's preferred start node id.")
+    parser = argparse.ArgumentParser(
+        description="Run an internal tasting fixture in the terminal."
+    )
+    parser.add_argument(
+        "fixture",
+        nargs="?",
+        default="action-potential-core",
+        help="Fixture id or path to a fixture JSON file.",
+    )
+    parser.add_argument(
+        "--list", action="store_true", help="List available fixtures and exit."
+    )
+    parser.add_argument(
+        "--node", help="Override the fixture's preferred start node id."
+    )
     parser.add_argument(
         "--sequence",
         help="Comma-separated scripted answer ids/labels to auto-run, or 'all' to replay every scripted answer.",
     )
-    parser.add_argument("--api-key", default=os.environ.get("GEMINI_API_KEY"), help="Gemini API key override.")
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("GEMINI_API_KEY"),
+        help="Gemini API key override.",
+    )
     args = parser.parse_args()
 
     if args.list:

--- a/scripts/summarize_ai_runs.py
+++ b/scripts/summarize_ai_runs.py
@@ -81,20 +81,32 @@ def extract_summary(rows: list[dict]) -> dict:
     success_rows = [row for row in rows if row.get("status") == "success"]
     error_rows = [row for row in rows if row.get("status") == "error"]
 
-    architecture = Counter(row.get("architecture_type") or "unknown" for row in success_rows)
+    architecture = Counter(
+        row.get("architecture_type") or "unknown" for row in success_rows
+    )
     difficulty = Counter(row.get("difficulty") or "unknown" for row in success_rows)
     error_types = Counter(row.get("error_type") or "unknown" for row in error_rows)
-    source_titles = Counter(row.get("source_title") or "unknown" for row in success_rows)
+    source_titles = Counter(
+        row.get("source_title") or "unknown" for row in success_rows
+    )
 
     return {
         "total_runs": len(rows),
         "success_count": len(success_rows),
         "error_count": len(error_rows),
         "success_rate": pct(len(success_rows), len(rows)),
-        "avg_duration_ms": safe_mean([row.get("duration_ms", 0) for row in success_rows]),
-        "avg_cluster_count": safe_mean([row.get("cluster_count", 0) for row in success_rows]),
-        "avg_backbone_count": safe_mean([row.get("backbone_count", 0) for row in success_rows]),
-        "avg_subnode_count": safe_mean([row.get("subnode_count", 0) for row in success_rows]),
+        "avg_duration_ms": safe_mean(
+            [row.get("duration_ms", 0) for row in success_rows]
+        ),
+        "avg_cluster_count": safe_mean(
+            [row.get("cluster_count", 0) for row in success_rows]
+        ),
+        "avg_backbone_count": safe_mean(
+            [row.get("backbone_count", 0) for row in success_rows]
+        ),
+        "avg_subnode_count": safe_mean(
+            [row.get("subnode_count", 0) for row in success_rows]
+        ),
         "low_density_rate": pct(
             sum(1 for row in success_rows if row.get("low_density") is True),
             len(success_rows),
@@ -117,32 +129,58 @@ def drill_summary(rows: list[dict]) -> dict:
     help_turns = [row for row in turn_rows if row.get("answer_mode") == "help_request"]
     classified_turns = [row for row in attempt_turns if row.get("classification")]
 
-    classification = Counter(row.get("classification") or "none" for row in classified_turns)
+    classification = Counter(
+        row.get("classification") or "none" for row in classified_turns
+    )
     routing = Counter(row.get("routing") or "none" for row in turn_rows)
     node_types = Counter(row.get("node_type") or "unknown" for row in turn_rows)
     answer_modes = Counter(row.get("answer_mode") or "none" for row in turn_rows)
-    help_request_reasons = Counter(row.get("help_request_reason") or "none" for row in help_turns)
-    response_tiers = Counter(str(row.get("response_tier")) for row in attempt_turns if row.get("response_tier") is not None)
-    response_bands = Counter(row.get("response_band") or "none" for row in attempt_turns if row.get("response_band"))
-    terminations = Counter(row.get("termination_reason") or "none" for row in success_rows if row.get("session_terminated"))
+    help_request_reasons = Counter(
+        row.get("help_request_reason") or "none" for row in help_turns
+    )
+    response_tiers = Counter(
+        str(row.get("response_tier"))
+        for row in attempt_turns
+        if row.get("response_tier") is not None
+    )
+    response_bands = Counter(
+        row.get("response_band") or "none"
+        for row in attempt_turns
+        if row.get("response_band")
+    )
+    terminations = Counter(
+        row.get("termination_reason") or "none"
+        for row in success_rows
+        if row.get("session_terminated")
+    )
     error_types = Counter(row.get("error_type") or "unknown" for row in error_rows)
     run_modes = Counter(row.get("run_mode") or "default" for row in turn_rows)
 
-    solid_turns = sum(1 for row in classified_turns if row.get("classification") == "solid")
+    solid_turns = sum(
+        1 for row in classified_turns if row.get("classification") == "solid"
+    )
     non_solid_next = sum(
         1
         for row in classified_turns
         if row.get("routing") == "NEXT" and row.get("classification") != "solid"
     )
-    force_advanced = sum(1 for row in classified_turns if row.get("force_advanced") is True)
-    attempt_force_advanced = sum(1 for row in attempt_turns if row.get("force_advanced") is True)
-    help_force_advanced = sum(1 for row in help_turns if row.get("force_advanced") is True)
+    force_advanced = sum(
+        1 for row in classified_turns if row.get("force_advanced") is True
+    )
+    attempt_force_advanced = sum(
+        1 for row in attempt_turns if row.get("force_advanced") is True
+    )
+    help_force_advanced = sum(
+        1 for row in help_turns if row.get("force_advanced") is True
+    )
     one_turn_solids = sum(
         1
         for row in classified_turns
         if row.get("classification") == "solid" and row.get("probe_count_in", 0) == 0
     )
-    reward_emitted = sum(1 for row in attempt_turns if row.get("ux_reward_emitted") is True)
+    reward_emitted = sum(
+        1 for row in attempt_turns if row.get("ux_reward_emitted") is True
+    )
 
     sessions: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
     for row in turn_rows:
@@ -155,12 +193,25 @@ def drill_summary(rows: list[dict]) -> dict:
     help_only_sessions = sum(
         1
         for session_rows in sessions.values()
-        if session_rows and all(row.get("answer_mode") == "help_request" for row in session_rows)
+        if session_rows
+        and all(row.get("answer_mode") == "help_request" for row in session_rows)
     )
 
-    by_node: dict[str, dict] = defaultdict(lambda: {"label": "", "turns": 0, "solid": 0, "misconception": 0, "force_advanced": 0})
-    by_cluster: dict[str, dict] = defaultdict(lambda: {"turns": 0, "solid": 0, "misconception": 0, "force_advanced": 0})
-    by_node_type: dict[str, dict] = defaultdict(lambda: {"turns": 0, "solid": 0, "non_solid": 0, "force_advanced": 0})
+    by_node: dict[str, dict] = defaultdict(
+        lambda: {
+            "label": "",
+            "turns": 0,
+            "solid": 0,
+            "misconception": 0,
+            "force_advanced": 0,
+        }
+    )
+    by_cluster: dict[str, dict] = defaultdict(
+        lambda: {"turns": 0, "solid": 0, "misconception": 0, "force_advanced": 0}
+    )
+    by_node_type: dict[str, dict] = defaultdict(
+        lambda: {"turns": 0, "solid": 0, "non_solid": 0, "force_advanced": 0}
+    )
 
     for row in classified_turns:
         node_id = row.get("node_id") or "unknown"
@@ -203,7 +254,13 @@ def drill_summary(rows: list[dict]) -> dict:
                 "force_advance_rate": pct(stats["force_advanced"], turns),
             }
         )
-    hotspot_nodes.sort(key=lambda row: (-row["force_advance_rate"], -row["misconception_rate"], row["solid_rate"]))
+    hotspot_nodes.sort(
+        key=lambda row: (
+            -row["force_advance_rate"],
+            -row["misconception_rate"],
+            row["solid_rate"],
+        )
+    )
 
     hotspot_clusters = []
     for cluster_id, stats in by_cluster.items():
@@ -219,7 +276,13 @@ def drill_summary(rows: list[dict]) -> dict:
                 "force_advance_rate": pct(stats["force_advanced"], turns),
             }
         )
-    hotspot_clusters.sort(key=lambda row: (-row["force_advance_rate"], -row["misconception_rate"], row["solid_rate"]))
+    hotspot_clusters.sort(
+        key=lambda row: (
+            -row["force_advance_rate"],
+            -row["misconception_rate"],
+            row["solid_rate"],
+        )
+    )
 
     node_type_benchmarks = []
     for node_type, stats in sorted(by_node_type.items()):
@@ -245,9 +308,15 @@ def drill_summary(rows: list[dict]) -> dict:
         "attempt_turn_count": len(attempt_turns),
         "help_turn_count": len(help_turns),
         "classified_turn_count": len(classified_turns),
-        "avg_duration_ms": safe_mean([row.get("duration_ms", 0) for row in success_rows]),
-        "avg_attempt_learner_chars": safe_mean([row.get("latest_learner_chars", 0) for row in attempt_turns]),
-        "avg_help_learner_chars": safe_mean([row.get("latest_learner_chars", 0) for row in help_turns]),
+        "avg_duration_ms": safe_mean(
+            [row.get("duration_ms", 0) for row in success_rows]
+        ),
+        "avg_attempt_learner_chars": safe_mean(
+            [row.get("latest_learner_chars", 0) for row in attempt_turns]
+        ),
+        "avg_help_learner_chars": safe_mean(
+            [row.get("latest_learner_chars", 0) for row in help_turns]
+        ),
         "latest_run_at": latest_timestamp(rows),
         "latest_turn_at": latest_timestamp(turn_rows),
         "latest_success_at": latest_timestamp(success_rows),
@@ -278,7 +347,9 @@ def drill_summary(rows: list[dict]) -> dict:
     }
 
 
-def recent_events(extract_rows: list[dict], drill_rows: list[dict], limit: int = 12) -> list[dict]:
+def recent_events(
+    extract_rows: list[dict], drill_rows: list[dict], limit: int = 12
+) -> list[dict]:
     events: list[dict] = []
 
     for row in extract_rows:
@@ -287,8 +358,12 @@ def recent_events(extract_rows: list[dict], drill_rows: list[dict], limit: int =
                 "timestamp": row.get("timestamp"),
                 "stage": "extract",
                 "status": row.get("status"),
-                "title": row.get("source_title") or row.get("fixture_title") or "Extraction",
-                "summary": row.get("reason") or row.get("architecture_type") or "Extraction run",
+                "title": row.get("source_title")
+                or row.get("fixture_title")
+                or "Extraction",
+                "summary": row.get("reason")
+                or row.get("architecture_type")
+                or "Extraction run",
                 "run_mode": row.get("run_mode") or "default",
                 "fixture_id": row.get("fixture_id"),
             }
@@ -335,16 +410,17 @@ def _normalize_concept_ids(concept_ids: list[str] | None) -> set[str]:
     if not concept_ids:
         return set()
     return {
-        str(concept_id).strip()
-        for concept_id in concept_ids
-        if str(concept_id).strip()
+        str(concept_id).strip() for concept_id in concept_ids if str(concept_id).strip()
     }
 
 
-def _filter_turn_rows(rows: list[dict], concept_ids: list[str] | None = None) -> list[dict]:
+def _filter_turn_rows(
+    rows: list[dict], concept_ids: list[str] | None = None
+) -> list[dict]:
     concept_filter = _normalize_concept_ids(concept_ids)
     return [
-        row for row in rows
+        row
+        for row in rows
         if row.get("status") == "success"
         and row.get("session_phase") == "turn"
         and (not concept_filter or str(row.get("concept_id") or "") in concept_filter)
@@ -358,7 +434,9 @@ def _days_between(now: datetime, timestamp: str | None) -> int | None:
     return max(int(delta.total_seconds() // 86400), 0)
 
 
-def _journal_outcome(row: dict, converted_node_ids: set[tuple[str, str]]) -> tuple[str, str]:
+def _journal_outcome(
+    row: dict, converted_node_ids: set[tuple[str, str]]
+) -> tuple[str, str]:
     concept_id = str(row.get("concept_id") or "")
     node_id = str(row.get("node_id") or "")
     key = (concept_id, node_id)
@@ -368,17 +446,28 @@ def _journal_outcome(row: dict, converted_node_ids: set[tuple[str, str]]) -> tup
     if answer_mode == "help_request":
         return ("Used scaffolding", "Try this node again from memory.")
     if classification == "solid" and key in converted_node_ids:
-        return ("Solidified on return", "Keep your momentum and take the next reachable node.")
+        return (
+            "Solidified on return",
+            "Keep your momentum and take the next reachable node.",
+        )
     if classification == "solid":
         return ("Verified understanding", "Advance to the next reachable node.")
     if classification == "misconception":
-        return ("Misconception caught", "Revisit this mechanism soon while the gap is fresh.")
+        return (
+            "Misconception caught",
+            "Revisit this mechanism soon while the gap is fresh.",
+        )
     if classification:
         return ("Still in progress", "Return for one more clean pass.")
-    return ("Activity logged", "Choose one reachable node and reconstruct it from memory.")
+    return (
+        "Activity logged",
+        "Choose one reachable node and reconstruct it from memory.",
+    )
 
 
-def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None) -> dict:
+def learner_summary(
+    drill_rows: list[dict], concept_ids: list[str] | None = None
+) -> dict:
     turn_rows = _filter_turn_rows(drill_rows, concept_ids)
     now = datetime.now(timezone.utc)
     recent_window = now - timedelta(days=14)
@@ -386,7 +475,11 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
 
     attempt_turns = [row for row in turn_rows if row.get("answer_mode") == "attempt"]
     help_turns = [row for row in turn_rows if row.get("answer_mode") == "help_request"]
-    recent_turns = [row for row in turn_rows if parse_timestamp(row.get("timestamp")) >= recent_window]
+    recent_turns = [
+        row
+        for row in turn_rows
+        if parse_timestamp(row.get("timestamp")) >= recent_window
+    ]
 
     session_keys = {
         (
@@ -396,20 +489,24 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
         )
         for row in turn_rows
     }
-    active_days = sorted({
-        parse_timestamp(row.get("timestamp")).date().isoformat()
-        for row in turn_rows
-        if row.get("timestamp")
-    })
+    active_days = sorted(
+        {
+            parse_timestamp(row.get("timestamp")).date().isoformat()
+            for row in turn_rows
+            if row.get("timestamp")
+        }
+    )
     active_days_last_7 = {
         parse_timestamp(row.get("timestamp")).date().isoformat()
         for row in turn_rows
-        if row.get("timestamp") and parse_timestamp(row.get("timestamp")) >= now - timedelta(days=7)
+        if row.get("timestamp")
+        and parse_timestamp(row.get("timestamp")) >= now - timedelta(days=7)
     }
     active_days_last_14 = {
         parse_timestamp(row.get("timestamp")).date().isoformat()
         for row in turn_rows
-        if row.get("timestamp") and parse_timestamp(row.get("timestamp")) >= recent_window
+        if row.get("timestamp")
+        and parse_timestamp(row.get("timestamp")) >= recent_window
     }
 
     node_history: dict[tuple[str, str], dict] = {}
@@ -423,7 +520,9 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
 
     for key, rows in grouped_rows.items():
         concept_id, node_id = key
-        ordered_rows = sorted(rows, key=lambda row: parse_timestamp(row.get("timestamp")))
+        ordered_rows = sorted(
+            rows, key=lambda row: parse_timestamp(row.get("timestamp"))
+        )
         history = {
             "concept_id": concept_id,
             "node_id": node_id,
@@ -458,7 +557,9 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
             history["attempt_count"] += 1
             history["last_attempt_at"] = timestamp or history["last_attempt_at"]
             classification = row.get("classification")
-            history["latest_classification"] = classification or history["latest_classification"]
+            history["latest_classification"] = (
+                classification or history["latest_classification"]
+            )
 
             if classification == "solid":
                 history["solid_count"] += 1
@@ -495,13 +596,17 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
         if stats["latest_classification"] not in (None, "solid")
         and (_days_between(now, stats["last_attempt_at"]) or 0) >= due_threshold_days
     ]
-    due_nodes.sort(key=lambda row: (-(row["days_since_attempt"] or 0), row["node_label"]))
+    due_nodes.sort(
+        key=lambda row: (-(row["days_since_attempt"] or 0), row["node_label"])
+    )
 
     conversion_history.sort(
         key=lambda row: parse_timestamp(row.get("converted_at")),
         reverse=True,
     )
-    journal_rows = sorted(turn_rows, key=lambda row: parse_timestamp(row.get("timestamp")), reverse=True)[:40]
+    journal_rows = sorted(
+        turn_rows, key=lambda row: parse_timestamp(row.get("timestamp")), reverse=True
+    )[:40]
     concept_stats: dict[str, dict] = {}
     concept_sessions: dict[str, set[tuple[str, str, str]]] = defaultdict(set)
 
@@ -528,7 +633,9 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
         )
         stats["turn_count"] += 1
         row_timestamp = row.get("timestamp")
-        if parse_timestamp(row_timestamp) > parse_timestamp(stats["latest_activity_at"]):
+        if parse_timestamp(row_timestamp) > parse_timestamp(
+            stats["latest_activity_at"]
+        ):
             stats["latest_activity_at"] = row_timestamp
         timestamp = parse_timestamp(row.get("timestamp"))
         if timestamp >= recent_window:
@@ -551,7 +658,8 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
                 sum(
                     1
                     for row in recent_turns
-                    if row.get("answer_mode") == "attempt" and row.get("classification") == "solid"
+                    if row.get("answer_mode") == "attempt"
+                    and row.get("classification") == "solid"
                 ),
                 sum(1 for row in recent_turns if row.get("answer_mode") == "attempt"),
             ),
@@ -576,14 +684,18 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
                 "timestamp": row.get("timestamp"),
                 "concept_id": row.get("concept_id"),
                 "node_id": row.get("node_id"),
-                "node_label": row.get("node_label") or row.get("node_id") or "Untitled node",
+                "node_label": row.get("node_label")
+                or row.get("node_id")
+                or "Untitled node",
                 "cluster_id": row.get("cluster_id"),
                 "classification": row.get("classification"),
                 "answer_mode": row.get("answer_mode"),
                 "help_request_reason": row.get("help_request_reason"),
                 "outcome_label": _journal_outcome(row, converted_node_ids)[0],
                 "next_action": _journal_outcome(row, converted_node_ids)[1],
-                "gap_label": row.get("classification") if row.get("classification") not in (None, "solid") else None,
+                "gap_label": row.get("classification")
+                if row.get("classification") not in (None, "solid")
+                else None,
             }
             for row in journal_rows
         ],
@@ -603,8 +715,12 @@ def learner_summary(drill_rows: list[dict], concept_ids: list[str] | None = None
                 **stats,
                 "session_count": len(concept_sessions.get(stats["concept_id"]) or []),
                 "active_days_last_14": len(stats["active_days_last_14"]),
-                "attempt_before_help_rate": pct(stats["attempt_turn_count"], stats["turn_count"]),
-                "verified_reconstruction_rate": pct(stats["solid_attempt_count"], stats["attempt_turn_count"]),
+                "attempt_before_help_rate": pct(
+                    stats["attempt_turn_count"], stats["turn_count"]
+                ),
+                "verified_reconstruction_rate": pct(
+                    stats["solid_attempt_count"], stats["attempt_turn_count"]
+                ),
             }
             for stats in sorted(
                 concept_stats.values(),
@@ -632,14 +748,22 @@ def render_markdown(extract_data: dict, drill_data: dict) -> str:
     lines.append("**AI Run Summary**")
     lines.append("")
     lines.append("**Extraction**")
-    lines.append(f"- Runs: {extract_data['total_runs']} ({extract_data['success_count']} success, {extract_data['error_count']} error, {extract_data['success_rate']:.1f}% success)")
+    lines.append(
+        f"- Runs: {extract_data['total_runs']} ({extract_data['success_count']} success, {extract_data['error_count']} error, {extract_data['success_rate']:.1f}% success)"
+    )
     lines.append(f"- Avg duration: {extract_data['avg_duration_ms']:.1f} ms")
-    lines.append(f"- Avg map size: {extract_data['avg_backbone_count']:.1f} backbone, {extract_data['avg_cluster_count']:.1f} clusters, {extract_data['avg_subnode_count']:.1f} subnodes")
+    lines.append(
+        f"- Avg map size: {extract_data['avg_backbone_count']:.1f} backbone, {extract_data['avg_cluster_count']:.1f} clusters, {extract_data['avg_subnode_count']:.1f} subnodes"
+    )
     lines.append(f"- Low-density success rate: {extract_data['low_density_rate']:.1f}%")
     if extract_data["architecture_distribution"]:
-        lines.append(f"- Architecture mix: {dict(extract_data['architecture_distribution'])}")
+        lines.append(
+            f"- Architecture mix: {dict(extract_data['architecture_distribution'])}"
+        )
     if extract_data["difficulty_distribution"]:
-        lines.append(f"- Difficulty mix: {dict(extract_data['difficulty_distribution'])}")
+        lines.append(
+            f"- Difficulty mix: {dict(extract_data['difficulty_distribution'])}"
+        )
     if extract_data["error_types"]:
         lines.append(f"- Error types: {dict(extract_data['error_types'])}")
     if extract_data["top_sources"]:
@@ -647,35 +771,59 @@ def render_markdown(extract_data: dict, drill_data: dict) -> str:
 
     lines.append("")
     lines.append("**Drill**")
-    lines.append(f"- Runs: {drill_data['total_runs']} ({drill_data['success_count']} success, {drill_data['error_count']} error, {drill_data['success_rate']:.1f}% success)")
-    lines.append(f"- Turns: {drill_data['turn_count']} ({drill_data['attempt_turn_count']} attempts, {drill_data['help_turn_count']} help requests)")
+    lines.append(
+        f"- Runs: {drill_data['total_runs']} ({drill_data['success_count']} success, {drill_data['error_count']} error, {drill_data['success_rate']:.1f}% success)"
+    )
+    lines.append(
+        f"- Turns: {drill_data['turn_count']} ({drill_data['attempt_turn_count']} attempts, {drill_data['help_turn_count']} help requests)"
+    )
     lines.append(f"- Scored attempt turns: {drill_data['classified_turn_count']}")
     lines.append(f"- Avg duration: {drill_data['avg_duration_ms']:.1f} ms")
-    lines.append(f"- Avg learner response length: {drill_data['avg_attempt_learner_chars']:.1f} chars on attempts, {drill_data['avg_help_learner_chars']:.1f} chars on help requests")
+    lines.append(
+        f"- Avg learner response length: {drill_data['avg_attempt_learner_chars']:.1f} chars on attempts, {drill_data['avg_help_learner_chars']:.1f} chars on help requests"
+    )
     lines.append(f"- Attempt rate: {drill_data['attempt_rate']:.1f}%")
     lines.append(f"- Help-request rate: {drill_data['help_request_rate']:.1f}%")
     lines.append(f"- Solid rate: {drill_data['solid_rate']:.1f}%")
     lines.append(f"- Non-solid NEXT rate: {drill_data['non_solid_next_rate']:.1f}%")
-    lines.append(f"- Force-advance rate: {drill_data['force_advance_rate']:.1f}% on scored attempts")
-    lines.append(f"- Attempt force-advance rate: {drill_data['attempt_force_advance_rate']:.1f}%")
-    lines.append(f"- Help force-advance rate: {drill_data['help_force_advance_rate']:.1f}%")
+    lines.append(
+        f"- Force-advance rate: {drill_data['force_advance_rate']:.1f}% on scored attempts"
+    )
+    lines.append(
+        f"- Attempt force-advance rate: {drill_data['attempt_force_advance_rate']:.1f}%"
+    )
+    lines.append(
+        f"- Help force-advance rate: {drill_data['help_force_advance_rate']:.1f}%"
+    )
     lines.append(f"- One-turn solid rate: {drill_data['one_turn_solid_rate']:.1f}%")
-    lines.append(f"- Reward emit rate: {drill_data['reward_emit_rate']:.1f}% of attempts")
+    lines.append(
+        f"- Reward emit rate: {drill_data['reward_emit_rate']:.1f}% of attempts"
+    )
     lines.append(f"- Help-only sessions: {drill_data['help_only_session_count']}")
     if drill_data["classification_distribution"]:
-        lines.append(f"- Classification mix: {dict(drill_data['classification_distribution'])}")
+        lines.append(
+            f"- Classification mix: {dict(drill_data['classification_distribution'])}"
+        )
     if drill_data["routing_distribution"]:
         lines.append(f"- Routing mix: {dict(drill_data['routing_distribution'])}")
     if drill_data["node_type_distribution"]:
         lines.append(f"- Node-type mix: {dict(drill_data['node_type_distribution'])}")
     if drill_data["answer_mode_distribution"]:
-        lines.append(f"- Answer-mode mix: {dict(drill_data['answer_mode_distribution'])}")
+        lines.append(
+            f"- Answer-mode mix: {dict(drill_data['answer_mode_distribution'])}"
+        )
     if drill_data["help_request_reason_distribution"]:
-        lines.append(f"- Help-request reasons: {dict(drill_data['help_request_reason_distribution'])}")
+        lines.append(
+            f"- Help-request reasons: {dict(drill_data['help_request_reason_distribution'])}"
+        )
     if drill_data["response_tier_distribution"]:
-        lines.append(f"- Response-tier mix: {dict(drill_data['response_tier_distribution'])}")
+        lines.append(
+            f"- Response-tier mix: {dict(drill_data['response_tier_distribution'])}"
+        )
     if drill_data["response_band_distribution"]:
-        lines.append(f"- Response-band mix: {dict(drill_data['response_band_distribution'])}")
+        lines.append(
+            f"- Response-band mix: {dict(drill_data['response_band_distribution'])}"
+        )
     if drill_data["termination_distribution"]:
         lines.append(f"- Terminations: {dict(drill_data['termination_distribution'])}")
     if drill_data["error_types"]:
@@ -713,8 +861,14 @@ def render_markdown(extract_data: dict, drill_data: dict) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Summarize extraction and drill telemetry logs.")
-    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of markdown.")
+    parser = argparse.ArgumentParser(
+        description="Summarize extraction and drill telemetry logs."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of markdown.",
+    )
     args = parser.parse_args()
 
     payload = build_summary_payload()

--- a/tests/test_auth_gate.py
+++ b/tests/test_auth_gate.py
@@ -49,7 +49,9 @@ class AuthGateTests(unittest.TestCase):
         response = client.get("/ai-runs-dashboard.html", follow_redirects=False)
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.headers["location"], "/login?return_to=%2Fai-runs-dashboard.html")
+        self.assertEqual(
+            response.headers["location"], "/login?return_to=%2Fai-runs-dashboard.html"
+        )
 
     def test_core_api_requires_guest_or_auth_entry(self):
         client = self.build_client(FakeAuthService(enabled=True))

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -28,14 +28,18 @@ class FakeAuthService:
             sealed_session="sealed-abc",
         )
 
-    def get_login_url(self, *, base_url: str, return_to: str | None = None, provider: str = "authkit") -> str:
+    def get_login_url(
+        self, *, base_url: str, return_to: str | None = None, provider: str = "authkit"
+    ) -> str:
         self.last_return_to = return_to
         self.last_provider = provider
         if not self.enabled:
             raise RuntimeError("disabled")
         return "https://auth.example/login"
 
-    def exchange_code(self, *, code: str, ip_address: str | None = None, user_agent: str | None = None):
+    def exchange_code(
+        self, *, code: str, ip_address: str | None = None, user_agent: str | None = None
+    ):
         return self.callback_state
 
     def load_session(self, sealed_session: str | None):
@@ -75,7 +79,9 @@ class AuthRouterTests(unittest.TestCase):
 
     def test_api_me_returns_anonymous_when_auth_disabled(self):
         service = FakeAuthService(enabled=False)
-        service.current_state = AuthSessionState(auth_enabled=False, authenticated=False)
+        service.current_state = AuthSessionState(
+            auth_enabled=False, authenticated=False
+        )
         client = build_client(service)
 
         response = client.get("/api/me")
@@ -83,21 +89,30 @@ class AuthRouterTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {"auth_enabled": False, "authenticated": False, "guest_mode": False, "user": None},
+            {
+                "auth_enabled": False,
+                "authenticated": False,
+                "guest_mode": False,
+                "user": None,
+            },
         )
 
     def test_login_redirect_uses_sanitized_return_path(self):
         service = FakeAuthService(enabled=True)
         client = build_client(service)
 
-        response = client.get("/auth/google?return_to=https://evil.test", follow_redirects=False)
+        response = client.get(
+            "/auth/google?return_to=https://evil.test", follow_redirects=False
+        )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers["location"], "https://auth.example/login")
         self.assertEqual(service.last_return_to, "nonce-123")
         self.assertEqual(service.last_provider, "GoogleOAuth")
         self.assertEqual(service.last_built_oauth_state, "/")
-        self.assertIn("wos_oauth_state=signed-state-token", response.headers.get("set-cookie", ""))
+        self.assertIn(
+            "wos_oauth_state=signed-state-token", response.headers.get("set-cookie", "")
+        )
 
     def test_login_page_renders_html(self):
         service = FakeAuthService(enabled=True)
@@ -150,7 +165,10 @@ class AuthRouterTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/login?return_to=%2Flibrary&auth_error=access_denied", response.headers["location"])
+        self.assertIn(
+            "/login?return_to=%2Flibrary&auth_error=access_denied",
+            response.headers["location"],
+        )
 
     def test_callback_invalid_state_redirects_back_to_login(self):
         service = FakeAuthService(enabled=True)
@@ -164,7 +182,10 @@ class AuthRouterTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/login?return_to=%2F&auth_error=invalid_state", response.headers["location"])
+        self.assertIn(
+            "/login?return_to=%2F&auth_error=invalid_state",
+            response.headers["location"],
+        )
 
     def test_logout_clears_cookie(self):
         service = FakeAuthService(enabled=True)
@@ -190,7 +211,12 @@ class AuthRouterTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {"auth_enabled": True, "authenticated": False, "guest_mode": True, "user": None},
+            {
+                "auth_enabled": True,
+                "authenticated": False,
+                "guest_mode": True,
+                "user": None,
+            },
         )
 
     def test_login_redirects_guest_sessions_back_into_app(self):
@@ -211,7 +237,9 @@ class AuthRouterTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers["location"], "/library")
-        self.assertIn(f"{GUEST_COOKIE_NAME}=guest", response.headers.get("set-cookie", ""))
+        self.assertIn(
+            f"{GUEST_COOKIE_NAME}=guest", response.headers.get("set-cookie", "")
+        )
 
     def test_magic_auth_send_is_disabled(self):
         service = FakeAuthService(enabled=True)

--- a/tests/test_repair_reps.py
+++ b/tests/test_repair_reps.py
@@ -171,11 +171,18 @@ class RepairRepsApiTests(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("measured temperature to the setpoint", captured["node_mechanism"])
+        self.assertIn(
+            "measured temperature to the setpoint", captured["node_mechanism"]
+        )
         payload = response.json()
         self.assertEqual(payload["prompt_version"], "repair-reps-system-v1")
         self.assertEqual(len(payload["reps"]), 3)
-        for forbidden_field in ("routing", "classification", "score_eligible", "graph_mutated"):
+        for forbidden_field in (
+            "routing",
+            "classification",
+            "score_eligible",
+            "graph_mutated",
+        ):
             self.assertNotIn(forbidden_field, payload)
 
     def test_repair_reps_endpoint_rejects_unknown_node_id(self):
@@ -195,13 +202,20 @@ class RepairRepsApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("Unknown node_id", response.json()["detail"])
 
-    def test_repair_reps_endpoint_returns_controlled_error_for_malformed_ai_output(self):
+    def test_repair_reps_endpoint_returns_controlled_error_for_malformed_ai_output(
+        self,
+    ):
         client = self.build_client()
 
-        with patch(
-            "main.generate_repair_reps",
-            side_effect=ValueError("Repair reps response must include exactly 3 reps."),
-        ), patch("main.logger.exception"):
+        with (
+            patch(
+                "main.generate_repair_reps",
+                side_effect=ValueError(
+                    "Repair reps response must include exactly 3 reps."
+                ),
+            ),
+            patch("main.logger.exception"),
+        ):
             response = client.post(
                 "/api/repair-reps",
                 json={
@@ -214,12 +228,17 @@ class RepairRepsApiTests(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 502)
-        self.assertEqual(response.json()["detail"], "Repair Reps generation failed. Please retry.")
+        self.assertEqual(
+            response.json()["detail"], "Repair Reps generation failed. Please retry."
+        )
 
     def test_generate_repair_reps_returns_exact_three_graph_neutral_reps(self):
-        with patch("ai_service._get_client", return_value=object()), patch(
-            "ai_service._call_gemini_with_retry",
-            return_value=FakeResponse(valid_repair_reps()),
+        with (
+            patch("ai_service._get_client", return_value=object()),
+            patch(
+                "ai_service._call_gemini_with_retry",
+                return_value=FakeResponse(valid_repair_reps()),
+            ),
         ):
             result = ai_service.generate_repair_reps(
                 knowledge_map=sample_knowledge_map(),
@@ -232,7 +251,12 @@ class RepairRepsApiTests(unittest.TestCase):
 
         self.assertEqual(result["prompt_version"], "repair-reps-system-v1")
         self.assertEqual(len(result["reps"]), 3)
-        for forbidden_field in ("routing", "classification", "score_eligible", "graph_mutated"):
+        for forbidden_field in (
+            "routing",
+            "classification",
+            "score_eligible",
+            "graph_mutated",
+        ):
             self.assertNotIn(forbidden_field, result)
 
     def test_repair_reps_gemini_schema_omits_unsupported_extra_forbid_keyword(self):
@@ -246,11 +270,16 @@ class RepairRepsApiTests(unittest.TestCase):
         payload["routing"] = "NEXT"
         payload["reps"][0]["score_eligible"] = True
 
-        with patch("ai_service._get_client", return_value=object()), patch(
-            "ai_service._call_gemini_with_retry",
-            return_value=FakeResponse(None, text=json.dumps(payload)),
+        with (
+            patch("ai_service._get_client", return_value=object()),
+            patch(
+                "ai_service._call_gemini_with_retry",
+                return_value=FakeResponse(None, text=json.dumps(payload)),
+            ),
         ):
-            with self.assertRaisesRegex(ValueError, "invalid structured repair reps response"):
+            with self.assertRaisesRegex(
+                ValueError, "invalid structured repair reps response"
+            ):
                 ai_service.generate_repair_reps(
                     knowledge_map=sample_knowledge_map(),
                     concept_id="thermostat",
@@ -265,9 +294,12 @@ class RepairRepsApiTests(unittest.TestCase):
             reps=valid_repair_reps().reps[:2]
         )
 
-        with patch("ai_service._get_client", return_value=object()), patch(
-            "ai_service._call_gemini_with_retry",
-            return_value=FakeResponse(undersized),
+        with (
+            patch("ai_service._get_client", return_value=object()),
+            patch(
+                "ai_service._call_gemini_with_retry",
+                return_value=FakeResponse(undersized),
+            ),
         ):
             with self.assertRaisesRegex(ValueError, "exactly 3 reps"):
                 ai_service.generate_repair_reps(

--- a/tests/test_url_import.py
+++ b/tests/test_url_import.py
@@ -61,7 +61,9 @@ class UrlImportTests(unittest.TestCase):
     def test_extract_url_blocks_youtube_hosts(self):
         client = self.build_client()
 
-        response = client.post("/api/extract-url", json={"url": "https://www.youtube.com/watch?v=abc123"})
+        response = client.post(
+            "/api/extract-url", json={"url": "https://www.youtube.com/watch?v=abc123"}
+        )
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -82,11 +84,16 @@ class UrlImportTests(unittest.TestCase):
         </html>
         """
 
-        with patch("main._is_private_url", return_value=False), patch(
-            "main.urlopen",
-            return_value=FakeUrlResponse(fake_html),
+        with (
+            patch("main._is_private_url", return_value=False),
+            patch(
+                "main.urlopen",
+                return_value=FakeUrlResponse(fake_html),
+            ),
         ):
-            response = client.post("/api/extract-url", json={"url": "https://notyoutube.com/article"})
+            response = client.post(
+                "/api/extract-url", json={"url": "https://notyoutube.com/article"}
+            )
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()


### PR DESCRIPTION
## Summary

Catch-up PR from `dev` to `main` spanning three concurrent threads of work:

- **Design system polish** — normalize buttons, cards, typography, sidebar, and dark-mode tokens. Layout fixes for the concept map view (app-bar + header zones, hamburger stacking, theme toggle survives map-open fade).
- **GSD planning scaffolding** — first-time introduction of `.planning/` structural artifacts (`PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `STATE.md`) so subsequent work can flow through the GSD loop. Transient phase artifacts excluded from this PR.
- **Backend/auth cleanup (wip)** — substantial refactors in `ai_service.py` (797-line diff), `main.py`, `auth/service.py`, `auth/router.py`, plus test updates across `test_auth_*`, `test_repair_reps`, `test_url_import`. Analytics script (`summarize_ai_runs.py`) and fixture runner updated. New `UX-todo.md` surface and Socratink Brain wiki script touch-ups.

Stat: **25 files, +2206/−777**.

## Changes

### Frontend / UI
- `public/css/**` (base, components, layout, variables, ai-runs-dashboard) — design system normalization
- `public/index.html`, `public/js/app.js` — concept map view restructure

### Backend
- `ai_service.py` — major refactor (+493 / −304 net)
- `main.py`, `api/index.py`, `auth/router.py`, `auth/service.py` — auth + route adjustments
- `scripts/run_tasting_fixture.py`, `scripts/summarize_ai_runs.py` — analytics improvements

### Tests
- `tests/test_auth_gate.py`, `tests/test_auth_router.py`, `tests/test_repair_reps.py`, `tests/test_url_import.py`

### Planning / tooling
- `.planning/PROJECT.md`, `.planning/REQUIREMENTS.md`, `.planning/ROADMAP.md`, `.planning/STATE.md` — GSD structural scaffolding
- `.agents/skills/socratink-brain/scripts/{validate_wiki,wiki_stats}.py` — KB tooling
- `UX-todo.md` — surfaced UX backlog

## Verification

- [ ] `pytest tests/` passes locally
- [ ] `uvicorn main:app --reload` boots without errors
- [ ] Auth flow (`/api/me`, login, logout) works end-to-end
- [ ] Extract + drill happy path on a starter topic
- [ ] Design system polish looks right in light + dark mode
- [ ] Concept map view header/hamburger/theme toggle behave correctly

## Notes

- This PR is the output of a reconciliation (`/reconcile` → `/gsd-pr-branch` → `/gsd-ship`). Transient `.planning/phases/` artifacts were stripped from the diff; they stay local on `dev`.
- The `a208d0b` backend wip commit is labeled **wip** because it predates a formal verification pass. CI + manual test plan above should cover before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)