### PR TITLE
feat(repair-reps): Slice B — metacognitive loop

### DIFF
--- a/docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md
+++ b/docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md
@@ -1,0 +1,1214 @@
+# Repair Reps Slice B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task with verification-before-completion at each step. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add pre-reveal confidence pill, soft reveal gate enforced inside `revealRepairRep()`, single-click lock-and-reveal with per-rep lock-duration tracking, and a completion-summary calibration readout (observational only).
+
+**Architecture:** Frontend + localStorage only. Three source files touched (`public/js/app.js`, `public/js/graph-view.js`, `public/css/layout.css`) plus cache-bust bumps in `public/index.html`, `public/js/app.js` line 4, and `public/js/learner-analytics.js` line 2. State shape is additive, storage schema is additive, and old records read cleanly. No backend, no prompts, no graph-state mutation.
+
+**Tech Stack:** Vanilla JS (ES modules, no build step), Cytoscape-driven graph view, FastAPI backend (untouched), localStorage persistence.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md`
+
+---
+
+## Pre-flight context (read before starting)
+
+1. **`setRepairRepsState` (app.js:2479) is pure assignment** — every call triggers `setInteractionMode('repair-reps', ...)` → `renderCurrentDetail()` → `detailEl.innerHTML = ...`. The textarea is torn down and rebuilt on every dispatch. **Do not dispatch state on every keystroke** — it destroys caret position. The spec's draft-preservation invariant is satisfied by reading the live textarea value at pill-click time (the re-render trigger), not per-keystroke. The textarea `input` listener stays DOM-local (toggle button `disabled` only).
+
+2. **Existing state callers build from scratch in three places** (`startRepairReps` at 2703, 2749, 2769) and **spread-update in others** (`revealRepairRep` 2796, `rateRepairRep` 2813, `nextRepairRep` 2836+2846). Every scratch-build instance must list the new fields. Spread-updates inherit them.
+
+3. **Existing `typedAnswer` render logic** (graph-view.js:623) currently renders `currentAnswer` **only in revealed state**. Pre-reveal renders empty. **Change to render in both states** so draft survives pill re-renders.
+
+4. **`learnops_repair_reps_v1` is not read by `learner-analytics.js`** — grep confirms it only appears in `app.js`. Additive schema is safe.
+
+5. **Wave 1 semantic tokens confirmed present** in `public/css/variables.css`: `--surface-card`, `--text-strong`, `--text-muted`, `--accent-primary`, `--accent-soft`, `--accent-border-strong`, `--border-subtle`, `--accent-ring`, `--radius-pill`, `--duration-micro`. Use these — skip deprecated aliases (`--bg`, `--card-bg`, `--text`, `--primary`, `--border`, `--text-sub`).
+
+6. **Cache-bust discipline** (every commit touching JS or CSS):
+   - `public/index.html:25` — bump `styles.css?v=N` when any CSS file changes.
+   - `public/index.html:495` — bump `js/app.js?v=N` when `app.js` changes.
+   - `public/js/app.js:4` — bump `./graph-view.js?v=N` when `graph-view.js` changes.
+   - `public/js/learner-analytics.js:2` — bump `./graph-view.js?v=N` in lockstep with app.js. If one bumps and the other doesn't, `learner-analytics` holds a stale module reference.
+
+7. **Commit message format (Wave 1 convention):**
+   ```
+   <type>(<scope>): <short summary>
+
+   <body>
+
+   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   ```
+
+---
+
+## File Map
+
+| File | Responsibility | Touched in steps |
+|------|---------------|-----------------|
+| `public/js/app.js` | State shape, reducer, reveal gate, completion storage write, `window.SocratinkApp` export | Steps 1, 5 |
+| `public/js/graph-view.js` | Markup helpers + listener binding in `renderCurrentDetail()` | Steps 2, 3 |
+| `public/css/layout.css` | Pill/calibration CSS rules | Step 4 |
+| `public/index.html` | `styles.css?v=N` + `js/app.js?v=N` cache-bust | Each step that touches the corresponding file |
+| `public/js/learner-analytics.js` | `graph-view.js?v=N` cache-bust (lockstep with app.js line 4) | Steps 2, 3 |
+| `docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md` | This plan | Step 0 |
+
+---
+
+## Task 0: Commit this plan
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md`
+
+- [ ] **Step 0.1: Stage and commit the plan file**
+
+```bash
+git add docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md
+git commit -m "$(cat <<'EOF'
+docs(plan): Repair Reps Slice B implementation plan
+
+Step-by-step plan for pre-reveal confidence pill, soft reveal gate
+inside revealRepairRep(), lock-and-reveal with per-rep lock duration,
+and completion calibration summary. No backend or prompt changes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: one commit, clean tree.
+
+---
+
+## Task 1: app.js reducer + state + reveal gate + predict export
+
+**Files:**
+- Modify: `public/js/app.js:2479-2482` (setRepairRepsState — no change; just verify)
+- Modify: `public/js/app.js:2703-2720` (startRepairReps loading state init)
+- Modify: `public/js/app.js:2749-2766` (startRepairReps ready state init)
+- Modify: `public/js/app.js:2769-2786` (startRepairReps error state init)
+- Modify: `public/js/app.js:2790-2805` (revealRepairRep preconditions + body)
+- Modify: `public/js/app.js:2822-2855` (nextRepairRep reset + restamp + complete)
+- Modify: `public/js/app.js` near line 2790 (add setRepairRepPreConfidence function)
+- Modify: `public/js/app.js:3990-3995` (add to export list)
+- Modify: `public/index.html:495` (cache-bust bump)
+
+### Step 1.1 — Define pre-confidence enum constant
+
+- [ ] **Add the enum constant above `REPAIR_REP_RATING_VALUES` (currently line 2437)**
+
+Locate in `public/js/app.js`:
+```js
+  const REPAIR_REP_RATING_VALUES = new Set(['close_match', 'partial', 'missed']);
+```
+
+Replace with:
+```js
+  const REPAIR_REP_PRE_CONFIDENCE_VALUES = new Set(['guessing', 'hunch', 'can_explain']);
+  const REPAIR_REP_RATING_VALUES = new Set(['close_match', 'partial', 'missed']);
+```
+
+### Step 1.2 — Extend `startRepairReps` loading state
+
+- [ ] **Replace the `setRepairRepsState({ status: 'loading', ...})` block at lines 2703-2720**
+
+```js
+    setRepairRepsState({
+      status: 'loading',
+      conceptId: concept.id,
+      nodeId: nodeContext.id,
+      nodeLabel,
+      gapType: nodeData.gap_type || null,
+      promptVersion: null,
+      reps: [],
+      currentIndex: 0,
+      revealed: false,
+      currentAnswer: '',
+      answerLengths: [],
+      ratings: [],
+      ratingSelected: false,
+      isDealing: false,
+      isRevealing: false,
+      error: null,
+      currentPreConfidence: null,
+      repStartedAt: null,
+      lockedAt: null,
+      preConfidences: [],
+      lockDurationsMs: [],
+    });
+```
+
+### Step 1.3 — Extend `startRepairReps` ready state (stamp repStartedAt for rep 1)
+
+- [ ] **Replace the `setRepairRepsState({ status: 'ready', ...})` block at lines 2749-2766**
+
+```js
+      setRepairRepsState({
+        status: 'ready',
+        conceptId: concept.id,
+        nodeId: nodeContext.id,
+        nodeLabel,
+        gapType: nodeData.gap_type || null,
+        promptVersion: payload.prompt_version || 'repair-reps-system-v1',
+        reps,
+        currentIndex: 0,
+        revealed: false,
+        currentAnswer: '',
+        answerLengths: [],
+        ratings: [],
+        ratingSelected: false,
+        isDealing: true,
+        isRevealing: false,
+        error: null,
+        currentPreConfidence: null,
+        repStartedAt: Date.now(),
+        lockedAt: null,
+        preConfidences: [],
+        lockDurationsMs: [],
+      });
+```
+
+### Step 1.4 — Extend `startRepairReps` error state
+
+- [ ] **Replace the `setRepairRepsState({ status: 'error', ...})` block at lines 2769-2786**
+
+```js
+      setRepairRepsState({
+        status: 'error',
+        conceptId: concept.id,
+        nodeId: nodeContext.id,
+        nodeLabel,
+        gapType: nodeData.gap_type || null,
+        promptVersion: null,
+        reps: [],
+        currentIndex: 0,
+        revealed: false,
+        currentAnswer: '',
+        answerLengths: [],
+        ratings: [],
+        ratingSelected: false,
+        isDealing: false,
+        isRevealing: false,
+        error: 'Repair Reps could not load. Reopen study and try again later.',
+        currentPreConfidence: null,
+        repStartedAt: null,
+        lockedAt: null,
+        preConfidences: [],
+        lockDurationsMs: [],
+      });
+```
+
+### Step 1.5 — Replace `revealRepairRep` with idempotent, pre-confidence-gated version
+
+- [ ] **Replace the entire `revealRepairRep` function (lines 2790-2805)**
+
+```js
+  function revealRepairRep(answerText = '') {
+    if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    // Idempotency: second call on the same rep is a no-op so lockedAt,
+    // preConfidences, and lockDurationsMs are written exactly once.
+    if (repairRepsState.revealed === true) return;
+    const answer = String(answerText || '').trim();
+    if (!answer) return;
+    if (!REPAIR_REP_PRE_CONFIDENCE_VALUES.has(repairRepsState.currentPreConfidence)) return;
+
+    const currentIndex = repairRepsState.currentIndex || 0;
+    const lockedAt = Date.now();
+    const repStartedAt = Number.isFinite(repairRepsState.repStartedAt)
+      ? repairRepsState.repStartedAt
+      : lockedAt;
+    const lockDuration = Math.max(0, lockedAt - repStartedAt);
+
+    const answerLengths = [...(repairRepsState.answerLengths || [])];
+    answerLengths[currentIndex] = answer.length;
+    const preConfidences = [...(repairRepsState.preConfidences || []), repairRepsState.currentPreConfidence];
+    const lockDurationsMs = [...(repairRepsState.lockDurationsMs || []), lockDuration];
+
+    setRepairRepsState({
+      ...repairRepsState,
+      revealed: true,
+      currentAnswer: answer,
+      answerLengths,
+      preConfidences,
+      lockDurationsMs,
+      lockedAt,
+      ratingSelected: Boolean(repairRepsState.ratings?.[currentIndex]),
+      isDealing: false,
+      isRevealing: true,
+    });
+  }
+```
+
+### Step 1.6 — Add `setRepairRepPreConfidence` handler
+
+- [ ] **Insert new function immediately after `revealRepairRep` (before `rateRepairRep`)**
+
+```js
+  function setRepairRepPreConfidence(value) {
+    if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    // Pill is frozen post-reveal. UI also suppresses via aria-disabled + pointer-events,
+    // but gate here so direct JS calls cannot mutate the locked-in stance.
+    if (repairRepsState.revealed === true) return;
+    if (!REPAIR_REP_PRE_CONFIDENCE_VALUES.has(value)) return;
+    setRepairRepsState({
+      ...repairRepsState,
+      currentPreConfidence: value,
+    });
+  }
+```
+
+Note: `currentAnswer` preservation on pill click happens at the listener site in graph-view.js (it reads the live textarea value and passes it as part of a broader state update when needed). This handler is kept narrow: it only mutates `currentPreConfidence`. The render loop picks up the new pill highlight and re-renders the textarea from `state.currentAnswer`.
+
+To make that work, the pill-click listener in graph-view.js (Task 3) will first write the live textarea value to `currentAnswer` by calling a sibling helper — see Step 1.6b.
+
+### Step 1.6b — Add `setRepairRepDraft` helper (used by pill listener to preserve draft)
+
+- [ ] **Insert new function immediately after `setRepairRepPreConfidence`**
+
+```js
+  function setRepairRepDraft(value) {
+    if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    if (repairRepsState.revealed === true) return;
+    setRepairRepsState({
+      ...repairRepsState,
+      currentAnswer: typeof value === 'string' ? value : '',
+    });
+  }
+```
+
+This helper is called by the pill-click listener **before** `setRepairRepPreConfidence`, so the draft is stamped into state first and the re-render renders it back into the textarea. The textarea `input` listener does **not** call this — it stays DOM-local to avoid caret thrash on every keystroke.
+
+### Step 1.7 — Extend `nextRepairRep` — reset per-rep fields + restamp `repStartedAt`
+
+- [ ] **Replace the entire `nextRepairRep` function (lines 2822-2855)**
+
+```js
+  function nextRepairRep() {
+    if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    if (!repairRepsState.revealed || !repairRepsState.ratingSelected) return;
+    const nextIndex = (repairRepsState.currentIndex || 0) + 1;
+    if (nextIndex >= (repairRepsState.reps || []).length) {
+      recordRepairRepsCompletion({
+        conceptId: repairRepsState.conceptId,
+        nodeId: repairRepsState.nodeId,
+        repCount: repairRepsState.reps.length,
+        promptVersion: repairRepsState.promptVersion,
+        gapType: repairRepsState.gapType,
+        answerLengths: repairRepsState.answerLengths,
+        ratings: repairRepsState.ratings,
+        preConfidences: repairRepsState.preConfidences,
+        lockDurationsMs: repairRepsState.lockDurationsMs,
+      });
+      setRepairRepsState({
+        ...repairRepsState,
+        status: 'complete',
+        revealed: true,
+        isDealing: false,
+        isRevealing: false,
+      });
+      return;
+    }
+
+    setRepairRepsState({
+      ...repairRepsState,
+      currentIndex: nextIndex,
+      revealed: false,
+      currentAnswer: '',
+      ratingSelected: false,
+      isDealing: true,
+      isRevealing: false,
+      currentPreConfidence: null,
+      lockedAt: null,
+      repStartedAt: Date.now(),
+    });
+  }
+```
+
+Note: Task 5 extends `recordRepairRepsCompletion` to accept the two new named arguments. The spread order above (`preConfidences`, `lockDurationsMs`) matches Task 5's signature.
+
+### Step 1.8 — Add exports to `window.SocratinkApp`
+
+- [ ] **Extend the export block at lines 3990-3995**
+
+Find:
+```js
+    startRepairReps,
+    getRepairRepsState,
+    revealRepairRep,
+    rateRepairRep,
+    nextRepairRep,
+    exitRepairReps,
+```
+
+Replace with:
+```js
+    startRepairReps,
+    getRepairRepsState,
+    revealRepairRep,
+    rateRepairRep,
+    nextRepairRep,
+    exitRepairReps,
+    setRepairRepPreConfidence,
+    setRepairRepDraft,
+```
+
+### Step 1.9 — Bump `js/app.js` cache-bust
+
+- [ ] **Edit `public/index.html:495`**
+
+Find:
+```html
+  <script type="module" src="js/app.js?v=27"></script>
+```
+
+Replace with:
+```html
+  <script type="module" src="js/app.js?v=28"></script>
+```
+
+### Step 1.10 — Node syntax check
+
+- [ ] **Run `node --check` on both JS files**
+
+Run:
+```bash
+node --check public/js/app.js
+node --check public/js/graph-view.js
+```
+
+Expected: both silent (no output = pass). Any parse error blocks progress; fix before continuing.
+
+### Step 1.11 — Commit
+
+- [ ] **Stage and commit**
+
+```bash
+git add public/js/app.js public/index.html
+git commit -m "$(cat <<'EOF'
+feat(repair-reps): Slice B reducer — per-rep pre-confidence + lock timing
+
+- Add REPAIR_REP_PRE_CONFIDENCE_VALUES enum (guessing/hunch/can_explain).
+- Extend startRepairReps loading/ready/error state init with
+  currentPreConfidence, repStartedAt, lockedAt, preConfidences,
+  lockDurationsMs. Stamp repStartedAt for rep 1 in ready state.
+- Rewrite revealRepairRep with idempotency guard (no-op if already
+  revealed), empty-answer guard, and pre-confidence enum guard.
+  Compute lockedAt - repStartedAt and push to per-rep arrays.
+- Add setRepairRepPreConfidence(value) + setRepairRepDraft(value)
+  handlers, both frozen post-reveal. Export on window.SocratinkApp.
+- Extend nextRepairRep to reset currentPreConfidence/lockedAt and
+  re-stamp repStartedAt for subsequent reps. Forward preConfidences
+  and lockDurationsMs into recordRepairRepsCompletion.
+- Bump js/app.js?v=27 -> v=28.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: one new commit. `git status` clean.
+
+---
+
+## Task 2: graph-view.js markup helpers + ready/revealed/complete rendering
+
+**Files:**
+- Modify: `public/js/graph-view.js:553-654` (repairRepsMarkupForNode — ready block around lines 609-653 plus complete block 582-607)
+- Modify: `public/js/graph-view.js` (add two new pure helpers immediately before `repairRepsMarkupForNode`)
+- Modify: `public/js/app.js:4` (bump graph-view.js?v=3 -> v=4)
+- Modify: `public/js/learner-analytics.js:2` (bump graph-view.js?v=3 -> v=4 in lockstep)
+
+### Step 2.1 — Add label-map constants + two pure helpers
+
+- [ ] **Insert above `function repairRepsMarkupForNode` (line 553) in `public/js/graph-view.js`**
+
+```js
+const REPAIR_PRE_CONFIDENCE_LABELS = {
+  guessing: 'Guessing',
+  hunch: 'Have a hunch',
+  can_explain: 'Can explain',
+};
+
+const REPAIR_RATING_SUMMARY_LABELS = {
+  close_match: 'Close match',
+  partial: 'Partly linked',
+  missed: 'Missed the link',
+};
+
+function repairPredictPillsMarkup(currentPreConfidence, isLocked) {
+  const selected = typeof currentPreConfidence === 'string' ? currentPreConfidence : '';
+  const lockedAttr = isLocked ? ' aria-disabled="true"' : '';
+  const lockedClass = isLocked ? ' is-locked' : '';
+  const pill = (value, label) => {
+    const checked = selected === value ? 'true' : 'false';
+    const selClass = selected === value ? ' is-selected' : '';
+    return `<button type="button" class="graph-repair-predict-pill trigger-repair-predict${selClass}" data-pre="${value}" role="radio" aria-checked="${checked}">${label}</button>`;
+  };
+  return `
+    <div class="graph-repair-predict">
+      <div class="graph-detail-kicker">Before you peek</div>
+      <div class="graph-repair-predict-group${lockedClass}" role="radiogroup" aria-label="Confidence before revealing reference"${lockedAttr}>
+        ${pill('guessing', 'Guessing')}
+        ${pill('hunch', 'Have a hunch')}
+        ${pill('can_explain', 'Can explain')}
+      </div>
+    </div>
+  `;
+}
+
+function repairCalibrationSummaryMarkup(preConfidences, ratings) {
+  const preList = Array.isArray(preConfidences) ? preConfidences : [];
+  const rateList = Array.isArray(ratings) ? ratings : [];
+  const rowCount = Math.min(preList.length, rateList.length);
+  if (rowCount === 0) return '';
+  const rows = [];
+  for (let i = 0; i < rowCount; i += 1) {
+    const preLabel = REPAIR_PRE_CONFIDENCE_LABELS[preList[i]] || 'Not recorded';
+    const rateLabel = REPAIR_RATING_SUMMARY_LABELS[rateList[i]] || 'Not recorded';
+    rows.push(`
+      <div class="graph-repair-summary-row">
+        <span class="graph-repair-summary-rep">Rep ${i + 1}</span>
+        <span class="graph-repair-summary-pair"><span class="muted">Predicted:</span> ${escHtml(preLabel)}</span>
+        <span class="graph-repair-summary-pair"><span class="muted">Rated:</span> ${escHtml(rateLabel)}</span>
+      </div>
+    `);
+  }
+  return `<div class="graph-repair-summary graph-repair-calibration">${rows.join('')}</div>`;
+}
+```
+
+### Step 2.2 — Extend ready-before-reveal markup (pill section above textarea, locked row after reveal, render textarea from state in all states, update button label + helper)
+
+- [ ] **Replace the ready-state return block (lines 609-653) in `repairRepsMarkupForNode`**
+
+Find the block starting at line 609 (`const reps = Array.isArray(state.reps)...`) down to the closing backtick at line 653. Replace with:
+
+```js
+  const reps = Array.isArray(state.reps) ? state.reps : [];
+  const currentIndex = Math.min(Math.max(Number(state.currentIndex || 0), 0), Math.max(reps.length - 1, 0));
+  const rep = reps[currentIndex] || null;
+  if (!rep) {
+    return `
+      ${repairContextStripMarkup({ nodeLabel, phaseLabel: 'Repair Reps' })}
+      <div class="graph-detail-kicker">Repair Reps</div>
+      <h3 class="graph-detail-title">${escHtml(nodeLabel)}</h3>
+      <p class="graph-detail-copy">Repair Reps are not ready for this node yet.</p>
+      <button class="${actionButtonClass} trigger-repair-exit">Back to graph</button>
+    `;
+  }
+
+  const revealed = Boolean(state.revealed);
+  const typedAnswer = escHtml(state.currentAnswer || '');
+  const ratingSelected = Boolean(state.ratingSelected || state.ratings?.[currentIndex]);
+  const preConfidence = state.currentPreConfidence || '';
+  const pillsMarkup = repairPredictPillsMarkup(preConfidence, revealed);
+  const preConfidenceValid = preConfidence === 'guessing' || preConfidence === 'hunch' || preConfidence === 'can_explain';
+  const hasAnswer = typeof state.currentAnswer === 'string' && state.currentAnswer.trim().length > 0;
+  const revealReady = preConfidenceValid && hasAnswer;
+  return `
+    ${repairContextStripMarkup({ nodeLabel, phaseLabel: `Repair Rep ${currentIndex + 1} of ${reps.length}` })}
+    <div class="graph-study-shell graph-repair-shell">
+      <section class="graph-detail-surface graph-repair-card ${state.isDealing ? 'is-dealing' : ''}">
+        ${repairProgressMarkup({ currentIndex, total: reps.length })}
+        <div class="graph-detail-kicker">Causal bridge</div>
+        <p class="graph-detail-copy">${escHtml(rep.prompt)}</p>
+        ${pillsMarkup}
+        <div class="graph-detail-kicker">Your bridge</div>
+        <textarea class="graph-repair-input" rows="4" aria-describedby="repair-reveal-helper" ${revealed ? 'readonly' : ''}>${typedAnswer}</textarea>
+        ${revealed ? '' : '<p class="graph-detail-copy graph-repair-helper">Trace the causal link in one or two sentences.</p>'}
+        ${revealed ? `
+          <div class="graph-repair-bridge ${state.isRevealing ? 'is-revealing' : ''}">
+            <div class="graph-detail-kicker">Reference bridge</div>
+            <p class="graph-detail-copy">${escHtml(rep.target_bridge)}</p>
+            <p class="graph-detail-copy graph-repair-compare-cue">Compare the link, not the wording.</p>
+          </div>
+          ${repairRatingMarkup(state, currentIndex)}
+        ` : ''}
+      </section>
+      <section class="graph-detail-surface graph-study-next graph-repair-next">
+        <p class="graph-detail-copy graph-repair-truth-line">Practice only. Graph progress comes from re-drill.</p>
+        ${revealed
+          ? (ratingSelected
+            ? `<button class="${actionButtonClass} trigger-repair-next">${currentIndex + 1 >= reps.length ? 'Finish Reps' : 'Next Rep'}</button>`
+            : '<p class="graph-detail-copy graph-repair-rating-hint">Choose the closest comparison before moving on.</p>')
+          : `
+            <button class="${actionButtonClass} trigger-repair-reveal" ${revealReady ? '' : 'disabled'} aria-describedby="repair-reveal-helper">Lock in and show reference bridge</button>
+            <p class="graph-repair-reveal-helper" id="repair-reveal-helper">Pick a stance and type your bridge to continue.</p>
+          `}
+      </section>
+    </div>
+  `;
+```
+
+Changes from original:
+- `typedAnswer = escHtml(state.currentAnswer || '')` is no longer gated by `revealed` — renders in both states for draft preservation.
+- Pill markup injected between the rep prompt and the "Your bridge" kicker.
+- Textarea gains `aria-describedby="repair-reveal-helper"`.
+- Reveal button: label changes to **`Lock in and show reference bridge`**, `disabled` attribute now depends on `revealReady` (pill + non-empty answer), gains `aria-describedby`.
+- Helper paragraph with `id="repair-reveal-helper"` added below reveal button.
+
+### Step 2.3 — Extend complete-state markup with calibration summary
+
+- [ ] **Replace the complete-state block in `repairRepsMarkupForNode` (lines 582-607)**
+
+Find the block starting `if (status === 'complete')` at line 582 through the closing `}` at line 607. Replace with:
+
+```js
+  if (status === 'complete') {
+    const reps = Array.isArray(state.reps) ? state.reps : [];
+    const ratings = Array.isArray(state.ratings) ? state.ratings : [];
+    const preConfidences = Array.isArray(state.preConfidences) ? state.preConfidences : [];
+    const calibrationMarkup = repairCalibrationSummaryMarkup(preConfidences, ratings);
+    const legacySummaryRows = reps.length && !calibrationMarkup
+      ? reps.map((rep, index) => {
+        const rating = ratings[index] || '';
+        return `
+          <div class="graph-repair-summary-row">
+            <span class="graph-detail-pill">${escHtml(repairKindLabel(rep.kind))}</span>
+            <span class="graph-repair-summary-rating ${escHtml(rating)}">${escHtml(repairRatingLabel(rating))}</span>
+          </div>
+        `;
+      }).join('')
+      : '';
+    return `
+      ${repairContextStripMarkup({ nodeLabel, phaseLabel: 'Repair Reps complete' })}
+      <div class="graph-repair-complete">
+        <div class="graph-detail-kicker">Repair Reps</div>
+        ${repairProgressMarkup({ currentIndex: 2, total: Math.max(reps.length, 3), complete: true })}
+        <h3 class="graph-detail-title">Practice logged</h3>
+        <p class="graph-detail-copy">Three bridge reps saved on ${escHtml(nodeLabel)}.</p>
+        ${calibrationMarkup || (legacySummaryRows ? `<div class="graph-repair-summary">${legacySummaryRows}</div>` : '')}
+        <p class="graph-detail-copy">These reps are saved. Graph progress comes from the next re-drill.</p>
+        <button class="${actionButtonClass} trigger-repair-exit">Back to graph</button>
+      </div>
+    `;
+  }
+```
+
+Calibration markup (new per-rep predicted/rated rows) takes precedence. Legacy summary (kind + rating badges) is preserved as fallback only when the new arrays are both empty — ensures old records without `pre_confidences` still show something and don't regress.
+
+### Step 2.4 — Bump graph-view.js cache-bust in BOTH importers
+
+- [ ] **Edit `public/js/app.js:4`**
+
+Find:
+```js
+import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=3';
+```
+
+Replace with:
+```js
+import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=4';
+```
+
+- [ ] **Edit `public/js/learner-analytics.js:2`**
+
+Find:
+```js
+import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=3';
+```
+
+Replace with:
+```js
+import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=4';
+```
+
+Both must be bumped in lockstep. Skipping either leaves that importer pinned to a stale module.
+
+### Step 2.5 — Bump `js/app.js` cache-bust again (since app.js line 4 changed)
+
+- [ ] **Edit `public/index.html:495`**
+
+Find:
+```html
+  <script type="module" src="js/app.js?v=28"></script>
+```
+
+Replace with:
+```html
+  <script type="module" src="js/app.js?v=29"></script>
+```
+
+### Step 2.6 — Node syntax check
+
+- [ ] **Run `node --check` on both JS files**
+
+```bash
+node --check public/js/app.js
+node --check public/js/graph-view.js
+```
+
+Expected: silent.
+
+### Step 2.7 — Commit
+
+- [ ] **Stage and commit**
+
+```bash
+git add public/js/graph-view.js public/js/app.js public/js/learner-analytics.js public/index.html
+git commit -m "$(cat <<'EOF'
+feat(repair-reps): Slice B markup helpers + ready/complete templates
+
+- Add repairPredictPillsMarkup() and repairCalibrationSummaryMarkup()
+  pure helpers with fixed enum->label maps. Calibration helper tolerates
+  length mismatches (renders min(length) rows) and returns '' on empty
+  arrays so old records omit the block entirely.
+- Extend ready-state repairRepsMarkupForNode: inject pills above
+  "Your bridge", always render textarea from state.currentAnswer for
+  draft preservation (not just in revealed state), switch reveal-button
+  label to "Lock in and show reference bridge", gate disabled by pill +
+  non-empty answer, add aria-describedby helper text.
+- Extend complete-state markup with calibration summary block
+  ("Rep N / Predicted: X / Rated: Y"). Fall back to legacy kind/rating
+  rows only when both new arrays are empty.
+- Bump graph-view.js?v=3 -> v=4 in both importers (app.js line 4
+  and learner-analytics.js line 2). Bump js/app.js?v=28 -> v=29 in
+  index.html.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: graph-view.js listener binding in renderCurrentDetail
+
+**Files:**
+- Modify: `public/js/graph-view.js:1613-1636` (listener binding block)
+- Modify: `public/js/app.js:4` (bump graph-view.js?v=4 -> v=5)
+- Modify: `public/js/learner-analytics.js:2` (bump in lockstep)
+- Modify: `public/index.html:495` (bump app.js?v=29 -> v=30)
+
+### Step 3.1 — Rewrite the listener block in `renderCurrentDetail`
+
+- [ ] **Replace lines 1613-1636 in `public/js/graph-view.js`** (from the `const repairBtn = ...` line through the `.trigger-repair-exit` binding)
+
+Find the existing block that starts with:
+```js
+        const repairBtn = detailEl.querySelector('.trigger-repair');
+        if (repairBtn) repairBtn.addEventListener('click', () => { window.SocratinkApp?.startRepairReps?.(activeNode.data()); });
+        const repairRevealBtn = detailEl.querySelector('.trigger-repair-reveal');
+```
+
+And replace the listener block (through the `.trigger-repair-exit` listener) with:
+
+```js
+        const repairBtn = detailEl.querySelector('.trigger-repair');
+        if (repairBtn) repairBtn.addEventListener('click', () => { window.SocratinkApp?.startRepairReps?.(activeNode.data()); });
+
+        const repairInput = detailEl.querySelector('.graph-repair-input');
+        const repairRevealBtn = detailEl.querySelector('.trigger-repair-reveal');
+
+        // Read the current pre-confidence from app state — the render was
+        // driven by it, so it's authoritative. Re-eval of the reveal-enable
+        // predicate on every keystroke stays DOM-local (no state dispatch)
+        // to avoid destroying caret position on textarea re-render.
+        const repairState = window.SocratinkApp?.getRepairRepsState?.(activeNode.id()) || null;
+        const preConfidenceValid = repairState
+          && (repairState.currentPreConfidence === 'guessing'
+            || repairState.currentPreConfidence === 'hunch'
+            || repairState.currentPreConfidence === 'can_explain');
+
+        if (repairInput && repairRevealBtn) {
+          const syncRevealReadiness = () => {
+            const hasAnswer = repairInput.value.trim().length > 0;
+            repairRevealBtn.disabled = !(preConfidenceValid && hasAnswer);
+          };
+          syncRevealReadiness();
+          repairInput.addEventListener('input', syncRevealReadiness);
+        }
+
+        if (repairRevealBtn) {
+          repairRevealBtn.addEventListener('click', () => {
+            const answer = repairInput?.value || '';
+            window.SocratinkApp?.revealRepairRep?.(answer);
+          });
+        }
+
+        // Pill listeners — on click, stamp the live textarea draft into
+        // state first (so re-render preserves the in-flight answer), then
+        // set the pre-confidence. The render loop will re-render the
+        // textarea with value="${currentAnswer}" and re-highlight the pill.
+        detailEl.querySelectorAll('.trigger-repair-predict').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            const liveDraft = repairInput?.value || '';
+            window.SocratinkApp?.setRepairRepDraft?.(liveDraft);
+            window.SocratinkApp?.setRepairRepPreConfidence?.(btn.dataset.pre);
+          });
+        });
+
+        const repairNextBtn = detailEl.querySelector('.trigger-repair-next');
+        if (repairNextBtn) repairNextBtn.addEventListener('click', () => { window.SocratinkApp?.nextRepairRep?.(); });
+        detailEl.querySelectorAll('.trigger-repair-rate').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            window.SocratinkApp?.rateRepairRep?.(btn.dataset.rating);
+          });
+        });
+        const repairExitBtn = detailEl.querySelector('.trigger-repair-exit');
+        if (repairExitBtn) repairExitBtn.addEventListener('click', () => { window.SocratinkApp?.exitRepairReps?.(); });
+```
+
+Key correctness notes:
+- `setRepairRepDraft` is called **before** `setRepairRepPreConfidence` so the draft is in state before the re-render triggered by the pill change.
+- The textarea `input` listener stays DOM-local — it only toggles `disabled` based on live textarea value and the (already rendered) pre-confidence. **It does not dispatch state**, preserving caret.
+- The reveal-gate enforcement is dual: UI disables the button AND `revealRepairRep()` itself no-ops if preconditions fail (Task 1 Step 1.5).
+
+### Step 3.2 — Bump cache-bust (graph-view.js and app.js both changed)
+
+- [ ] **Edit `public/js/app.js:4`**
+
+`./graph-view.js?v=4` → `./graph-view.js?v=5`
+
+- [ ] **Edit `public/js/learner-analytics.js:2`**
+
+`./graph-view.js?v=4` → `./graph-view.js?v=5`
+
+- [ ] **Edit `public/index.html:495`**
+
+`js/app.js?v=29` → `js/app.js?v=30`
+
+### Step 3.3 — Node syntax check
+
+- [ ] **Run**
+
+```bash
+node --check public/js/app.js
+node --check public/js/graph-view.js
+```
+
+Expected: silent.
+
+### Step 3.4 — Commit
+
+- [ ] **Stage and commit**
+
+```bash
+git add public/js/graph-view.js public/js/app.js public/js/learner-analytics.js public/index.html
+git commit -m "$(cat <<'EOF'
+feat(repair-reps): Slice B listeners — pill click, dual reveal gate
+
+- Bind .trigger-repair-predict click listeners. Each stamps the live
+  textarea draft into state (setRepairRepDraft) BEFORE setting the
+  pre-confidence (setRepairRepPreConfidence) so the render triggered
+  by the pill change re-renders the draft.
+- Rewire .graph-repair-input input listener to DOM-local enable/disable
+  only (no state dispatch per keystroke) to preserve caret position on
+  textarea re-render. Reveal-enable predicate requires BOTH a valid
+  pre-confidence (from state) AND non-empty trimmed textarea.
+- .trigger-repair-reveal click reads live textarea value and hands
+  off to window.SocratinkApp.revealRepairRep(). The function itself
+  gates on idempotency + answer + pre-confidence, so bypass via direct
+  JS call (without pill + answer) is a no-op.
+- Bump graph-view.js?v=4 -> v=5 in both importers; app.js?v=29 -> v=30.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: layout.css — pill + calibration styles with Wave 1 tokens
+
+**Files:**
+- Modify: `public/css/layout.css` (append new rules near existing `.graph-repair-*` block; if no such block exists, append at end of file)
+- Modify: `public/index.html:25` (bump styles.css?v=42 -> v=43)
+
+### Step 4.1 — Locate existing `.graph-repair-*` rules (to know insertion point)
+
+- [ ] **Grep for existing rules**
+
+```bash
+grep -n "graph-repair-" public/css/layout.css | head -20
+```
+
+Insert the new block **after** the last existing `.graph-repair-*` rule in `layout.css`. If none exist in this file, append at the end of file (before any trailing `}` closing a media query).
+
+### Step 4.2 — Append the new CSS rules
+
+- [ ] **Edit `public/css/layout.css`** — append the following block
+
+```css
+/* ── Repair Reps Slice B — pre-reveal pill + calibration summary ── */
+
+.graph-repair-predict {
+  margin-bottom: 18px;
+}
+
+.graph-repair-predict > .graph-detail-kicker {
+  margin-bottom: 8px;
+}
+
+.graph-repair-predict-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.graph-repair-predict-pill {
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-strong);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background var(--duration-micro) var(--ease-standard, ease),
+              border-color var(--duration-micro) var(--ease-standard, ease);
+}
+
+.graph-repair-predict-pill:hover {
+  border-color: var(--accent-border-strong);
+}
+
+.graph-repair-predict-pill.is-selected,
+.graph-repair-predict-pill[aria-checked="true"] {
+  background: var(--accent-soft);
+  border-color: var(--accent-border-strong);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.graph-repair-predict-group.is-locked,
+.graph-repair-predict-group[aria-disabled="true"] {
+  pointer-events: none;
+}
+
+.graph-repair-predict-group.is-locked .graph-repair-predict-pill,
+.graph-repair-predict-group[aria-disabled="true"] .graph-repair-predict-pill {
+  cursor: default;
+}
+
+.graph-repair-reveal-helper {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin: 6px 0 0;
+}
+
+.graph-repair-calibration .graph-repair-summary-row {
+  display: grid;
+  grid-template-columns: max-content 1fr 1fr;
+  gap: 10px 16px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.graph-repair-calibration .graph-repair-summary-row:last-child {
+  border-bottom: none;
+}
+
+.graph-repair-summary-rep {
+  font-weight: 700;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+}
+
+.graph-repair-summary-pair .muted {
+  color: var(--text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graph-repair-predict-pill {
+    transition: none;
+  }
+}
+```
+
+Note: `--ease-standard` has a fallback of plain `ease` so missing tokens degrade gracefully. The global reduced-motion block in `base.css` already suppresses transitions; the explicit rule here is a belt-and-suspenders per spec and is harmless.
+
+### Step 4.3 — Bump styles.css cache-bust
+
+- [ ] **Edit `public/index.html:25`**
+
+Find:
+```html
+  <link rel="stylesheet" href="styles.css?v=42">
+```
+
+Replace with:
+```html
+  <link rel="stylesheet" href="styles.css?v=43">
+```
+
+### Step 4.4 — Commit
+
+- [ ] **Stage and commit**
+
+```bash
+git add public/css/layout.css public/index.html
+git commit -m "$(cat <<'EOF'
+feat(repair-reps): Slice B CSS — predict pills + calibration rows
+
+- Add .graph-repair-predict / .graph-repair-predict-group /
+  .graph-repair-predict-pill rules. Pills render as Wave 1 chips:
+  --surface-card + --border-subtle; selected = --accent-soft +
+  --accent-primary + stronger border.
+- Lock state via .is-locked and [aria-disabled="true"] sets
+  pointer-events: none on the group and cursor: default on children.
+- Add .graph-repair-reveal-helper for the "Pick a stance..." helper.
+- Add .graph-repair-calibration row grid (max-content 1fr 1fr) with
+  subtle dividers; .graph-repair-summary-rep small-caps label; .muted
+  inline tag for Predicted/Rated prefixes.
+- Respect prefers-reduced-motion: reduce on pill transitions (global
+  base.css already handles this, but spec calls it out explicitly).
+- Bump styles.css?v=42 -> v=43.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: app.js recordRepairRepsCompletion — persist the two new arrays + invariant comment
+
+**Files:**
+- Modify: `public/js/app.js:2439-2456` (recordRepairRepsCompletion)
+- Modify: `public/index.html:495` (bump app.js?v=30 -> v=31)
+
+### Step 5.1 — Extend `recordRepairRepsCompletion`
+
+- [ ] **Replace the function (lines 2439-2456)**
+
+```js
+  function recordRepairRepsCompletion({
+    conceptId, nodeId, repCount, promptVersion, gapType,
+    answerLengths, ratings, preConfidences, lockDurationsMs,
+  }) {
+    if (!conceptId || !nodeId) return;
+    const history = loadRepairRepsHistory();
+    const key = `${conceptId}::${nodeId}`;
+    const entries = Array.isArray(history[key]) ? history[key] : [];
+    // pre_confidences and lock_durations_ms are practice metadata — a
+    // calibration read-out for the learner. They MUST NOT feed scheduling,
+    // node prioritization, drill_status, or any graph-truth mutation.
+    // See spec §Invariant Boundary.
+    history[key] = [
+      ...entries,
+      {
+        completed_at: new Date().toISOString(),
+        rep_count: repCount,
+        prompt_version: promptVersion,
+        gap_type: gapType || null,
+        answer_lengths: Array.isArray(answerLengths) ? answerLengths : [],
+        ratings: Array.isArray(ratings) ? ratings : [],
+        pre_confidences: Array.isArray(preConfidences) ? preConfidences : [],
+        lock_durations_ms: Array.isArray(lockDurationsMs) ? lockDurationsMs : [],
+      },
+    ].slice(-20);
+    saveRepairRepsHistory(history);
+  }
+```
+
+Task 1 Step 1.7 already forwards `preConfidences` and `lockDurationsMs` into this function from `nextRepairRep`. No other call sites need updating.
+
+### Step 5.2 — Bump app.js cache-bust
+
+- [ ] **Edit `public/index.html:495`**
+
+`js/app.js?v=30` → `js/app.js?v=31`
+
+### Step 5.3 — Node syntax check
+
+- [ ] **Run**
+
+```bash
+node --check public/js/app.js
+```
+
+Expected: silent.
+
+### Step 5.4 — Commit
+
+- [ ] **Stage and commit**
+
+```bash
+git add public/js/app.js public/index.html
+git commit -m "$(cat <<'EOF'
+feat(repair-reps): Slice B persist pre_confidences + lock_durations_ms
+
+Extend recordRepairRepsCompletion to accept preConfidences and
+lockDurationsMs named params and persist them as additive arrays
+on each learnops_repair_reps_v1 record. Missing arrays from older
+records read as []; no migration needed.
+
+Add inline invariant comment: these fields are practice metadata
+only, must not feed scheduling or graph-truth mutation (spec
+Invariant Boundary).
+
+Bump js/app.js?v=30 -> v=31.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Automated verification + manual browser flow
+
+**Files:** none modified.
+
+### Step 6.1 — Automated checks
+
+- [ ] **Node syntax on both JS files**
+
+```bash
+node --check public/js/app.js && node --check public/js/graph-view.js
+```
+
+Expected: silent (both pass).
+
+- [ ] **Repair Reps unit + prompt tests (unchanged surface — must stay green)**
+
+```bash
+python -m pytest tests/test_repair_reps.py tests/test_app_prompts.py -v
+```
+
+Expected: all pass. Slice B touches no backend code; any failure here is a regression unrelated to Slice B and must be investigated before proceeding.
+
+- [ ] **Full test discovery (call out pre-existing failures if telemetry tests flake — document but do not treat as new regression)**
+
+```bash
+python -m unittest discover -s tests -v 2>&1 | tail -40
+```
+
+Expected: no NEW failures. Pre-existing flakes (if any) are documented in `docs/project/state.md` — compare before blocking.
+
+- [ ] **Whitespace / trailing-space check**
+
+```bash
+git diff --check origin/dev...HEAD
+```
+
+Expected: silent (no whitespace errors).
+
+### Step 6.2 — Serve and cache-verify
+
+- [ ] **Kill any existing uvicorn on :8000 and restart from this worktree**
+
+```bash
+pkill -f "uvicorn main:app" || true
+sleep 1
+uvicorn main:app --reload
+```
+
+(Run in a separate terminal pane, or as `&` in background.)
+
+- [ ] **Cache-bust & feature-landing curl checks**
+
+```bash
+curl -s http://localhost:8000/ | grep -oE 'styles\.css\?v=[0-9]+'
+curl -s http://localhost:8000/ | grep -oE 'js/app\.js\?v=[0-9]+'
+curl -s "http://localhost:8000/js/app.js?v=31" | grep -c 'setRepairRepPreConfidence'
+curl -s "http://localhost:8000/js/app.js?v=31" | grep -c 'setRepairRepDraft'
+curl -s "http://localhost:8000/js/graph-view.js?v=5" | grep -c 'trigger-repair-predict'
+```
+
+Expected:
+- `styles.css?v=43`
+- `js/app.js?v=31`
+- `setRepairRepPreConfidence` count > 0 (should be ≥2: definition + export)
+- `setRepairRepDraft` count > 0
+- `trigger-repair-predict` count > 0 (markup + class)
+
+If any of these is wrong, investigate cache-bust mismatch before running manual tests.
+
+### Step 6.3 — Manual browser verification (20-item spec test plan)
+
+Open `http://localhost:8000/` in a browser on a fresh profile (or hard-reload). Create or open a concept where at least one node is eligible for Repair Reps (post-study, non-solid). Click `Start Repair Reps`.
+
+Walk through each item. Tick the box only after observation (not assumption).
+
+- [ ] **1. Pill renders**: "Before you peek" kicker + three pills render above "Your bridge". Reveal button disabled. Helper text reads "Pick a stance and type your bridge to continue."
+- [ ] **2. Type without pill**: helper remains visible, reveal button stays disabled.
+- [ ] **3. Pill no-type**: select `Have a hunch`; pill highlights with `aria-checked="true"` (inspect element to confirm); textarea empty; reveal stays disabled.
+- [ ] **4. Type-then-pill draft preservation**: type `test draft`, THEN select `Guessing`. Textarea still reads `test draft` after the re-render. (This is the draft-preservation test — the reason for Step 1.6b's `setRepairRepDraft`.)
+- [ ] **5. Both satisfied**: pill + non-empty trimmed attempt → reveal button enables.
+- [ ] **6. Clear textarea**: clear after enabling → reveal re-disables, pill selection persists.
+- [ ] **7. Change pill pre-reveal**: click a different pill → highlight moves; reveal stays enabled.
+- [ ] **8. Single-click reveal**: click `Lock in and show reference bridge`. Textarea becomes `readonly` (inspect); pill row gains `aria-disabled="true"` and `.is-locked` class (inspect); reference bridge unfolds; self-rating row renders with `Close match / Partly linked / Missed the link`.
+- [ ] **9. Post-reveal pill click**: click pills after reveal → nothing happens (CSS `pointer-events: none`).
+- [ ] **10. Direct JS bypass**: in DevTools console, run before selecting a pill on a fresh rep: `window.SocratinkApp.revealRepairRep("x")` — no reveal. Then select a pill, type, and run it again — reveal happens.
+- [ ] **11. Idempotency**: after reveal, run `window.SocratinkApp.revealRepairRep("anything")` a second time. Inspect `window.SocratinkApp.getRepairRepsState()`: `lockedAt`, `preConfidences`, and `lockDurationsMs` are each written exactly once for this rep (lengths should match `currentIndex + 1`).
+- [ ] **12. Lock duration**: `getRepairRepsState()` shows `lockedAt - repStartedAt > 0`. After `nextRepairRep()`, `repStartedAt` has a new value, `lockedAt` is null.
+- [ ] **13. Complete 3 reps**: walk through reps 2 and 3 with different `Predicted → Rated` combinations (aim for at least one of each pill value).
+- [ ] **14. Completion summary**: three rows `Rep N / Predicted: <label> / Rated: <label>` with the fixed label map. Observational language only — no "overconfident", "miscalibrated", or "wrong". Closing copy "These reps are saved. Graph progress comes from the next re-drill." visible.
+- [ ] **15. localStorage record**: run `JSON.parse(localStorage.learnops_repair_reps_v1)` in DevTools. The latest record for the concept has `pre_confidences.length === 3`, `lock_durations_ms.length === 3` (all positive integers), alongside existing `ratings` and `answer_lengths`. No `answer`, `prompt`, `target_bridge`, or `feedback_cue` fields.
+- [ ] **16. Old-record backward compat**: inject a pre-slice-B record into localStorage:
+
+    ```js
+    const k = 'learnops_repair_reps_v1';
+    const h = JSON.parse(localStorage.getItem(k) || '{}');
+    h['fake-concept::fake-node'] = [{
+      completed_at: new Date().toISOString(), rep_count: 3,
+      prompt_version: 'repair-reps-system-v1', gap_type: 'mechanism',
+      answer_lengths: [10, 20, 30], ratings: ['close_match', 'partial', 'missed'],
+    }];
+    localStorage.setItem(k, JSON.stringify(h));
+    ```
+
+    Reload. No crash on any surface that reads this store. (App doesn't currently re-render history from this store, so the check is: page loads and Repair Reps still works on real nodes.)
+
+- [ ] **17. Length-mismatch injection**: inject a record with `pre_confidences.length === 2` and `ratings.length === 3` (paste one manually into localStorage). No code surface currently re-renders this back, but simulate by temporarily overriding a state object in DevTools and forcing a render. Or simpler: complete a 3-rep run, then in DevTools directly call `repairCalibrationSummaryMarkup(['guessing','hunch'], ['close_match','partial','missed'])` after importing it (or observe via unit inspection of the render). **If the helper isn't trivially callable from DevTools** (it's not exported globally), verify by reading the source: Task 2 Step 2.1 uses `Math.min(preList.length, rateList.length)` — ≤ min rows. Check passes by inspection.
+- [ ] **18. Exit**: `Back to graph` releases focused mode and returns to the graph view.
+- [ ] **19. Reduced motion**: toggle OS `prefers-reduced-motion: reduce` (macOS: System Preferences → Accessibility → Display → Reduce motion). Reload. Pill transitions suppressed.
+- [ ] **20. A11y**: Tab key cycles into the pill group. Space/Enter activates the focused pill. Selected pill has `aria-checked="true"`. Disabled reveal button has `aria-describedby="repair-reveal-helper"` pointing at the helper paragraph.
+
+### Step 6.4 — If any manual check fails
+
+Do not fix silently. Log the failure + reproduction in a scratch note, triage whether it is spec-correct-but-impl-wrong (fix and re-verify that step + all subsequent) or impl-correct-but-spec-ambiguous (surface to the user before deciding).
+
+### Step 6.5 — Verification tail commit (optional, only if final tweaks needed)
+
+If a manual check revealed a small fix (e.g., missing `aria-describedby`, off-by-one in label), land it as a single commit with message `fix(repair-reps): <specific fix>` and re-run only the affected manual checks.
+
+---
+
+## Final verification
+
+- [ ] **Full test run (last check before PR)**
+
+```bash
+node --check public/js/app.js && node --check public/js/graph-view.js
+python -m pytest tests/test_repair_reps.py tests/test_app_prompts.py -v
+git diff --check origin/dev...HEAD
+git log --oneline origin/dev..HEAD
+```
+
+Expected: all pass; commit graph shows 5-6 focused commits (plan + Task 1-5, optional Task 6 fix).
+
+- [ ] **Confirm zero-touch invariants via grep**
+
+```bash
+# Must NOT appear in any Slice B diff:
+git diff origin/dev...HEAD -- public/js/app.js public/js/graph-view.js \
+  | grep -E 'patchActiveConceptDrillOutcome|recordInterleavingEvent|markNodeVisitedThisSession|drill_status\s*[:=]|drill_phase\s*[:=]|study_completed_at\s*[:=]|re_drill_eligible_after\s*[:=]' \
+  | grep -v '^-'
+```
+
+Expected: empty (no NEW lines touching those identifiers). Any match is an invariant violation.
+
+- [ ] **Confirm no backend / prompt drift**
+
+```bash
+git diff origin/dev...HEAD -- main.py ai_service.py app_prompts/
+```
+
+Expected: empty.
+
+---
+
+## PR checklist
+
+- [ ] Branch: `claude/repair-reps-slice-b`, target `dev`.
+- [ ] PR body references `docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md`.
+- [ ] Test-plan items 1-20 checked (mark the three that only a human can run: **#10 direct-JS bypass**, **#11 idempotency**, **#17 length-mismatch** — note human-verified).
+- [ ] Zero backend diff.
+- [ ] Cache-bust values at final commit: `styles.css?v=43`, `app.js?v=31`, `graph-view.js?v=5` (both importers).

--- a/docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md
+++ b/docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md
@@ -4,11 +4,11 @@
 
 > **What this document is**: This spec governs the *metacognitive loop* addition
 > to the Repair Reps focused workbench: a pre-reveal confidence pill, a soft
-> reveal gate that requires both a non-empty attempt and a committed stance, a
-> single-click lock-and-reveal mechanic, and a completion-summary calibration
-> readout pairing predicted confidence with self-rated outcome. This is
-> Slice B on top of already-specced Phase 1+2 copy/layout work in
-> `docs/product/repair-reps-focused-mode-spec.md`.
+> reveal gate enforced both in the UI and inside `revealRepairRep()`, a
+> single-click lock-and-reveal mechanic with defined duration semantics, and a
+> completion-summary calibration readout pairing predicted confidence with
+> self-rated outcome. This is Slice B on top of already-specced Phase 1+2
+> copy/layout work in `docs/product/repair-reps-focused-mode-spec.md`.
 >
 > **When to read it**:
 > - Before changing `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
@@ -16,16 +16,19 @@
 > - Before extending the `learnops_repair_reps_v1` localStorage record shape.
 > - Before changing the visible wording around "Before you peek", "Lock in and show reference bridge", or the per-rep calibration summary.
 >
-> **What it is NOT**: This does not replace or modify `docs/product/repair-reps-focused-mode-spec.md` (Phase 1+2 focused layout), `docs/product/repair-reps-card-stack-spec.md` (card-stack animation vocabulary), or `docs/product/repair-reps-self-rating-spec.md` (self-rating semantics). It does not change the Repair Reps backend generation contract in `main.py` or `ai_service.py`. It does not change `/api/repair-reps`, `RepairRepsRequest`, or `app_prompts/repair-reps-system-v1.md`.
+> **What it is NOT**: This does not replace or modify `docs/product/repair-reps-focused-mode-spec.md` (Phase 1+2 focused layout), `docs/product/repair-reps-card-stack-spec.md` (card-stack animation vocabulary), or `docs/product/repair-reps-self-rating-spec.md` (self-rating semantics, including the existing `Close match` / `Partly linked` / `Missed the link` visible labels and the `close_match` / `partial` / `missed` stored values). It does not change the Repair Reps backend generation contract in `main.py` or `ai_service.py`. It does not change `/api/repair-reps`, `RepairRepsRequest`, or `app_prompts/repair-reps-system-v1.md`.
 >
 > **Key constraints** (inherited and extended):
 > - Repair Reps must not call `patchActiveConceptDrillOutcome()`, `recordInterleavingEvent()`, or `markNodeVisitedThisSession()`.
 > - Repair Reps must not mutate `drill_status`, `drill_phase`, `study_completed_at`, `re_drill_eligible_after`, `gap_type`, or `gap_description`.
-> - Reference bridge must render only after the learner has committed a pre-reveal confidence *and* typed a non-empty answer.
-> - The reveal button is the single commitment point — one click locks the attempt and reveals the reference.
-> - Pre-confidence and lock durations are persisted on completion only; never during an in-progress rep.
-> - Calibration readout must be observational ("Predicted: X - Rated: Y") — never judgmental ("overconfident", "miscalibrated").
-> - Confidence values must not mutate graph state, feed routing, or appear as progress/mastery evidence.
+> - The reveal gate is enforced inside `revealRepairRep()`, not only by disabled-button UI. Direct JS calls to `revealRepairRep()` without a non-empty trimmed answer AND a valid `currentPreConfidence` MUST no-op.
+> - `revealRepairRep()` MUST be idempotent: a second call when `repairRepsState.revealed === true` MUST no-op without rewriting `lockedAt`, `preConfidences`, or `lockDurationsMs`.
+> - Pre-confidence and lock durations live as per-rep arrays in transient state. Completion writes those arrays to `learnops_repair_reps_v1`.
+> - Lock duration is defined as `lockedAt - repStartedAt`, where `repStartedAt` is stamped when a rep becomes current (on `startRepairReps()` for rep 1 and on `nextRepairRep()` for subsequent reps).
+> - Rating labels and stored values are unchanged from `docs/product/repair-reps-self-rating-spec.md`: visible `Close match` / `Partly linked` / `Missed the link`; stored `close_match` / `partial` / `missed`.
+> - localStorage MUST NOT persist full learner answers, rep prompts, reference bridges, or feedback cues. Only confidence enum labels, lock durations in milliseconds, answer lengths (counts, not text), and existing fields are allowed.
+> - Calibration readout must be observational ("Predicted: X / Rated: Y") - never judgmental ("overconfident", "miscalibrated"). No aggregate calibration score.
+> - Confidence values must not mutate graph state, feed scheduling, or appear as progress/mastery evidence.
 > - Copy must avoid score, correct, mastered, streak, win, or celebration language.
 
 ---
@@ -43,9 +46,9 @@ This slice is intentionally narrower than the full metacognitive-UX review (P0-P
 ## Assumptions
 
 - The implementation can use the existing `syncInteractionChrome()` mode hooks: `.graph-layout.mode-repair-reps` and `.graph-detail.is-repair-reps`.
-- The existing `repairRepsState` shape can absorb two new transient fields (`preConfidence`, `lockedAt`) without schema churn at the module boundary.
+- The existing `repairRepsState` shape can absorb new fields: per-rep arrays (`preConfidences`, `lockDurationsMs`), a per-rep working timestamp (`repStartedAt`), a per-rep working stance (`currentPreConfidence`), and a per-rep working draft (`currentAnswer`).
 - The existing `learnops_repair_reps_v1` localStorage entry is readable by older callers that do not know about the new fields; missing arrays are treated as `[]`.
-- Repair Reps evidence writes happen on completion only, as already specced. No per-rep localStorage writes.
+- Repair Reps evidence writes happen on completion only. No per-rep localStorage writes.
 - No DB layer. localStorage is the sole persistence substrate for this slice.
 - The founder is the only user during this slice's lifespan. No telemetry infrastructure is added.
 
@@ -56,36 +59,47 @@ This slice is intentionally narrower than the full metacognitive-UX review (P0-P
 ### Primary Flow
 
 1. The learner enters Repair Reps focused mode from an eligible node, per existing spec.
-2. The rep card renders the standard context strip, node title, rep prompt, and the Phase 1+2 "Your bridge" label / textarea / helper copy.
-3. A new **"Before you peek"** section renders directly above the "Your bridge" label. It contains:
+2. On `startRepairReps()`, the reducer stamps `repStartedAt = Date.now()` for rep 1 and initializes the per-rep working fields (`currentPreConfidence = null`, `currentAnswer = ""`).
+3. The rep card renders the standard context strip, node title, rep prompt, and the Phase 1+2 "Your bridge" label / textarea / helper copy.
+4. A new **"Before you peek"** section renders directly above the "Your bridge" label. It contains:
    - The kicker: `Before you peek`
    - A horizontal row of three pills: `Guessing` / `Have a hunch` / `Can explain`
-4. The learner can type into the textarea at any time; typing does not require a pill selection. Order-independent: pill-then-type and type-then-pill are both valid.
-5. The **"Lock in and show reference bridge"** button is disabled until both conditions are true:
-   - A pill has been selected (stored as `preConfidence`)
-   - The textarea trimmed value is non-empty
-6. On button click (single click), the following happens atomically:
-   - `repairRepsState.lockedAt` is stamped with `Date.now()`
-   - The textarea becomes `readonly`
-   - The pill row becomes non-interactive (visually keeps the selected pill highlighted)
-   - The reference bridge panel unfolds with the existing reveal animation
-   - The self-rating row renders below, matching the Phase 1+2 revealed-state markup
-7. The learner selects one self-rating (`Matched` / `Partial` / `Off track`). The next-rep advance fires as before.
-8. After the third rep rating, the card transitions to the Repair Reps complete state.
-9. The complete state shows the existing `Practice logged` heading, the existing context strip, and a new per-rep calibration summary block:
-   - Three rows, one per rep: `Rep 1 - Predicted: Have a hunch - Rated: Partial`, etc.
-   - Completion evidence is written to `learnops_repair_reps_v1` with the extended shape (see Storage Schema below).
-10. The learner clicks `Back to graph`. State is released via the existing `exitRepairReps()` path.
+5. The learner can type into the textarea at any time; typing does not require a pill selection. Order-independent: pill-then-type and type-then-pill are both valid.
+6. Every `input` event on the textarea calls `setRepairRepsState({ currentAnswer: textarea.value })` so the latest draft survives re-renders caused by pill selection.
+7. Every pill click calls `setRepairRepPreConfidence(value)` with `value in ("guessing" | "hunch" | "can_explain")`. The handler reads the live textarea value into `currentAnswer` before dispatching the state update, guaranteeing that an unsubmitted draft is preserved across the re-render triggered by the pill selection.
+8. The **"Lock in and show reference bridge"** button is disabled until both conditions are true in state:
+   - `currentPreConfidence !== null`
+   - `currentAnswer.trim().length > 0`
+9. On button click (single click), `revealRepairRep(answer)` fires. The function:
+   - No-ops if `repairRepsState.revealed === true` (idempotent).
+   - No-ops if the trimmed answer is empty.
+   - No-ops if `repairRepsState.currentPreConfidence` is null or not in the enum.
+   - Stamps `lockedAt = Date.now()`.
+   - Pushes `currentPreConfidence` onto `preConfidences`.
+   - Pushes `lockedAt - repStartedAt` onto `lockDurationsMs`.
+   - Sets `revealed = true` and triggers the existing reveal path.
+10. The textarea becomes `readonly`. The pill row receives `aria-disabled="true"` and `.is-locked`, keeping the selected pill visibly highlighted but non-interactive.
+11. The reference bridge panel unfolds with the existing reveal animation. The self-rating row renders below using the existing `Close match` / `Partly linked` / `Missed the link` buttons, matching `docs/product/repair-reps-self-rating-spec.md`.
+12. The learner selects one self-rating. The existing `rateRepairRep()` path is unchanged.
+13. On `nextRepairRep()`, the reducer resets `currentPreConfidence = null`, `currentAnswer = ""`, `lockedAt = null`, stamps a new `repStartedAt = Date.now()` for the next rep, and advances `currentIndex`.
+14. After the third rep rating, the card transitions to the Repair Reps complete state.
+15. The complete state renders the existing `Practice logged` heading and context strip plus a new per-rep calibration summary block with three rows: `Rep N / Predicted: <label> / Rated: <label>`. Labels map from enum values via fixed lookup tables in `repairCalibrationSummaryMarkup()`.
+16. `recordRepairRepsCompletion()` writes the extended record to `learnops_repair_reps_v1` (see Storage Schema).
+17. The learner clicks `Back to graph`. State is released via the existing `exitRepairReps()` path.
 
 ### Edge Cases
 
-- **Learner never picks a pill**: Reveal button stays disabled. The learner cannot reveal the reference without selecting a stance. This is intentional; it is the metacognitive gate.
-- **Learner picks pill, types, then clears the textarea**: Reveal button re-disables. Pill selection persists.
-- **Learner picks pill, types, reveals, then attempts to change pill**: The pill row is non-interactive after reveal. Pre-confidence is frozen at reveal time.
+- **Learner never picks a pill**: Reveal button stays disabled. `revealRepairRep()` invoked directly via JS also no-ops. Pill is a hard prerequisite for reveal.
+- **Learner picks pill, types, then clears the textarea**: Reveal button re-disables. Pill selection persists in `currentPreConfidence`.
+- **Type-then-pill draft preservation**: Because every textarea `input` event updates `currentAnswer` in state, selecting a pill after typing does not wipe the textarea on re-render. The value is re-rendered from state.
+- **Learner picks pill, types, reveals, then attempts to change pill**: The pill row is non-interactive after reveal via `aria-disabled="true"` and CSS `pointer-events: none` under `.is-locked`. Pre-confidence is frozen at reveal time.
+- **Direct JS call to `revealRepairRep()` bypassing UI**: No-ops unless both non-empty trimmed answer AND valid `currentPreConfidence` are present, and state is not already revealed. UI disabled-button state is not the only gate.
+- **Repeated calls to `revealRepairRep()` on the same rep**: Second call no-ops. `lockedAt`, `preConfidences`, and `lockDurationsMs` are written exactly once per rep.
 - **Loading state**: The "Before you peek" section does not render during loading. The existing loading markup is unchanged.
 - **Error state**: The pill section does not render. Existing error markup is unchanged.
 - **Reduced motion**: The pill-row appearance, button-enable transition, and reveal animation all respect `prefers-reduced-motion: reduce`.
-- **Old evidence records**: Existing `learnops_repair_reps_v1` records without `pre_confidences` or `lock_durations_ms` remain readable. Readers must treat missing arrays as `[]` and tolerate length mismatches with `ratings` and `answer_lengths`.
+- **Old evidence records without `pre_confidences` / `lock_durations_ms`**: The calibration summary omits per-rep Predicted/Rated rows entirely, OR renders `Predicted: Not recorded` for missing values. Must not imply failure. Must not crash on missing arrays or length mismatches.
+- **Mixed-length arrays**: If `pre_confidences.length != ratings.length` (legacy edge case), render up to `min(length)` rows with present data only.
 - **Mobile layout**: Pill row wraps to a second line on narrow panels. The reveal button remains full-width below.
 
 ---
@@ -94,14 +108,18 @@ This slice is intentionally narrower than the full metacognitive-UX review (P0-P
 
 This slice must NOT:
 
-- Call or modify `patchActiveConceptDrillOutcome()`, `recordInterleavingEvent()`, or `markNodeVisitedThisSession()`. Pre-confidence and lock duration are practice metadata, not drill outcomes.
+- Call or modify `patchActiveConceptDrillOutcome()`, `recordInterleavingEvent()`, or `markNodeVisitedThisSession()`.
 - Mutate `concept.graphData`, `drill_status`, `drill_phase`, `study_completed_at`, `re_drill_eligible_after`, `gap_type`, or `gap_description`.
-- Treat `pre_confidence`, `lock_durations_ms`, or the calibration pairs as evidence of understanding. They are metacognitive self-report.
+- Treat `pre_confidences`, `lock_durations_ms`, or the calibration pairs as evidence of understanding.
 - Display the calibration readout per-rep inline (only in the completion summary).
 - Use judgmental labels in the calibration readout ("overconfident", "miscalibrated", "wrong"). Language stays observational.
 - Route, filter, or prioritize nodes based on pre-confidence values. Scheduling is the re-drill system's job.
 - Add a separate `Lock in` button. The single button `Lock in and show reference bridge` is the commitment point.
 - Add a confirm modal, side-by-side diff view, or "I don't know yet" help path. Those are deferred.
+- Rename or re-style the existing self-rating labels `Close match` / `Partly linked` / `Missed the link` or the stored values `close_match` / `partial` / `missed`.
+- Persist full learner answer text, rep prompts, reference bridges, or AI feedback cues to localStorage. Answer lengths (counts, not text) remain allowed.
+- Compute or display an aggregate calibration score.
+- Rely on UI-disabled state as the reveal gate. `revealRepairRep()` itself validates preconditions.
 - Change `/api/repair-reps`, `RepairRepsRequest`, `generate_repair_reps()`, `RepairRepsEvaluation`, or `app_prompts/repair-reps-system-v1.md`.
 - Add manual JS `element.style.pointerEvents` mutations. Graph interactivity continues to flow through the existing `.mode-repair-reps` CSS gate.
 
@@ -111,48 +129,88 @@ This slice must NOT:
 
 ### New or Modified State
 
-`repairRepsState` gains two transient fields:
+`repairRepsState` gains these fields:
 
 ```
-repairRepsState.preConfidence: "guessing" | "hunch" | "can_explain" | null = null
-  - Per-rep pre-reveal confidence selection.
-  - Resets to null when `nextRepairRep()` advances to the next rep.
-  - Null indicates the learner has not yet selected a stance; reveal button stays disabled.
+// Per-rep working fields (reset per rep)
+repairRepsState.currentPreConfidence: "guessing" | "hunch" | "can_explain" | null = null
+  - Stance for the current rep.
+  - Set by setRepairRepPreConfidence().
+  - Reset to null on startRepairReps() and nextRepairRep().
 
-repairRepsState.preConfidences: Array<"guessing"|"hunch"|"can_explain"> = []
-  - Accumulated per-rep selections, pushed on each reveal.
-  - Length matches completed-rep count.
+repairRepsState.currentAnswer: string = ""
+  - Live textarea draft for the current rep.
+  - Updated by the textarea input listener on every keystroke.
+  - Reset to "" on startRepairReps() and nextRepairRep().
+
+repairRepsState.repStartedAt: number | null = null
+  - Timestamp (Date.now()) when the current rep became active.
+  - Stamped on startRepairReps() for rep 1 and on nextRepairRep() for subsequent reps.
+  - Used as the denominator for lock-duration calculation.
 
 repairRepsState.lockedAt: number | null = null
-  - Per-rep timestamp at reveal-button click (Date.now()).
-  - Resets to null on `nextRepairRep()`.
+  - Timestamp at reveal-button click for the current rep.
+  - Set by revealRepairRep() inside the atomic reveal transition.
+  - Reset to null on nextRepairRep() and startRepairReps().
+
+// Accumulated per-rep arrays (grow across reps)
+repairRepsState.preConfidences: Array<"guessing"|"hunch"|"can_explain"> = []
+  - Pushed on each successful revealRepairRep().
+  - Length matches completed-rep count.
 
 repairRepsState.lockDurationsMs: Array<number> = []
-  - Accumulated per-rep durations: `lockedAt - repStartAt`, pushed on reveal.
-  - `repStartAt` is captured on rep entry (new internal timestamp in the reducer, not exposed).
+  - Pushed on each successful revealRepairRep() as lockedAt - repStartedAt.
+  - Length matches completed-rep count. Invariant: length === preConfidences.length === ratings.length at completion.
 ```
 
-No existing state fields are renamed or repurposed.
+No existing state fields are renamed or repurposed. Existing `ratings`, `ratingSelected`, `currentIndex`, `revealed`, `status`, `answerLengths` are unchanged.
 
 ### New or Modified Functions
 
-**`repairRepsMarkupForNode(data, repairState = {})`** in `public/js/graph-view.js`:
-Modify the ready-before-reveal markup to include the "Before you peek" pill section above `Your bridge`. Modify the button label to `Lock in and show reference bridge`. Modify the complete-state markup to render the per-rep calibration summary.
+**`startRepairReps()`** (existing, in `public/js/app.js`):
+Extend to initialize `preConfidences = []`, `lockDurationsMs = []`, `currentPreConfidence = null`, `currentAnswer = ""`, `lockedAt = null`, and stamp `repStartedAt = Date.now()`.
 
-**`repairPredictPillsMarkup(currentPreConfidence)`** in `public/js/graph-view.js`:
-New helper that returns the three-pill markup for the predict block. Must be pure; no state mutation.
+**`nextRepairRep()`** (existing, in `public/js/app.js`):
+Extend to reset `currentPreConfidence = null`, `currentAnswer = ""`, `lockedAt = null`, and re-stamp `repStartedAt = Date.now()` before advancing `currentIndex`.
 
-**`repairCalibrationSummaryMarkup(preConfidences, ratings)`** in `public/js/graph-view.js`:
-New helper that returns the per-rep `Predicted: X - Rated: Y` summary block. Tolerates array length mismatches gracefully (pads with `-`).
+**`setRepairRepPreConfidence(value)`** (new, in `public/js/app.js`, exported on `window.SocratinkApp`):
+```
+setRepairRepPreConfidence(value: "guessing" | "hunch" | "can_explain")
+  - Validate value is in the enum; otherwise no-op.
+  - No-op if repairRepsState.revealed === true (pill frozen post-reveal).
+  - Read current textarea.value into currentAnswer first, so the re-render
+    caused by the state update does not wipe the draft.
+  - setRepairRepsState({ currentPreConfidence: value, currentAnswer: latestValue }).
+```
 
-**`setRepairRepsState(patch)`** in `public/js/graph-view.js` (or wherever the reducer lives):
-Must handle `preConfidence`, `lockedAt`, and the reveal-transition atomic update (push to `preConfidences` + `lockDurationsMs`, set textarea readonly flag).
+**`revealRepairRep(answer)`** (existing, in `public/js/app.js`):
+Replace preconditions with:
+```
+  - If repairRepsState.revealed === true: no-op. (Idempotency.)
+  - If repairRepsState.status !== "ready": no-op.
+  - If typeof answer !== "string" or answer.trim().length === 0: no-op.
+  - If repairRepsState.currentPreConfidence not in enum: no-op.
+  - Stamp lockedAt = Date.now().
+  - Push currentPreConfidence onto preConfidences.
+  - Push (lockedAt - repStartedAt) onto lockDurationsMs.
+  - Existing: push answer.trim().length onto answerLengths.
+  - Set revealed = true, apply existing reveal path.
+```
 
-**`revealRepairRep(answer)`** in `public/js/app.js` (or graph-view.js, wherever defined):
-Extend preconditions: require both non-empty trimmed answer AND non-null `preConfidence`. On success, stamp `lockedAt`, push to `preConfidences` and `lockDurationsMs`, then call the existing reveal path.
+**`recordRepairRepsCompletion()`** (existing, in `public/js/app.js`):
+Extend the persisted record to include `pre_confidences: [...preConfidences]` and `lock_durations_ms: [...lockDurationsMs]`. No other fields change.
 
-**`completeRepairReps()`** in `public/js/app.js` (or wherever the completion write happens):
-Extend the `learnops_repair_reps_v1` write to include `pre_confidences` and `lock_durations_ms` arrays.
+**`repairRepsMarkupForNode(data, repairState = {})`** (existing, in `public/js/graph-view.js`):
+Extend ready-before-reveal markup with the "Before you peek" pill section above `Your bridge`. Update the reveal button label to `Lock in and show reference bridge`. In revealed state, render the pill row with `aria-disabled="true"` and `.is-locked`. Textarea uses `value="${escHtml(state.currentAnswer || "")}"` so draft preservation re-render works. Extend complete-state markup with `repairCalibrationSummaryMarkup()`.
+
+**`repairPredictPillsMarkup(currentPreConfidence, isLocked)`** (new, in `public/js/graph-view.js`):
+Pure helper returning the three-pill `<div role="radiogroup">` markup with `aria-checked` reflecting selection and `aria-disabled` reflecting lock state. No state mutation.
+
+**`repairCalibrationSummaryMarkup(preConfidences, ratings)`** (new, in `public/js/graph-view.js`):
+Pure helper returning the per-rep `Rep N / Predicted: X / Rated: Y` rows. Handles missing/short arrays by rendering up to `min(length)` complete rows, or by omitting the block entirely if both arrays are empty. Uses fixed lookup tables for enum-to-label translation.
+
+**`setRepairRepsState(patch)`** (existing):
+No signature change. Must preserve existing behavior of merging patches and triggering re-render.
 
 ### Storage Schema
 
@@ -162,20 +220,22 @@ The existing `learnops_repair_reps_v1` key gains two additive arrays. Schema aft
 {
   "concept_id::node_id": [
     {
-      "completed_at": "ISO timestamp",
+      "completed_at": "2026-04-18T17:12:03.410Z",
       "rep_count": 3,
       "prompt_version": "repair-reps-system-v1",
-      "gap_type": "string|null",
-      "answer_lengths": [0, 0, 0],
+      "gap_type": "mechanism",
+      "answer_lengths": [42, 37, 51],
       "ratings": ["close_match", "partial", "missed"],
       "pre_confidences": ["guessing", "hunch", "can_explain"],
-      "lock_durations_ms": [12034, 8120, 15240]
+      "lock_durations_ms": [12000, 18000, 9000]
     }
   ]
 }
 ```
 
-Backward compatibility: readers must treat missing `pre_confidences` / `lock_durations_ms` as `[]`. No migration of old records.
+**Explicit ban**: Full learner answers, rep prompts, reference bridges, and AI feedback cues MUST NOT be persisted to localStorage. Only confidence enum labels, lock durations, answer lengths (counts), ratings (enum labels), and the existing metadata are allowed. This preserves the privacy boundary already set by `answer_lengths`.
+
+**Backward compatibility**: Readers must treat missing `pre_confidences` and `lock_durations_ms` as `[]`. No migration of old records. Length mismatches (legacy edge) are handled by rendering `min(length)` complete rows.
 
 ---
 
@@ -207,37 +267,39 @@ Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
     <div class="graph-repair-predict">
       <div class="graph-detail-kicker">Before you peek</div>
       <div class="graph-repair-predict-group" role="radiogroup" aria-label="Confidence before revealing reference">
-        <button class="graph-repair-predict-pill" data-pre="guessing" role="radio" aria-checked="false">Guessing</button>
-        <button class="graph-repair-predict-pill" data-pre="hunch" role="radio" aria-checked="false">Have a hunch</button>
-        <button class="graph-repair-predict-pill" data-pre="can_explain" role="radio" aria-checked="false">Can explain</button>
+        <button type="button" class="graph-repair-predict-pill trigger-repair-predict" data-pre="guessing" role="radio" aria-checked="false">Guessing</button>
+        <button type="button" class="graph-repair-predict-pill trigger-repair-predict" data-pre="hunch" role="radio" aria-checked="false">Have a hunch</button>
+        <button type="button" class="graph-repair-predict-pill trigger-repair-predict" data-pre="can_explain" role="radio" aria-checked="false">Can explain</button>
       </div>
     </div>
 
     <div class="graph-detail-kicker">Your bridge</div>
-    <textarea class="graph-repair-input" rows="4"></textarea>
+    <textarea class="graph-repair-input" rows="4" aria-describedby="repair-reveal-helper">${escHtml(state.currentAnswer || "")}</textarea>
     <p class="graph-detail-copy graph-repair-helper">Trace the causal link in one or two sentences.</p>
   </section>
   <section class="graph-detail-surface graph-study-next graph-repair-next">
     <p class="graph-detail-copy graph-repair-truth-line">Practice only. Graph progress comes from re-drill.</p>
-    <button class="btn-start-drill graph-detail-action trigger-repair-reveal" disabled>Lock in and show reference bridge</button>
+    <button class="btn-start-drill graph-detail-action trigger-repair-reveal" disabled aria-describedby="repair-reveal-helper">Lock in and show reference bridge</button>
+    <p class="graph-repair-reveal-helper" id="repair-reveal-helper">Pick a stance and type your bridge to continue.</p>
   </section>
 </div>
 ```
 
-A selected pill carries `aria-checked="true"` and `.is-selected`.
+A selected pill carries `aria-checked="true"` and `.is-selected`. The aria-describedby helper names both requirements for the disabled button.
 
 ### Revealed State
 
-Unchanged from the Phase 1+2 spec, with two additions:
+Unchanged from Phase 1+2 focused-mode spec, with these additions:
 
-- The pill row remains visible above `Your bridge` with the locked-in pill highlighted and the row marked `aria-disabled="true"`.
-- The textarea is `readonly`.
+- Pill row remains visible above `Your bridge` with the locked-in pill highlighted and the row marked `aria-disabled="true"` and class `.is-locked` (CSS sets `pointer-events: none` and `cursor: default` on children).
+- Textarea is rendered with the `readonly` attribute.
+- Self-rating row continues to use the existing `Close match` / `Partly linked` / `Missed the link` labels and `rateRepairRep()` handler from `docs/product/repair-reps-self-rating-spec.md`. No label changes.
 
 No inline per-rep calibration readout is rendered in this state.
 
 ### Complete State
 
-Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
+Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`. Rating labels in the summary use the existing mapping: `close_match -> Close match`, `partial -> Partly linked`, `missed -> Missed the link`. Pre-confidence labels use: `guessing -> Guessing`, `hunch -> Have a hunch`, `can_explain -> Can explain`.
 
 ```html
 <div class="graph-repair-context-strip">
@@ -249,13 +311,13 @@ Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
   <div class="graph-detail-kicker">Repair Reps</div>
   <div class="graph-repair-progress" aria-label="Repair Reps progress">...</div>
   <h3 class="graph-detail-title">Practice logged</h3>
-  <p class="graph-detail-copy">Three bridge reps saved on &lt;node label&gt;.</p>
+  <p class="graph-detail-copy">Three bridge reps saved on <node label>.</p>
 
   <div class="graph-repair-summary graph-repair-calibration">
     <div class="graph-repair-summary-row">
       <span class="graph-repair-summary-rep">Rep 1</span>
       <span class="graph-repair-summary-pair"><span class="muted">Predicted:</span> Have a hunch</span>
-      <span class="graph-repair-summary-pair"><span class="muted">Rated:</span> Partial</span>
+      <span class="graph-repair-summary-pair"><span class="muted">Rated:</span> Partly linked</span>
     </div>
     <div class="graph-repair-summary-row">...Rep 2...</div>
     <div class="graph-repair-summary-row">...Rep 3...</div>
@@ -266,15 +328,20 @@ Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
 </div>
 ```
 
+If `pre_confidences` is missing from a legacy record, render the rep row with `Predicted: Not recorded` OR omit the Predicted span entirely, per the Edge Cases rule.
+
 ### Event Listeners
 
 | Selector | Event | Handler | Bound in |
 |----------|-------|---------|----------|
-| `.graph-repair-predict-pill` | `click` | `window.SocratinkApp?.selectRepairPreConfidence?.(btn.dataset.pre)` | `renderCurrentDetail()` in `public/js/graph-view.js` |
-| `.graph-repair-input` | `input` | Enable `.trigger-repair-reveal` only when trimmed input is non-empty AND `preConfidence !== null` | `renderCurrentDetail()` in `public/js/graph-view.js` |
-| `.trigger-repair-reveal` | `click` | `window.SocratinkApp?.revealRepairRep?.(answer)` (extended to validate `preConfidence` and stamp `lockedAt` before calling existing reveal path) | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.trigger-repair-predict` | `click` | `window.SocratinkApp?.setRepairRepPreConfidence?.(btn.dataset.pre)` | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.graph-repair-input` | `input` | `window.SocratinkApp?.setRepairRepsDraft?.(textarea.value)` (a thin wrapper that calls `setRepairRepsState({ currentAnswer: value })`) plus the existing enable/disable predicate that checks non-empty input AND non-null `currentPreConfidence` | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.trigger-repair-reveal` | `click` | `window.SocratinkApp?.revealRepairRep?.(textarea.value.trim())` (now gated inside the function, not only by button `disabled`) | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.trigger-repair-rate` | `click` | `window.SocratinkApp?.rateRepairRep?.(btn.dataset.rating)` (unchanged) | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.trigger-repair-next` | `click` | `window.SocratinkApp?.nextRepairRep?.()` (unchanged; reducer resets per-rep fields and restamps `repStartedAt`) | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.trigger-repair-exit` | `click` | `window.SocratinkApp?.exitRepairReps?.()` (unchanged) | `renderCurrentDetail()` in `public/js/graph-view.js` |
 
-All existing listeners (`.trigger-repair-rate`, `.trigger-repair-next`, `.trigger-repair-exit`, `.trigger-reopen`) remain unchanged.
+`setRepairRepsDraft` may be inlined if `setRepairRepsState` is already safe to call from a listener.
 
 ---
 
@@ -322,9 +389,19 @@ New rules in `public/css/layout.css`:
   font-weight: 600;
 }
 
+.graph-repair-predict-group.is-locked,
+.graph-repair-predict-group[aria-disabled="true"] {
+  pointer-events: none;
+}
+.graph-repair-predict-group.is-locked .graph-repair-predict-pill,
 .graph-repair-predict-group[aria-disabled="true"] .graph-repair-predict-pill {
   cursor: default;
-  pointer-events: none;
+}
+
+.graph-repair-reveal-helper {
+  font-size: 11px;
+  color: var(--text-sub);
+  margin: 6px 0 0;
 }
 
 .graph-repair-calibration .graph-repair-summary-row {
@@ -360,7 +437,7 @@ New rules in `public/css/layout.css`:
 }
 ```
 
-Animations must continue to respect the existing reduced-motion override from the focused-mode spec.
+Animations continue to respect the existing reduced-motion override from the focused-mode spec.
 
 ---
 
@@ -374,9 +451,9 @@ None. This slice does not make new LLM calls and does not change `app_prompts/re
 
 **Requires**:
 - Phase 1+2 focused-mode spec already implemented (`docs/product/repair-reps-focused-mode-spec.md`).
-- Existing self-rating behavior (`docs/product/repair-reps-self-rating-spec.md`).
+- Existing self-rating behavior with its labels and stored values (`docs/product/repair-reps-self-rating-spec.md`).
 - Existing card-stack animation behavior (`docs/product/repair-reps-card-stack-spec.md`).
-- Existing state machine: `startRepairReps()`, `repairRepsState`, `setRepairRepsState()`, `revealRepairRep()`, `rateRepairRep()`, `nextRepairRep()`, `exitRepairReps()`, `completeRepairReps()`.
+- Existing state machine: `startRepairReps()`, `repairRepsState`, `setRepairRepsState()`, `revealRepairRep()`, `rateRepairRep()`, `nextRepairRep()`, `exitRepairReps()`, `recordRepairRepsCompletion()`.
 
 **Enables**:
 - Future: calibration analytics tile (post-DB), split Claim/Mechanism fields, hedge detector, rep-dot hover explanations.
@@ -387,13 +464,14 @@ None. This slice does not make new LLM calls and does not change `app_prompts/re
 
 | File | Change |
 |------|--------|
-| `public/js/graph-view.js` | Extend `repairRepsMarkupForNode()` ready and complete states. Add `repairPredictPillsMarkup()` and `repairCalibrationSummaryMarkup()` helpers. Extend listener binding for `.graph-repair-predict-pill`. Update reveal-enable predicate. |
-| `public/js/app.js` | Add `selectRepairPreConfidence()` dispatcher on `window.SocratinkApp`. Extend `revealRepairRep()` precondition and reveal handler to stamp `lockedAt` / push `preConfidences` / push `lockDurationsMs`. Extend `completeRepairReps()` localStorage write to include the two new arrays. |
-| `public/css/layout.css` | Add `.graph-repair-predict`, `.graph-repair-predict-group`, `.graph-repair-predict-pill`, `.graph-repair-calibration` rules. Respect reduced-motion. |
+| `public/js/graph-view.js` | Extend `repairRepsMarkupForNode()` ready and complete states. Add `repairPredictPillsMarkup()` and `repairCalibrationSummaryMarkup()` helpers. Extend listener binding for `.trigger-repair-predict` and extend the `.graph-repair-input` listener to update `currentAnswer`. Update reveal-enable predicate to require both conditions. Render textarea value from state for draft preservation. |
+| `public/js/app.js` | Add `setRepairRepPreConfidence()` and `setRepairRepsDraft()` (or inline `setRepairRepsState` use). Extend `startRepairReps()` and `nextRepairRep()` reducer paths to initialize/reset per-rep fields and stamp `repStartedAt`. Extend `revealRepairRep()` preconditions (idempotency + pre-confidence requirement) and body (push to `preConfidences` / `lockDurationsMs`). Extend `recordRepairRepsCompletion()` persisted record. Export new handlers on `window.SocratinkApp`. |
+| `public/css/layout.css` | Add `.graph-repair-predict`, `.graph-repair-predict-group`, `.graph-repair-predict-pill`, `.graph-repair-reveal-helper`, `.graph-repair-calibration` rules. Respect reduced-motion. |
 | `main.py` | None. |
 | `ai_service.py` | None. |
 | `app_prompts/*` | None. |
 | `docs/product/repair-reps-focused-mode-spec.md` | None - this slice extends, does not replace. |
+| `docs/product/repair-reps-self-rating-spec.md` | None - labels and values are consumed as-is. |
 
 ---
 
@@ -410,21 +488,26 @@ None. This slice does not make new LLM calls and does not change `app_prompts/re
 
 ### Manual
 
-1. **Pill renders**: Open Repair Reps on an eligible node. The "Before you peek" kicker and three pills render above "Your bridge". No pill is selected by default.
-2. **Textarea independent of pill**: Type in the textarea before selecting a pill. Typing is accepted. Helper copy remains visible. Reveal button stays disabled.
-3. **Pill-first flow**: Select "Have a hunch". Pill highlights. Textarea is still empty. Reveal button stays disabled.
-4. **Both satisfied**: Select a pill AND type a non-empty attempt. Reveal button enables.
-5. **Clear textarea**: Clear the textarea after enabling. Reveal button re-disables. Pill selection persists.
-6. **Change pill pre-reveal**: Select a different pill before clicking reveal. Highlight moves to the new pill. Reveal button stays enabled (assuming non-empty attempt).
-7. **Single-click reveal**: Click "Lock in and show reference bridge". Textarea becomes readonly. Pill row becomes non-interactive (highlight persists). Reference bridge unfolds with the existing animation. Self-rating row appears.
-8. **Try to change pill post-reveal**: Click pills after reveal. Nothing happens. Selected pill remains highlighted.
-9. **Complete 3 reps**: Progress through all three reps with different predicted/rated combinations.
-10. **Completion summary**: Verify the calibration summary shows three rows with `Rep N - Predicted: X - Rated: Y` pairs. Language is observational (no "overconfident" etc.). "These reps are saved. Graph progress comes from the next re-drill." appears below the summary.
-11. **localStorage**: Inspect `localStorage.learnops_repair_reps_v1`. The completion record has `pre_confidences: [...]` and `lock_durations_ms: [...]` arrays, each length 3, in rep order.
-12. **Old record backward compat**: Manually inject a pre-slice-B record (without the new arrays) into localStorage and re-open Repair Reps for that node. Existing summary does not crash; missing arrays render as absent (no calibration section, or padded `-`).
-13. **Exit from completion**: Click "Back to graph". Graph pointer behavior and normal layout return. `repairRepsState` resets.
-14. **Reduced motion**: Enable `prefers-reduced-motion: reduce`. Pill transitions, reveal animation, and card-stack animations are all suppressed.
-15. **A11y**: Pills are keyboard-focusable, arrow-key navigable via the `role="radiogroup"` hint, and screen-reader-labeled as a radio group.
+1. **Pill renders**: Open Repair Reps on an eligible node. "Before you peek" kicker and three pills render above "Your bridge". No pill selected. Reveal button disabled. Helper text reads `Pick a stance and type your bridge to continue.`
+2. **Textarea independent of pill**: Type before selecting a pill. Helper copy remains visible. Reveal button stays disabled.
+3. **Pill-first flow**: Select `Have a hunch`. Pill highlights with `aria-checked="true"`. Textarea still empty. Reveal button stays disabled.
+4. **Type-then-pill draft preservation**: Type `test draft`, THEN select `Guessing`. Verify the textarea still reads `test draft` after the re-render. This is the draft-preservation test.
+5. **Both satisfied**: Pill + non-empty trimmed attempt. Reveal button enables.
+6. **Clear textarea**: Clear after enabling. Reveal button re-disables. Pill selection persists.
+7. **Change pill pre-reveal**: Select different pill. Highlight moves. Reveal stays enabled.
+8. **Single-click reveal**: Click `Lock in and show reference bridge`. Textarea becomes `readonly`. Pill row gets `aria-disabled="true"` and `.is-locked`; clicking pills now does nothing. Reference unfolds. Self-rating row (`Close match` / `Partly linked` / `Missed the link`) appears.
+9. **Post-reveal pill attempt**: Click pills after reveal. Nothing happens (pointer-events:none).
+10. **Direct revealRepairRep bypass test (console)**: From DevTools, call `window.SocratinkApp.revealRepairRep("something")` BEFORE selecting a pill. Reveal does NOT happen. Then call it again AFTER selecting a pill with a non-empty answer - reveal does happen.
+11. **Idempotency**: After reveal, call `window.SocratinkApp.revealRepairRep(...)` again from DevTools. Assert `lockedAt`, `preConfidences`, and `lockDurationsMs` are each written exactly once for this rep.
+12. **Lock duration**: Use DevTools to confirm `lockedAt - repStartedAt > 0` and that `repStartedAt` resets on `nextRepairRep()`.
+13. **Complete 3 reps**: Progress through all three with different predicted/rated combinations (at least one of each enum).
+14. **Completion summary**: Three rows with `Rep N` / `Predicted: <label>` / `Rated: <label>` using the fixed label map. Language observational, no "overconfident" / "miscalibrated". "These reps are saved. Graph progress comes from the next re-drill." visible below the summary.
+15. **localStorage record**: Inspect `localStorage.learnops_repair_reps_v1`. Completion record has `pre_confidences` (length 3), `lock_durations_ms` (length 3, all positive integers), alongside existing `ratings`, `answer_lengths`. No `answer`, `prompt`, `target_bridge`, or `feedback_cue` fields present.
+16. **Old record backward compat**: Inject a pre-slice-B record (without the two new arrays) into localStorage and re-open Repair Reps on a completed node if the UI surfaces history. Rendering must not crash. Calibration section either omits the rows entirely or renders `Predicted: Not recorded`.
+17. **Length-mismatch legacy**: Inject a record with `pre_confidences.length === 2` but `ratings.length === 3`. Summary renders 2 complete rows, no crash.
+18. **Exit**: `Back to graph` releases focused mode. State resets.
+19. **Reduced motion**: Pill transitions, reveal animation, card-stack animations all suppressed under `prefers-reduced-motion: reduce`.
+20. **A11y**: Tab cycles into the pill group. Pills are keyboard activatable via Space/Enter. Selected pill has `aria-checked="true"`. Disabled reveal button announces helper text via `aria-describedby`.
 
 ### Regression
 
@@ -439,11 +522,11 @@ None. This slice does not make new LLM calls and does not change `app_prompts/re
 
 1. Does it preserve the three-phase loop? **Yes** - Repair Reps remains optional practice outside cold attempt, study, and scored re-drill transitions.
 2. Does it make the current target and phase clearer? **Yes** - the pre-reveal pill names the stance; the calibration summary names the gap at completion.
-3. Does it reward real reconstruction or buffer echo? **Yes** - the reveal gate requires a non-empty attempt; the pill adds a pre-reveal commitment.
+3. Does it reward real reconstruction or buffer echo? **Yes** - the reveal gate requires a non-empty attempt AND a committed stance, enforced in `revealRepairRep()`.
 4. Does the AI support the loop or replace the thinking? **Yes** - the reference bridge still appears only after learner generation and still does not score the answer.
-5. Does it frame difficulty as exploration or evaluation? **Yes** - "Predicted / Rated" is observational; no judgmental labels.
+5. Does it frame difficulty as exploration or evaluation? **Yes** - `Predicted / Rated` is observational; no judgmental labels.
 6. Does the graph tell the truth? **Yes** - no graph mutation paths are touched; pre-confidence is practice metadata, not progress evidence.
-7. Would the learner still choose this behavior if they knew how the system influenced them? **Yes** - the pill is a low-cost stance; the soft gate is explicit via button label; the completion readout is observational.
+7. Would the learner still choose this behavior if they knew how the system influenced them? **Yes** - the pill is a low-cost stance; the gate is explicit via button label and helper text; the completion readout is observational.
 
 ---
 
@@ -454,6 +537,6 @@ None. This slice does not make new LLM calls and does not change `app_prompts/re
 | Spec review | **elliot** | Validate that Slice B does not conflict with focused-mode, card-stack, or self-rating specs and that copy preserves graph truth. |
 | Gap analysis | **praxis:gap-analysis** | 7-check pass (inversion, second-order, MECE, map vs territory, adversarial, simplicity, reversibility) before writing-plans is invoked. |
 | Plan writing | **superpowers:writing-plans** | Turn this spec into an ordered implementation plan with TDD checkpoints. |
-| Implementation | **socratinker** via **gm** | PLAN -> EXECUTE -> EMIT -> VERIFY -> COMPLETE state machine. Order: state additions, markup helpers, listeners, CSS, storage-write extension, test manual flow in browser. |
-| QA / release gate | **thurman** | Run the automated checks and manual browser flow; verify backward-compat localStorage read; verify `prefers-reduced-motion`. |
+| Implementation | **socratinker** via **gm** | PLAN -> EXECUTE -> EMIT -> VERIFY -> COMPLETE state machine. Order: state additions + reducer, markup helpers, listeners, CSS, storage-write extension, manual browser flow. |
+| QA / release gate | **thurman** | Run the automated checks and full manual browser flow; verify backward-compat localStorage read, idempotency, direct-call bypass, draft preservation, and `prefers-reduced-motion`. |
 | Post-implementation review | **glenna** | Review whether the multi-agent handoff kept role boundaries clear and whether the final implementation followed the slice scope without creep into deferred P0-P3 items. |

--- a/docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md
+++ b/docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md
@@ -1,0 +1,459 @@
+# Socratink - Repair Reps Slice B: Metacognitive Loop Spec
+
+## Agent Summary
+
+> **What this document is**: This spec governs the *metacognitive loop* addition
+> to the Repair Reps focused workbench: a pre-reveal confidence pill, a soft
+> reveal gate that requires both a non-empty attempt and a committed stance, a
+> single-click lock-and-reveal mechanic, and a completion-summary calibration
+> readout pairing predicted confidence with self-rated outcome. This is
+> Slice B on top of already-specced Phase 1+2 copy/layout work in
+> `docs/product/repair-reps-focused-mode-spec.md`.
+>
+> **When to read it**:
+> - Before changing `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
+> - Before changing `.graph-repair-card`, `.graph-repair-predict`, `.graph-repair-rating-group`, or `.graph-repair-summary` rules in `public/css/layout.css`.
+> - Before extending the `learnops_repair_reps_v1` localStorage record shape.
+> - Before changing the visible wording around "Before you peek", "Lock in and show reference bridge", or the per-rep calibration summary.
+>
+> **What it is NOT**: This does not replace or modify `docs/product/repair-reps-focused-mode-spec.md` (Phase 1+2 focused layout), `docs/product/repair-reps-card-stack-spec.md` (card-stack animation vocabulary), or `docs/product/repair-reps-self-rating-spec.md` (self-rating semantics). It does not change the Repair Reps backend generation contract in `main.py` or `ai_service.py`. It does not change `/api/repair-reps`, `RepairRepsRequest`, or `app_prompts/repair-reps-system-v1.md`.
+>
+> **Key constraints** (inherited and extended):
+> - Repair Reps must not call `patchActiveConceptDrillOutcome()`, `recordInterleavingEvent()`, or `markNodeVisitedThisSession()`.
+> - Repair Reps must not mutate `drill_status`, `drill_phase`, `study_completed_at`, `re_drill_eligible_after`, `gap_type`, or `gap_description`.
+> - Reference bridge must render only after the learner has committed a pre-reveal confidence *and* typed a non-empty answer.
+> - The reveal button is the single commitment point — one click locks the attempt and reveals the reference.
+> - Pre-confidence and lock durations are persisted on completion only; never during an in-progress rep.
+> - Calibration readout must be observational ("Predicted: X - Rated: Y") — never judgmental ("overconfident", "miscalibrated").
+> - Confidence values must not mutate graph state, feed routing, or appear as progress/mastery evidence.
+> - Copy must avoid score, correct, mastered, streak, win, or celebration language.
+
+---
+
+## Motivation
+
+Today's Repair Reps workbench accepts a bridge, reveals a reference on demand, and logs a self-rating. It misses the metacognitive beat: the learner never has to declare a stance *before* seeing the answer, so the reveal becomes a peek rather than a commitment. Without commitment, the self-rating collapses into hindsight, and the founder using the product loses the calibration signal that separates "I thought I knew this" from "I knew this."
+
+Slice B adds the smallest possible pre-reveal commitment device (three pills), soft-gates the reveal behind that commitment plus a typed attempt, and surfaces predicted-vs-rated pairs in the completion summary. No new routes, no new backend, no new graph state. It is a frontend rendering and localStorage-shape change.
+
+This slice is intentionally narrower than the full metacognitive-UX review (P0-P3, 30+ items). Deferred for future slices: split Claim/Mechanism fields, hedge-word detector, autosave, rep-dot hover explanations, "I don't know yet" help path, and analytics calibration tiles.
+
+---
+
+## Assumptions
+
+- The implementation can use the existing `syncInteractionChrome()` mode hooks: `.graph-layout.mode-repair-reps` and `.graph-detail.is-repair-reps`.
+- The existing `repairRepsState` shape can absorb two new transient fields (`preConfidence`, `lockedAt`) without schema churn at the module boundary.
+- The existing `learnops_repair_reps_v1` localStorage entry is readable by older callers that do not know about the new fields; missing arrays are treated as `[]`.
+- Repair Reps evidence writes happen on completion only, as already specced. No per-rep localStorage writes.
+- No DB layer. localStorage is the sole persistence substrate for this slice.
+- The founder is the only user during this slice's lifespan. No telemetry infrastructure is added.
+
+---
+
+## Behavior
+
+### Primary Flow
+
+1. The learner enters Repair Reps focused mode from an eligible node, per existing spec.
+2. The rep card renders the standard context strip, node title, rep prompt, and the Phase 1+2 "Your bridge" label / textarea / helper copy.
+3. A new **"Before you peek"** section renders directly above the "Your bridge" label. It contains:
+   - The kicker: `Before you peek`
+   - A horizontal row of three pills: `Guessing` / `Have a hunch` / `Can explain`
+4. The learner can type into the textarea at any time; typing does not require a pill selection. Order-independent: pill-then-type and type-then-pill are both valid.
+5. The **"Lock in and show reference bridge"** button is disabled until both conditions are true:
+   - A pill has been selected (stored as `preConfidence`)
+   - The textarea trimmed value is non-empty
+6. On button click (single click), the following happens atomically:
+   - `repairRepsState.lockedAt` is stamped with `Date.now()`
+   - The textarea becomes `readonly`
+   - The pill row becomes non-interactive (visually keeps the selected pill highlighted)
+   - The reference bridge panel unfolds with the existing reveal animation
+   - The self-rating row renders below, matching the Phase 1+2 revealed-state markup
+7. The learner selects one self-rating (`Matched` / `Partial` / `Off track`). The next-rep advance fires as before.
+8. After the third rep rating, the card transitions to the Repair Reps complete state.
+9. The complete state shows the existing `Practice logged` heading, the existing context strip, and a new per-rep calibration summary block:
+   - Three rows, one per rep: `Rep 1 - Predicted: Have a hunch - Rated: Partial`, etc.
+   - Completion evidence is written to `learnops_repair_reps_v1` with the extended shape (see Storage Schema below).
+10. The learner clicks `Back to graph`. State is released via the existing `exitRepairReps()` path.
+
+### Edge Cases
+
+- **Learner never picks a pill**: Reveal button stays disabled. The learner cannot reveal the reference without selecting a stance. This is intentional; it is the metacognitive gate.
+- **Learner picks pill, types, then clears the textarea**: Reveal button re-disables. Pill selection persists.
+- **Learner picks pill, types, reveals, then attempts to change pill**: The pill row is non-interactive after reveal. Pre-confidence is frozen at reveal time.
+- **Loading state**: The "Before you peek" section does not render during loading. The existing loading markup is unchanged.
+- **Error state**: The pill section does not render. Existing error markup is unchanged.
+- **Reduced motion**: The pill-row appearance, button-enable transition, and reveal animation all respect `prefers-reduced-motion: reduce`.
+- **Old evidence records**: Existing `learnops_repair_reps_v1` records without `pre_confidences` or `lock_durations_ms` remain readable. Readers must treat missing arrays as `[]` and tolerate length mismatches with `ratings` and `answer_lengths`.
+- **Mobile layout**: Pill row wraps to a second line on narrow panels. The reveal button remains full-width below.
+
+---
+
+## Invariant Boundary
+
+This slice must NOT:
+
+- Call or modify `patchActiveConceptDrillOutcome()`, `recordInterleavingEvent()`, or `markNodeVisitedThisSession()`. Pre-confidence and lock duration are practice metadata, not drill outcomes.
+- Mutate `concept.graphData`, `drill_status`, `drill_phase`, `study_completed_at`, `re_drill_eligible_after`, `gap_type`, or `gap_description`.
+- Treat `pre_confidence`, `lock_durations_ms`, or the calibration pairs as evidence of understanding. They are metacognitive self-report.
+- Display the calibration readout per-rep inline (only in the completion summary).
+- Use judgmental labels in the calibration readout ("overconfident", "miscalibrated", "wrong"). Language stays observational.
+- Route, filter, or prioritize nodes based on pre-confidence values. Scheduling is the re-drill system's job.
+- Add a separate `Lock in` button. The single button `Lock in and show reference bridge` is the commitment point.
+- Add a confirm modal, side-by-side diff view, or "I don't know yet" help path. Those are deferred.
+- Change `/api/repair-reps`, `RepairRepsRequest`, `generate_repair_reps()`, `RepairRepsEvaluation`, or `app_prompts/repair-reps-system-v1.md`.
+- Add manual JS `element.style.pointerEvents` mutations. Graph interactivity continues to flow through the existing `.mode-repair-reps` CSS gate.
+
+---
+
+## State Changes
+
+### New or Modified State
+
+`repairRepsState` gains two transient fields:
+
+```
+repairRepsState.preConfidence: "guessing" | "hunch" | "can_explain" | null = null
+  - Per-rep pre-reveal confidence selection.
+  - Resets to null when `nextRepairRep()` advances to the next rep.
+  - Null indicates the learner has not yet selected a stance; reveal button stays disabled.
+
+repairRepsState.preConfidences: Array<"guessing"|"hunch"|"can_explain"> = []
+  - Accumulated per-rep selections, pushed on each reveal.
+  - Length matches completed-rep count.
+
+repairRepsState.lockedAt: number | null = null
+  - Per-rep timestamp at reveal-button click (Date.now()).
+  - Resets to null on `nextRepairRep()`.
+
+repairRepsState.lockDurationsMs: Array<number> = []
+  - Accumulated per-rep durations: `lockedAt - repStartAt`, pushed on reveal.
+  - `repStartAt` is captured on rep entry (new internal timestamp in the reducer, not exposed).
+```
+
+No existing state fields are renamed or repurposed.
+
+### New or Modified Functions
+
+**`repairRepsMarkupForNode(data, repairState = {})`** in `public/js/graph-view.js`:
+Modify the ready-before-reveal markup to include the "Before you peek" pill section above `Your bridge`. Modify the button label to `Lock in and show reference bridge`. Modify the complete-state markup to render the per-rep calibration summary.
+
+**`repairPredictPillsMarkup(currentPreConfidence)`** in `public/js/graph-view.js`:
+New helper that returns the three-pill markup for the predict block. Must be pure; no state mutation.
+
+**`repairCalibrationSummaryMarkup(preConfidences, ratings)`** in `public/js/graph-view.js`:
+New helper that returns the per-rep `Predicted: X - Rated: Y` summary block. Tolerates array length mismatches gracefully (pads with `-`).
+
+**`setRepairRepsState(patch)`** in `public/js/graph-view.js` (or wherever the reducer lives):
+Must handle `preConfidence`, `lockedAt`, and the reveal-transition atomic update (push to `preConfidences` + `lockDurationsMs`, set textarea readonly flag).
+
+**`revealRepairRep(answer)`** in `public/js/app.js` (or graph-view.js, wherever defined):
+Extend preconditions: require both non-empty trimmed answer AND non-null `preConfidence`. On success, stamp `lockedAt`, push to `preConfidences` and `lockDurationsMs`, then call the existing reveal path.
+
+**`completeRepairReps()`** in `public/js/app.js` (or wherever the completion write happens):
+Extend the `learnops_repair_reps_v1` write to include `pre_confidences` and `lock_durations_ms` arrays.
+
+### Storage Schema
+
+The existing `learnops_repair_reps_v1` key gains two additive arrays. Schema after this slice:
+
+```json
+{
+  "concept_id::node_id": [
+    {
+      "completed_at": "ISO timestamp",
+      "rep_count": 3,
+      "prompt_version": "repair-reps-system-v1",
+      "gap_type": "string|null",
+      "answer_lengths": [0, 0, 0],
+      "ratings": ["close_match", "partial", "missed"],
+      "pre_confidences": ["guessing", "hunch", "can_explain"],
+      "lock_durations_ms": [12034, 8120, 15240]
+    }
+  ]
+}
+```
+
+Backward compatibility: readers must treat missing `pre_confidences` / `lock_durations_ms` as `[]`. No migration of old records.
+
+---
+
+## API Changes
+
+None. Backend, request models, response models, prompts, and AI generation behavior are unchanged.
+
+---
+
+## Markup / UI
+
+### Ready (before reveal) State
+
+Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
+
+```html
+<div class="graph-repair-context-strip">
+  <span>Node label</span>
+  <span>Repair Rep 1 of 3</span>
+  <span>Practice only</span>
+</div>
+<div class="graph-study-shell graph-repair-shell">
+  <section class="graph-detail-surface graph-repair-card is-dealing">
+    <div class="graph-detail-kicker">Repair Rep 1 of 3</div>
+    <div class="graph-repair-progress" aria-label="Repair Reps progress">...</div>
+    <h3 class="graph-detail-title">Node label</h3>
+    <p class="graph-detail-copy">Rep prompt</p>
+
+    <div class="graph-repair-predict">
+      <div class="graph-detail-kicker">Before you peek</div>
+      <div class="graph-repair-predict-group" role="radiogroup" aria-label="Confidence before revealing reference">
+        <button class="graph-repair-predict-pill" data-pre="guessing" role="radio" aria-checked="false">Guessing</button>
+        <button class="graph-repair-predict-pill" data-pre="hunch" role="radio" aria-checked="false">Have a hunch</button>
+        <button class="graph-repair-predict-pill" data-pre="can_explain" role="radio" aria-checked="false">Can explain</button>
+      </div>
+    </div>
+
+    <div class="graph-detail-kicker">Your bridge</div>
+    <textarea class="graph-repair-input" rows="4"></textarea>
+    <p class="graph-detail-copy graph-repair-helper">Trace the causal link in one or two sentences.</p>
+  </section>
+  <section class="graph-detail-surface graph-study-next graph-repair-next">
+    <p class="graph-detail-copy graph-repair-truth-line">Practice only. Graph progress comes from re-drill.</p>
+    <button class="btn-start-drill graph-detail-action trigger-repair-reveal" disabled>Lock in and show reference bridge</button>
+  </section>
+</div>
+```
+
+A selected pill carries `aria-checked="true"` and `.is-selected`.
+
+### Revealed State
+
+Unchanged from the Phase 1+2 spec, with two additions:
+
+- The pill row remains visible above `Your bridge` with the locked-in pill highlighted and the row marked `aria-disabled="true"`.
+- The textarea is `readonly`.
+
+No inline per-rep calibration readout is rendered in this state.
+
+### Complete State
+
+Produced by `repairRepsMarkupForNode()` in `public/js/graph-view.js`.
+
+```html
+<div class="graph-repair-context-strip">
+  <span>Node label</span>
+  <span>Repair Reps complete</span>
+  <span>Practice only</span>
+</div>
+<div class="graph-repair-complete">
+  <div class="graph-detail-kicker">Repair Reps</div>
+  <div class="graph-repair-progress" aria-label="Repair Reps progress">...</div>
+  <h3 class="graph-detail-title">Practice logged</h3>
+  <p class="graph-detail-copy">Three bridge reps saved on &lt;node label&gt;.</p>
+
+  <div class="graph-repair-summary graph-repair-calibration">
+    <div class="graph-repair-summary-row">
+      <span class="graph-repair-summary-rep">Rep 1</span>
+      <span class="graph-repair-summary-pair"><span class="muted">Predicted:</span> Have a hunch</span>
+      <span class="graph-repair-summary-pair"><span class="muted">Rated:</span> Partial</span>
+    </div>
+    <div class="graph-repair-summary-row">...Rep 2...</div>
+    <div class="graph-repair-summary-row">...Rep 3...</div>
+  </div>
+
+  <p class="graph-detail-copy">These reps are saved. Graph progress comes from the next re-drill.</p>
+  <button class="btn-start-drill graph-detail-action trigger-repair-exit">Back to graph</button>
+</div>
+```
+
+### Event Listeners
+
+| Selector | Event | Handler | Bound in |
+|----------|-------|---------|----------|
+| `.graph-repair-predict-pill` | `click` | `window.SocratinkApp?.selectRepairPreConfidence?.(btn.dataset.pre)` | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.graph-repair-input` | `input` | Enable `.trigger-repair-reveal` only when trimmed input is non-empty AND `preConfidence !== null` | `renderCurrentDetail()` in `public/js/graph-view.js` |
+| `.trigger-repair-reveal` | `click` | `window.SocratinkApp?.revealRepairRep?.(answer)` (extended to validate `preConfidence` and stamp `lockedAt` before calling existing reveal path) | `renderCurrentDetail()` in `public/js/graph-view.js` |
+
+All existing listeners (`.trigger-repair-rate`, `.trigger-repair-next`, `.trigger-repair-exit`, `.trigger-reopen`) remain unchanged.
+
+---
+
+## CSS
+
+New rules in `public/css/layout.css`:
+
+```css
+.graph-repair-predict {
+  margin-bottom: 18px;
+}
+
+.graph-repair-predict > .graph-detail-kicker {
+  margin-bottom: 8px;
+}
+
+.graph-repair-predict-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.graph-repair-predict-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--surface-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.graph-repair-predict-pill:hover {
+  border-color: var(--accent-border-strong);
+}
+
+.graph-repair-predict-pill.is-selected,
+.graph-repair-predict-pill[aria-checked="true"] {
+  background: var(--accent-soft);
+  border-color: var(--accent-border-strong);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.graph-repair-predict-group[aria-disabled="true"] .graph-repair-predict-pill {
+  cursor: default;
+  pointer-events: none;
+}
+
+.graph-repair-calibration .graph-repair-summary-row {
+  display: grid;
+  grid-template-columns: max-content 1fr 1fr;
+  gap: 10px 16px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.graph-repair-calibration .graph-repair-summary-row:last-child {
+  border-bottom: none;
+}
+
+.graph-repair-summary-rep {
+  font-weight: 700;
+  color: var(--text-sub);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+}
+
+.graph-repair-summary-pair .muted {
+  color: var(--text-sub);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graph-repair-predict-pill {
+    transition: none;
+  }
+}
+```
+
+Animations must continue to respect the existing reduced-motion override from the focused-mode spec.
+
+---
+
+## Prompt / AI Contract
+
+None. This slice does not make new LLM calls and does not change `app_prompts/repair-reps-system-v1.md`, `RepairRepsEvaluation`, or `generate_repair_reps()`.
+
+---
+
+## Dependencies
+
+**Requires**:
+- Phase 1+2 focused-mode spec already implemented (`docs/product/repair-reps-focused-mode-spec.md`).
+- Existing self-rating behavior (`docs/product/repair-reps-self-rating-spec.md`).
+- Existing card-stack animation behavior (`docs/product/repair-reps-card-stack-spec.md`).
+- Existing state machine: `startRepairReps()`, `repairRepsState`, `setRepairRepsState()`, `revealRepairRep()`, `rateRepairRep()`, `nextRepairRep()`, `exitRepairReps()`, `completeRepairReps()`.
+
+**Enables**:
+- Future: calibration analytics tile (post-DB), split Claim/Mechanism fields, hedge detector, rep-dot hover explanations.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `public/js/graph-view.js` | Extend `repairRepsMarkupForNode()` ready and complete states. Add `repairPredictPillsMarkup()` and `repairCalibrationSummaryMarkup()` helpers. Extend listener binding for `.graph-repair-predict-pill`. Update reveal-enable predicate. |
+| `public/js/app.js` | Add `selectRepairPreConfidence()` dispatcher on `window.SocratinkApp`. Extend `revealRepairRep()` precondition and reveal handler to stamp `lockedAt` / push `preConfidences` / push `lockDurationsMs`. Extend `completeRepairReps()` localStorage write to include the two new arrays. |
+| `public/css/layout.css` | Add `.graph-repair-predict`, `.graph-repair-predict-group`, `.graph-repair-predict-pill`, `.graph-repair-calibration` rules. Respect reduced-motion. |
+| `main.py` | None. |
+| `ai_service.py` | None. |
+| `app_prompts/*` | None. |
+| `docs/product/repair-reps-focused-mode-spec.md` | None - this slice extends, does not replace. |
+
+---
+
+## Test Plan
+
+### Automated
+
+- `RepairRepsApiTests.test_repair_reps_api_requires_guest_or_auth_entry` in `tests/test_repair_reps.py`: still passes; no API surface change.
+- `RepairRepsApiTests.test_repair_reps_endpoint_uses_server_resolved_mechanism`: still passes; no backend change.
+- `RepairRepsApiTests.test_generate_repair_reps_returns_exact_three_graph_neutral_reps`: still passes.
+- `AppPromptTests.test_repair_reps_prompt_bans_recognition_and_mastery_shortcuts`: still passes.
+- `node --check public/js/graph-view.js` and `node --check public/js/app.js`: clean.
+- `git diff --check`: clean.
+
+### Manual
+
+1. **Pill renders**: Open Repair Reps on an eligible node. The "Before you peek" kicker and three pills render above "Your bridge". No pill is selected by default.
+2. **Textarea independent of pill**: Type in the textarea before selecting a pill. Typing is accepted. Helper copy remains visible. Reveal button stays disabled.
+3. **Pill-first flow**: Select "Have a hunch". Pill highlights. Textarea is still empty. Reveal button stays disabled.
+4. **Both satisfied**: Select a pill AND type a non-empty attempt. Reveal button enables.
+5. **Clear textarea**: Clear the textarea after enabling. Reveal button re-disables. Pill selection persists.
+6. **Change pill pre-reveal**: Select a different pill before clicking reveal. Highlight moves to the new pill. Reveal button stays enabled (assuming non-empty attempt).
+7. **Single-click reveal**: Click "Lock in and show reference bridge". Textarea becomes readonly. Pill row becomes non-interactive (highlight persists). Reference bridge unfolds with the existing animation. Self-rating row appears.
+8. **Try to change pill post-reveal**: Click pills after reveal. Nothing happens. Selected pill remains highlighted.
+9. **Complete 3 reps**: Progress through all three reps with different predicted/rated combinations.
+10. **Completion summary**: Verify the calibration summary shows three rows with `Rep N - Predicted: X - Rated: Y` pairs. Language is observational (no "overconfident" etc.). "These reps are saved. Graph progress comes from the next re-drill." appears below the summary.
+11. **localStorage**: Inspect `localStorage.learnops_repair_reps_v1`. The completion record has `pre_confidences: [...]` and `lock_durations_ms: [...]` arrays, each length 3, in rep order.
+12. **Old record backward compat**: Manually inject a pre-slice-B record (without the new arrays) into localStorage and re-open Repair Reps for that node. Existing summary does not crash; missing arrays render as absent (no calibration section, or padded `-`).
+13. **Exit from completion**: Click "Back to graph". Graph pointer behavior and normal layout return. `repairRepsState` resets.
+14. **Reduced motion**: Enable `prefers-reduced-motion: reduce`. Pill transitions, reveal animation, and card-stack animations are all suppressed.
+15. **A11y**: Pills are keyboard-focusable, arrow-key navigable via the `role="radiogroup"` hint, and screen-reader-labeled as a radio group.
+
+### Regression
+
+- `python -m unittest tests.test_app_prompts tests.test_repair_reps -v` passes.
+- `python -m unittest discover -s tests -v` passes (call out pre-existing telemetry failures if still present).
+- Normal graph inspect, study, post-drill, cold-attempt-active, and re-drill-active modes retain their existing layouts.
+- `patchActiveConceptDrillOutcome`, `recordInterleavingEvent`, and `markNodeVisitedThisSession` do not appear in any new Repair Reps call path.
+
+---
+
+## Constraints Checklist
+
+1. Does it preserve the three-phase loop? **Yes** - Repair Reps remains optional practice outside cold attempt, study, and scored re-drill transitions.
+2. Does it make the current target and phase clearer? **Yes** - the pre-reveal pill names the stance; the calibration summary names the gap at completion.
+3. Does it reward real reconstruction or buffer echo? **Yes** - the reveal gate requires a non-empty attempt; the pill adds a pre-reveal commitment.
+4. Does the AI support the loop or replace the thinking? **Yes** - the reference bridge still appears only after learner generation and still does not score the answer.
+5. Does it frame difficulty as exploration or evaluation? **Yes** - "Predicted / Rated" is observational; no judgmental labels.
+6. Does the graph tell the truth? **Yes** - no graph mutation paths are touched; pre-confidence is practice metadata, not progress evidence.
+7. Would the learner still choose this behavior if they knew how the system influenced them? **Yes** - the pill is a low-cost stance; the soft gate is explicit via button label; the completion readout is observational.
+
+---
+
+## Agent Routing
+
+| Phase | Owner | Action |
+|-------|-------|--------|
+| Spec review | **elliot** | Validate that Slice B does not conflict with focused-mode, card-stack, or self-rating specs and that copy preserves graph truth. |
+| Gap analysis | **praxis:gap-analysis** | 7-check pass (inversion, second-order, MECE, map vs territory, adversarial, simplicity, reversibility) before writing-plans is invoked. |
+| Plan writing | **superpowers:writing-plans** | Turn this spec into an ordered implementation plan with TDD checkpoints. |
+| Implementation | **socratinker** via **gm** | PLAN -> EXECUTE -> EMIT -> VERIFY -> COMPLETE state machine. Order: state additions, markup helpers, listeners, CSS, storage-write extension, test manual flow in browser. |
+| QA / release gate | **thurman** | Run the automated checks and manual browser flow; verify backward-compat localStorage read; verify `prefers-reduced-motion`. |
+| Post-implementation review | **glenna** | Review whether the multi-agent handoff kept role boundaries clear and whether the final implementation followed the slice scope without creep into deferred P0-P3 items. |

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -1438,6 +1438,97 @@ body:not([data-map-open="true"]) .map-back-link {
   color: var(--text-sub);
   opacity: 1;
 }
+
+/* ── Repair Reps Slice B — pre-reveal pill + calibration summary ── */
+
+.graph-repair-predict {
+  margin-bottom: 18px;
+}
+
+.graph-repair-predict > .graph-detail-kicker {
+  margin-bottom: 8px;
+}
+
+.graph-repair-predict-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.graph-repair-predict-pill {
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-strong);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background var(--duration-micro) var(--ease-standard, ease),
+              border-color var(--duration-micro) var(--ease-standard, ease);
+}
+
+.graph-repair-predict-pill:hover {
+  border-color: var(--accent-border-strong);
+}
+
+.graph-repair-predict-pill.is-selected,
+.graph-repair-predict-pill[aria-checked="true"] {
+  background: var(--accent-soft);
+  border-color: var(--accent-border-strong);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.graph-repair-predict-group.is-locked,
+.graph-repair-predict-group[aria-disabled="true"] {
+  pointer-events: none;
+}
+
+.graph-repair-predict-group.is-locked .graph-repair-predict-pill,
+.graph-repair-predict-group[aria-disabled="true"] .graph-repair-predict-pill {
+  cursor: default;
+}
+
+.graph-repair-reveal-helper {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin: 6px 0 0;
+}
+
+.graph-repair-calibration .graph-repair-summary-row {
+  display: grid;
+  grid-template-columns: max-content 1fr 1fr;
+  gap: 10px 16px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.graph-repair-calibration .graph-repair-summary-row:last-child {
+  border-bottom: none;
+}
+
+.graph-repair-summary-rep {
+  font-weight: 700;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+}
+
+.graph-repair-summary-pair .muted {
+  color: var(--text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graph-repair-predict-pill {
+    transition: none;
+  }
+}
+
 .graph-detail-meta-compact {
   margin-top: 6px;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="styles.css?v=42">
+  <link rel="stylesheet" href="styles.css?v=43">
 </head>
 
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -492,7 +492,7 @@
   <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 
   <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=30"></script>
+  <script type="module" src="js/app.js?v=31"></script>
 
   <!-- Vercel Speed Insights -->
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -492,7 +492,7 @@
   <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 
   <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=29"></script>
+  <script type="module" src="js/app.js?v=30"></script>
 
   <!-- Vercel Speed Insights -->
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -492,7 +492,7 @@
   <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 
   <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=28"></script>
+  <script type="module" src="js/app.js?v=29"></script>
 
   <!-- Vercel Speed Insights -->
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -492,7 +492,7 @@
   <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 
   <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=27"></script>
+  <script type="module" src="js/app.js?v=28"></script>
 
   <!-- Vercel Speed Insights -->
   <script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,7 +1,7 @@
 import { Bus } from './bus.js';
 import { GEO, easeInOutCubic, interpCoords, coordsToPoints } from './geo.js';
 import { Morph, crystalPolygons } from './morph.js';
-import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=4';
+import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=5';
 import { bootstrapAuthUi, buildLoginHref, fetchAuthSession, logout, redirectToLogin } from './auth.js?v=2';
 import { mountLearnerAnalyticsDashboard } from './learner-analytics.js?v=3';
 import {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2437,11 +2437,18 @@ const App = (() => {
   const REPAIR_REP_PRE_CONFIDENCE_VALUES = new Set(['guessing', 'hunch', 'can_explain']);
   const REPAIR_REP_RATING_VALUES = new Set(['close_match', 'partial', 'missed']);
 
-  function recordRepairRepsCompletion({ conceptId, nodeId, repCount, promptVersion, gapType, answerLengths, ratings }) {
+  function recordRepairRepsCompletion({
+    conceptId, nodeId, repCount, promptVersion, gapType,
+    answerLengths, ratings, preConfidences, lockDurationsMs,
+  }) {
     if (!conceptId || !nodeId) return;
     const history = loadRepairRepsHistory();
     const key = `${conceptId}::${nodeId}`;
     const entries = Array.isArray(history[key]) ? history[key] : [];
+    // pre_confidences and lock_durations_ms are practice metadata — a
+    // calibration read-out for the learner. They MUST NOT feed scheduling,
+    // node prioritization, drill_status, or any graph-truth mutation.
+    // See spec §Invariant Boundary.
     history[key] = [
       ...entries,
       {
@@ -2451,6 +2458,8 @@ const App = (() => {
         gap_type: gapType || null,
         answer_lengths: Array.isArray(answerLengths) ? answerLengths : [],
         ratings: Array.isArray(ratings) ? ratings : [],
+        pre_confidences: Array.isArray(preConfidences) ? preConfidences : [],
+        lock_durations_ms: Array.isArray(lockDurationsMs) ? lockDurationsMs : [],
       },
     ].slice(-20);
     saveRepairRepsHistory(history);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,7 +1,7 @@
 import { Bus } from './bus.js';
 import { GEO, easeInOutCubic, interpCoords, coordsToPoints } from './geo.js';
 import { Morph, crystalPolygons } from './morph.js';
-import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=3';
+import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=4';
 import { bootstrapAuthUi, buildLoginHref, fetchAuthSession, logout, redirectToLogin } from './auth.js?v=2';
 import { mountLearnerAnalyticsDashboard } from './learner-analytics.js?v=3';
 import {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2434,6 +2434,7 @@ const App = (() => {
     localStorage.setItem(REPAIR_REPS_STORE_KEY, JSON.stringify(history || {}));
   }
 
+  const REPAIR_REP_PRE_CONFIDENCE_VALUES = new Set(['guessing', 'hunch', 'can_explain']);
   const REPAIR_REP_RATING_VALUES = new Set(['close_match', 'partial', 'missed']);
 
   function recordRepairRepsCompletion({ conceptId, nodeId, repCount, promptVersion, gapType, answerLengths, ratings }) {
@@ -2717,6 +2718,11 @@ const App = (() => {
       isDealing: false,
       isRevealing: false,
       error: null,
+      currentPreConfidence: null,
+      repStartedAt: null,
+      lockedAt: null,
+      preConfidences: [],
+      lockDurationsMs: [],
     });
 
     try {
@@ -2763,6 +2769,11 @@ const App = (() => {
         isDealing: true,
         isRevealing: false,
         error: null,
+        currentPreConfidence: null,
+        repStartedAt: Date.now(),
+        lockedAt: null,
+        preConfidences: [],
+        lockDurationsMs: [],
       });
     } catch (err) {
       console.error(err);
@@ -2783,24 +2794,68 @@ const App = (() => {
         isDealing: false,
         isRevealing: false,
         error: 'Repair Reps could not load. Reopen study and try again later.',
+        currentPreConfidence: null,
+        repStartedAt: null,
+        lockedAt: null,
+        preConfidences: [],
+        lockDurationsMs: [],
       });
     }
   }
 
   function revealRepairRep(answerText = '') {
     if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    // Idempotency: second call on the same rep is a no-op so lockedAt,
+    // preConfidences, and lockDurationsMs are written exactly once.
+    if (repairRepsState.revealed === true) return;
     const answer = String(answerText || '').trim();
     if (!answer) return;
+    if (!REPAIR_REP_PRE_CONFIDENCE_VALUES.has(repairRepsState.currentPreConfidence)) return;
+
+    const currentIndex = repairRepsState.currentIndex || 0;
+    const lockedAt = Date.now();
+    const repStartedAt = Number.isFinite(repairRepsState.repStartedAt)
+      ? repairRepsState.repStartedAt
+      : lockedAt;
+    const lockDuration = Math.max(0, lockedAt - repStartedAt);
+
     const answerLengths = [...(repairRepsState.answerLengths || [])];
-    answerLengths[repairRepsState.currentIndex || 0] = answer.length;
+    answerLengths[currentIndex] = answer.length;
+    const preConfidences = [...(repairRepsState.preConfidences || []), repairRepsState.currentPreConfidence];
+    const lockDurationsMs = [...(repairRepsState.lockDurationsMs || []), lockDuration];
+
     setRepairRepsState({
       ...repairRepsState,
       revealed: true,
       currentAnswer: answer,
       answerLengths,
-      ratingSelected: Boolean(repairRepsState.ratings?.[repairRepsState.currentIndex || 0]),
+      preConfidences,
+      lockDurationsMs,
+      lockedAt,
+      ratingSelected: Boolean(repairRepsState.ratings?.[currentIndex]),
       isDealing: false,
       isRevealing: true,
+    });
+  }
+
+  function setRepairRepPreConfidence(value) {
+    if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    // Pill is frozen post-reveal. UI also suppresses via aria-disabled + pointer-events,
+    // but gate here so direct JS calls cannot mutate the locked-in stance.
+    if (repairRepsState.revealed === true) return;
+    if (!REPAIR_REP_PRE_CONFIDENCE_VALUES.has(value)) return;
+    setRepairRepsState({
+      ...repairRepsState,
+      currentPreConfidence: value,
+    });
+  }
+
+  function setRepairRepDraft(value) {
+    if (!repairRepsState || repairRepsState.status !== 'ready') return;
+    if (repairRepsState.revealed === true) return;
+    setRepairRepsState({
+      ...repairRepsState,
+      currentAnswer: typeof value === 'string' ? value : '',
     });
   }
 
@@ -2832,6 +2887,8 @@ const App = (() => {
         gapType: repairRepsState.gapType,
         answerLengths: repairRepsState.answerLengths,
         ratings: repairRepsState.ratings,
+        preConfidences: repairRepsState.preConfidences,
+        lockDurationsMs: repairRepsState.lockDurationsMs,
       });
       setRepairRepsState({
         ...repairRepsState,
@@ -2851,6 +2908,9 @@ const App = (() => {
       ratingSelected: false,
       isDealing: true,
       isRevealing: false,
+      currentPreConfidence: null,
+      lockedAt: null,
+      repStartedAt: Date.now(),
     });
   }
 
@@ -3993,6 +4053,8 @@ const App = (() => {
     rateRepairRep,
     nextRepairRep,
     exitRepairReps,
+    setRepairRepPreConfidence,
+    setRepairRepDraft,
     getNodeInspectAction,
     runInspectAction,
     deleteConcept,

--- a/public/js/graph-view.js
+++ b/public/js/graph-view.js
@@ -1677,19 +1677,48 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
         if (reopenBtn) reopenBtn.addEventListener('click', () => { window.SocratinkApp?.reopenStudy?.(activeNode.data()); });
         const repairBtn = detailEl.querySelector('.trigger-repair');
         if (repairBtn) repairBtn.addEventListener('click', () => { window.SocratinkApp?.startRepairReps?.(activeNode.data()); });
-        const repairRevealBtn = detailEl.querySelector('.trigger-repair-reveal');
-        if (repairRevealBtn) repairRevealBtn.addEventListener('click', () => {
-          const answer = detailEl.querySelector('.graph-repair-input')?.value || '';
-          window.SocratinkApp?.revealRepairRep?.(answer);
-        });
+
         const repairInput = detailEl.querySelector('.graph-repair-input');
-        if (repairRevealBtn && repairInput) {
+        const repairRevealBtn = detailEl.querySelector('.trigger-repair-reveal');
+
+        // Read the current pre-confidence from app state — the render was
+        // driven by it, so it's authoritative. Re-eval of the reveal-enable
+        // predicate on every keystroke stays DOM-local (no state dispatch)
+        // to avoid destroying caret position on textarea re-render.
+        const repairState = window.SocratinkApp?.getRepairRepsState?.(activeNode.id()) || null;
+        const preConfidenceValid = repairState
+          && (repairState.currentPreConfidence === 'guessing'
+            || repairState.currentPreConfidence === 'hunch'
+            || repairState.currentPreConfidence === 'can_explain');
+
+        if (repairInput && repairRevealBtn) {
           const syncRevealReadiness = () => {
-            repairRevealBtn.disabled = !repairInput.value.trim();
+            const hasAnswer = repairInput.value.trim().length > 0;
+            repairRevealBtn.disabled = !(preConfidenceValid && hasAnswer);
           };
           syncRevealReadiness();
           repairInput.addEventListener('input', syncRevealReadiness);
         }
+
+        if (repairRevealBtn) {
+          repairRevealBtn.addEventListener('click', () => {
+            const answer = repairInput?.value || '';
+            window.SocratinkApp?.revealRepairRep?.(answer);
+          });
+        }
+
+        // Pill listeners — on click, stamp the live textarea draft into
+        // state first (so re-render preserves the in-flight answer), then
+        // set the pre-confidence. The render loop will re-render the
+        // textarea with value="${currentAnswer}" and re-highlight the pill.
+        detailEl.querySelectorAll('.trigger-repair-predict').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            const liveDraft = repairInput?.value || '';
+            window.SocratinkApp?.setRepairRepDraft?.(liveDraft);
+            window.SocratinkApp?.setRepairRepPreConfidence?.(btn.dataset.pre);
+          });
+        });
+
         const repairNextBtn = detailEl.querySelector('.trigger-repair-next');
         if (repairNextBtn) repairNextBtn.addEventListener('click', () => { window.SocratinkApp?.nextRepairRep?.(); });
         detailEl.querySelectorAll('.trigger-repair-rate').forEach((btn) => {

--- a/public/js/graph-view.js
+++ b/public/js/graph-view.js
@@ -550,6 +550,59 @@ function repairRatingMarkup(state, currentIndex) {
   `;
 }
 
+const REPAIR_PRE_CONFIDENCE_LABELS = {
+  guessing: 'Guessing',
+  hunch: 'Have a hunch',
+  can_explain: 'Can explain',
+};
+
+const REPAIR_RATING_SUMMARY_LABELS = {
+  close_match: 'Close match',
+  partial: 'Partly linked',
+  missed: 'Missed the link',
+};
+
+function repairPredictPillsMarkup(currentPreConfidence, isLocked) {
+  const selected = typeof currentPreConfidence === 'string' ? currentPreConfidence : '';
+  const lockedAttr = isLocked ? ' aria-disabled="true"' : '';
+  const lockedClass = isLocked ? ' is-locked' : '';
+  const pill = (value, label) => {
+    const checked = selected === value ? 'true' : 'false';
+    const selClass = selected === value ? ' is-selected' : '';
+    return `<button type="button" class="graph-repair-predict-pill trigger-repair-predict${selClass}" data-pre="${value}" role="radio" aria-checked="${checked}">${label}</button>`;
+  };
+  return `
+    <div class="graph-repair-predict">
+      <div class="graph-detail-kicker">Before you peek</div>
+      <div class="graph-repair-predict-group${lockedClass}" role="radiogroup" aria-label="Confidence before revealing reference"${lockedAttr}>
+        ${pill('guessing', 'Guessing')}
+        ${pill('hunch', 'Have a hunch')}
+        ${pill('can_explain', 'Can explain')}
+      </div>
+    </div>
+  `;
+}
+
+function repairCalibrationSummaryMarkup(preConfidences, ratings) {
+  const preList = Array.isArray(preConfidences) ? preConfidences : [];
+  const rateList = Array.isArray(ratings) ? ratings : [];
+  const rowCount = Math.min(preList.length, rateList.length);
+  if (rowCount === 0) return '';
+  const rows = [];
+  for (let i = 0; i < rowCount; i += 1) {
+    const preLabel = REPAIR_PRE_CONFIDENCE_LABELS[preList[i]] || 'Not recorded';
+    const rateLabel = REPAIR_RATING_SUMMARY_LABELS[rateList[i]] || 'Not recorded';
+    rows.push(`
+      <div class="graph-repair-summary-row">
+        <span class="graph-repair-summary-rep">Rep ${i + 1}</span>
+        <span class="graph-repair-summary-pair"><span class="muted">Predicted:</span> ${escHtml(preLabel)}</span>
+        <span class="graph-repair-summary-pair"><span class="muted">Rated:</span> ${escHtml(rateLabel)}</span>
+      </div>
+    `);
+  }
+  return `<div class="graph-repair-summary graph-repair-calibration">${rows.join('')}</div>`;
+}
+
 function repairRepsMarkupForNode(data, repairState = {}) {
   const state = repairState || {};
   const actionButtonClass = 'btn-start-drill graph-detail-action';
@@ -582,7 +635,9 @@ function repairRepsMarkupForNode(data, repairState = {}) {
   if (status === 'complete') {
     const reps = Array.isArray(state.reps) ? state.reps : [];
     const ratings = Array.isArray(state.ratings) ? state.ratings : [];
-    const summaryRows = reps.length
+    const preConfidences = Array.isArray(state.preConfidences) ? state.preConfidences : [];
+    const calibrationMarkup = repairCalibrationSummaryMarkup(preConfidences, ratings);
+    const legacySummaryRows = reps.length && !calibrationMarkup
       ? reps.map((rep, index) => {
         const rating = ratings[index] || '';
         return `
@@ -599,7 +654,8 @@ function repairRepsMarkupForNode(data, repairState = {}) {
         <div class="graph-detail-kicker">Repair Reps</div>
         ${repairProgressMarkup({ currentIndex: 2, total: Math.max(reps.length, 3), complete: true })}
         <h3 class="graph-detail-title">Practice logged</h3>
-        ${summaryRows ? `<div class="graph-repair-summary">${summaryRows}</div>` : ''}
+        <p class="graph-detail-copy">Three bridge reps saved on ${escHtml(nodeLabel)}.</p>
+        ${calibrationMarkup || (legacySummaryRows ? `<div class="graph-repair-summary">${legacySummaryRows}</div>` : '')}
         <p class="graph-detail-copy">These reps are saved. Graph progress comes from the next re-drill.</p>
         <button class="${actionButtonClass} trigger-repair-exit">Back to graph</button>
       </div>
@@ -620,8 +676,13 @@ function repairRepsMarkupForNode(data, repairState = {}) {
   }
 
   const revealed = Boolean(state.revealed);
-  const typedAnswer = revealed ? escHtml(state.currentAnswer || '') : '';
+  const typedAnswer = escHtml(state.currentAnswer || '');
   const ratingSelected = Boolean(state.ratingSelected || state.ratings?.[currentIndex]);
+  const preConfidence = state.currentPreConfidence || '';
+  const pillsMarkup = repairPredictPillsMarkup(preConfidence, revealed);
+  const preConfidenceValid = preConfidence === 'guessing' || preConfidence === 'hunch' || preConfidence === 'can_explain';
+  const hasAnswer = typeof state.currentAnswer === 'string' && state.currentAnswer.trim().length > 0;
+  const revealReady = preConfidenceValid && hasAnswer;
   return `
     ${repairContextStripMarkup({ nodeLabel, phaseLabel: `Repair Rep ${currentIndex + 1} of ${reps.length}` })}
     <div class="graph-study-shell graph-repair-shell">
@@ -629,8 +690,9 @@ function repairRepsMarkupForNode(data, repairState = {}) {
         ${repairProgressMarkup({ currentIndex, total: reps.length })}
         <div class="graph-detail-kicker">Causal bridge</div>
         <p class="graph-detail-copy">${escHtml(rep.prompt)}</p>
+        ${pillsMarkup}
         <div class="graph-detail-kicker">Your bridge</div>
-        <textarea class="graph-repair-input" rows="4" ${revealed ? 'readonly' : ''}>${typedAnswer}</textarea>
+        <textarea class="graph-repair-input" rows="4" aria-describedby="repair-reveal-helper" ${revealed ? 'readonly' : ''}>${typedAnswer}</textarea>
         ${revealed ? '' : '<p class="graph-detail-copy graph-repair-helper">Trace the causal link in one or two sentences.</p>'}
         ${revealed ? `
           <div class="graph-repair-bridge ${state.isRevealing ? 'is-revealing' : ''}">
@@ -647,7 +709,10 @@ function repairRepsMarkupForNode(data, repairState = {}) {
           ? (ratingSelected
             ? `<button class="${actionButtonClass} trigger-repair-next">${currentIndex + 1 >= reps.length ? 'Finish Reps' : 'Next Rep'}</button>`
             : '<p class="graph-detail-copy graph-repair-rating-hint">Choose the closest comparison before moving on.</p>')
-          : `<button class="${actionButtonClass} trigger-repair-reveal" disabled>Show reference bridge</button>`}
+          : `
+            <button class="${actionButtonClass} trigger-repair-reveal" ${revealReady ? '' : 'disabled'} aria-describedby="repair-reveal-helper">Lock in and show reference bridge</button>
+            <p class="graph-repair-reveal-helper" id="repair-reveal-helper">Pick a stance and type your bridge to continue.</p>
+          `}
       </section>
     </div>
   `;

--- a/public/js/learner-analytics.js
+++ b/public/js/learner-analytics.js
@@ -1,5 +1,5 @@
 import { loadConcepts, getActiveId, setActiveId } from './store.js';
-import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=4';
+import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=5';
 import { buildBrowserLearnerSummaryPayload } from './browser-analytics.js';
 
 let conceptSelect = null;

--- a/public/js/learner-analytics.js
+++ b/public/js/learner-analytics.js
@@ -1,5 +1,5 @@
 import { loadConcepts, getActiveId, setActiveId } from './store.js';
-import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=3';
+import { escHtml, transformKnowledgeMapToGraph } from './graph-view.js?v=4';
 import { buildBrowserLearnerSummaryPayload } from './browser-analytics.js';
 
 let conceptSelect = null;


### PR DESCRIPTION
## Summary

Slice B of Repair Reps: pre-reveal confidence pill, soft reveal gate enforced inside `revealRepairRep()`, single-click lock-and-reveal with per-rep lock-duration tracking, and a completion-summary calibration readout (observational only).

Spec: [`docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md`](../blob/claude/repair-reps-slice-b/docs/superpowers/specs/2026-04-18-repair-reps-slice-b-metacognitive-loop-design.md)
Plan: [`docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md`](../blob/claude/repair-reps-slice-b/docs/superpowers/plans/2026-04-20-repair-reps-slice-b.md)

### What shipped
- **Pre-reveal commitment pill** above "Your bridge": `Guessing` / `Have a hunch` / `Can explain`
- **Dual reveal gate**: UI disables `Lock in and show reference bridge` until pill + non-empty answer; `revealRepairRep()` itself enforces idempotency + empty-answer + pre-confidence guards so direct-JS bypass no-ops
- **Lock-and-reveal**: single click freezes textarea (`readonly`), locks pill row (`aria-disabled` + `pointer-events: none`), unfolds reference
- **Calibration summary on completion**: three rows `Rep N / Predicted: X / Rated: Y`, observational language only
- **Per-rep timing**: `repStartedAt` stamped on rep 1 in `startRepairReps()` and re-stamped in `nextRepairRep()`; `lockDurationsMs = lockedAt - repStartedAt` persisted
- **Additive localStorage**: `learnops_repair_reps_v1` records now carry `pre_confidences` and `lock_durations_ms`. Old records without these arrays read as `[]`; length-mismatch legacy renders `min(length)` rows
- **Privacy**: no full answers, prompts, reference bridges, or feedback cues persisted — only enum labels, durations, and counts

### Scope
- 3 source files: `public/js/app.js`, `public/js/graph-view.js`, `public/css/layout.css`
- Cache-bust: `public/index.html`, `public/js/app.js` line 4, `public/js/learner-analytics.js` line 2
- **Zero backend diff** (`main.py`, `ai_service.py`, `app_prompts/` untouched)
- **Zero prompt diff** (`/api/repair-reps`, `RepairRepsRequest`, `repair-reps-system-v1.md` untouched)
- **Zero graph-state mutation** — invariant grep confirms no new lines touching `patchActiveConceptDrillOutcome`, `recordInterleavingEvent`, `markNodeVisitedThisSession`, `drill_status`, `drill_phase`, `study_completed_at`, `re_drill_eligible_after`

### Implementation note
Spec suggests updating `currentAnswer` on every textarea `input` event. Since `setRepairRepsState` triggers a full `detailEl.innerHTML` rebuild, per-keystroke dispatch would destroy caret position. Instead, the textarea `input` listener stays DOM-local (toggle `disabled` only), and the pill-click handler reads the live textarea value just-in-time via `setRepairRepDraft` before setting the pre-confidence. Satisfies the draft-preservation invariant (Edge Case #3) without caret thrash.

### Final cache-bust state
- `styles.css?v=43`
- `js/app.js?v=31`
- `graph-view.js?v=5` (both importers: `app.js` line 4 and `learner-analytics.js` line 2)

## Test Plan

### Automated (green)
- [x] `python -m unittest discover -s tests` — 35/35 pass
- [x] `node --check public/js/app.js public/js/graph-view.js public/js/learner-analytics.js` — clean
- [x] `git diff --check origin/dev...HEAD` — clean
- [x] Invariant grep (no banned identifiers in Slice B diff) — empty
- [x] Zero backend/prompt diff — confirmed

### Manual — 17 items (walk in browser)
See spec §Test Plan items 1-9, 12-16, 18-20.

### Manual — 3 human-only items (require DevTools)
- [ ] **#10 Direct-JS bypass**: `window.SocratinkApp.revealRepairRep("x")` before selecting a pill → no reveal. After pill + answer → reveals.
- [ ] **#11 Idempotency**: after reveal, calling `revealRepairRep(...)` a second time → `lockedAt`, `preConfidences`, `lockDurationsMs` each written exactly once for this rep.
- [ ] **#17 Length-mismatch legacy**: inject a record with `pre_confidences.length === 2`, `ratings.length === 3` → summary renders 2 complete rows, no crash.

## Risks & Reversibility

Type 2 (reversible). Frontend + additive localStorage only. Worst case: revert 5 commits + cache-bust rollback. Old readers ignore unknown fields.