### PR TITLE
fix: restore Vercel ASGI entrypoint

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -4,3 +4,5 @@ from pathlib import Path
 # Ensure the project root is on the Python path so `main` can be imported
 # regardless of how Vercel sets up the function's working directory.
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from main import app  # noqa: E402


### PR DESCRIPTION
## Context & Intent
- Fixes the active Vercel production and PR deployment failure where `vercel.json` configures `api/index.py` as the Python function but the module no longer exposes a discoverable ASGI app.
- This stems from MVP stabilization / deployment repair after PR #28 removed the entrypoint export while leaving the Vercel function config unchanged.

## Implementation Details
- Re-export `main.app` from `api/index.py` after the existing project-root `sys.path` setup.
- Keeps the existing FastAPI + Vercel serverless architecture unchanged.
- No frontend, auth, routing, or drill behavior changes.

## MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [x] Are there SSRF or error leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

Notes:
- This is a deployment discovery fix, not a new runtime path.
- No new external calls are introduced.
- Verified locally with `TestClient(api.index.app).get("/api/health") == 200` and focused pytest suite: `32 passed`.

## UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Not applicable: no UI/drill behavior changed.