### PR TITLE
fix: restore Vercel ASGI entrypoint on main

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -4,3 +4,5 @@ from pathlib import Path
 # Ensure the project root is on the Python path so `main` can be imported
 # regardless of how Vercel sets up the function's working directory.
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from main import app as app  # noqa: E402, F401


### PR DESCRIPTION
## Summary
- Main HEAD (`dba4218`) fails Vercel build: `api/index.py` pattern matches no Serverless Function because `app` symbol was stripped.
- Dev has fix `435a0a7` — `from main import app as app` with `noqa: E402, F401` so ruff won't auto-strip the re-export.
- Production currently stale on `cea8bea` (PR #29). This PR clears the runway.

## Test plan
- [ ] Vercel preview build on this PR reports READY
- [ ] After merge, production deploy on main HEAD reports READY
- [ ] `/api/health` returns 200 on production alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)