### PR TITLE
ux(dashboard): empty-state collapse + lifted-route graph + auth/graph polish

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1234,27 +1234,178 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
 
 /* Empty-state voice line + ghost graph preview */
 .hero-voice-line { display: none; margin: 0; }
-.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-voice-line {
-  display: block;
-  font-family: var(--font-body);
-  font-size: var(--text-sm);
-  font-style: italic;
-  font-weight: 400;
-  line-height: var(--leading-snug);
-  color: var(--text-sub);
-  margin: 0;
-  max-width: 420px;
-}
 
 .hero-ghost-graph { display: none; margin: 0; }
 .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin: 6px auto 0;
-  max-width: 380px;
+  margin: 0 auto;
+  max-width: 304px;
   width: 100%;
+  opacity: 0.7;
 }
+
+/* Empty-state single input. Hidden outside empty state. */
+.hero-single-input { display: none; }
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-single-input {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: left;
+  width: 100%;
+  max-width: 560px;
+  gap: 12px;
+  margin: 0 auto;
+}
+
+/* In empty state, hide the guidance sub-head (it re-introduces mode cognition),
+   the voice line, the primary Begin button (replaced by single-input form's own Begin),
+   the timer, and the state-chip meta row (BOARD EMPTY is redundant with the
+   invitation — the chip stays in the DOM as a :has() hook only). Keep the
+   eyebrow, title, and ghost graph. */
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-guidance,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-voice-line,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-actions,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-meta-row {
+  display: none;
+}
+
+.hero-single-input__field {
+  font-family: var(--font-body);
+  font-size: var(--text-md, 15px);
+  line-height: var(--leading-relaxed, 1.55);
+  color: var(--text-strong);
+  width: 100%;
+  min-height: 64px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--surface-card);
+  box-shadow: var(--shadow-card-sm, var(--shadow-card));
+  resize: none;
+  overflow: hidden;
+  box-sizing: border-box;
+  transition:
+    border-color var(--duration-standard, 220ms) var(--ease-standard),
+    box-shadow var(--duration-standard, 220ms) var(--ease-standard);
+}
+.hero-single-input__field::placeholder {
+  color: var(--text-sub);
+  opacity: 0.85;
+}
+.hero-single-input__field:focus-visible {
+  outline: none;
+  border-color: var(--accent-border-strong);
+  box-shadow: var(--accent-ring);
+}
+
+.hero-single-input__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hero-single-input__clipboard {
+  /* Link-style helper, not a second CTA. Reset the global button box-shadow
+     from base.css so it doesn't read as a pill. */
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-sub);
+  font-family: var(--font-body);
+  font-size: var(--text-sm, 13px);
+  cursor: pointer;
+  padding: 4px 2px;
+  border-radius: 4px;
+  flex: none;
+}
+.hero-single-input__clipboard:hover {
+  color: var(--accent-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  background: transparent;
+  box-shadow: none;
+  transform: none;
+}
+.hero-single-input__clipboard:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+}
+.hero-single-input__clipboard-icon {
+  display: inline-flex;
+  align-items: center;
+  color: currentColor;
+}
+
+.hero-single-input__submit {
+  font-family: var(--font-display, inherit);
+  font-size: var(--text-sm, 14px);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #fff;
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-border-strong, var(--accent-primary));
+  border-radius: 10px;
+  padding: 10px 22px;
+  min-width: 120px;
+  cursor: pointer;
+  transition:
+    transform var(--duration-standard, 220ms) var(--ease-standard),
+    box-shadow var(--duration-standard, 220ms) var(--ease-standard),
+    opacity var(--duration-standard, 220ms) var(--ease-standard);
+}
+.hero-single-input__submit:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--accent-shadow-md);
+}
+.hero-single-input__submit:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+}
+.hero-single-input__submit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.hero-single-input__reassure {
+  font-family: var(--font-body);
+  font-size: var(--text-sm, 13px);
+  font-style: italic;
+  line-height: var(--leading-snug, 1.45);
+  color: var(--text-sub);
+  margin: 0;
+  text-align: center;
+}
+
+/* Three-zone vertical rhythm: question (eyebrow + H1) → action (input) → promise (ghost graph).
+   The input sits ~80px below the H1; the ghost graph sits ~100px below the input. */
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-title {
+  margin-bottom: 0;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-single-input {
+  margin-top: 80px;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph {
+  margin-top: 100px;
+}
+
+@media (max-width: 720px) {
+  .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-single-input {
+    margin-top: 48px;
+  }
+  .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph {
+    margin-top: 64px;
+  }
+  .hero-single-input__row {
+    flex-wrap: wrap;
+  }
+}
+
 .hero-info:has(.hero-state-chip[data-state="empty"]) {
   justify-content: flex-start;
   gap: 12px;
@@ -1273,10 +1424,8 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   justify-content: center;
   width: 100%;
 }
-.hero-info:has(.hero-state-chip[data-state="empty"]) .desc,
-.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-voice-line,
 .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph__caption {
-  text-align: left;
+  text-align: center;
   width: 100%;
 }
 @media (min-width: 900px) {

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -209,9 +209,6 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
 .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-eyebrow {
   display: block;
 }
-.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-state-chip {
-  display: none;
-}
 
 .hero-primary-action:disabled {
   background: var(--surface-nested);
@@ -1197,9 +1194,6 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   align-items: center;
   gap: var(--space-2);
 }
-.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-state-chip-group {
-  display: none;
-}
 
 .help-tip-trigger {
   display: inline-flex;
@@ -1207,6 +1201,7 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   justify-content: center;
   width: 24px;
   height: 24px;
+  min-height: 24px;
   padding: 0;
   border-radius: 999px;
   background: transparent;
@@ -1235,6 +1230,79 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   outline: none;
   box-shadow: var(--accent-ring);
   border-color: var(--accent-border-strong);
+}
+
+/* Empty-state voice line + ghost graph preview */
+.hero-voice-line { display: none; margin: 0; }
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-voice-line {
+  display: block;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-style: italic;
+  font-weight: 400;
+  line-height: var(--leading-snug);
+  color: var(--text-sub);
+  margin: 0;
+  max-width: 420px;
+}
+
+.hero-ghost-graph { display: none; margin: 0; }
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 6px auto 0;
+  max-width: 380px;
+  width: 100%;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) {
+  justify-content: flex-start;
+  gap: 12px;
+  align-items: stretch;
+  text-align: center;
+  max-width: 640px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-eyebrow-row,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-meta-row {
+  justify-content: center;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-actions {
+  justify-content: center;
+  width: 100%;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .desc,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-voice-line,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph__caption {
+  text-align: left;
+  width: 100%;
+}
+@media (min-width: 900px) {
+  .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-primary-action {
+    min-width: 200px;
+  }
+}
+.hero-ghost-graph__svg {
+  width: 100%;
+  height: auto;
+  max-height: 180px;
+  opacity: 0.32;
+  pointer-events: none;
+}
+.hero-ghost-graph__caption {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-style: italic;
+  line-height: var(--leading-snug);
+  color: var(--text-sub);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-ghost-graph {
+    transition: opacity var(--duration-standard, 220ms) var(--ease-standard);
+  }
 }
 
 .help-tip {

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1251,9 +1251,11 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin: 6px auto 0;
-  max-width: 380px;
+  margin: 80px auto 0;
+  max-width: 304px;
   width: 100%;
+  transform: scale(0.85);
+  transform-origin: center top;
 }
 .hero-info:has(.hero-state-chip[data-state="empty"]) {
   justify-content: flex-start;
@@ -1265,13 +1267,19 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   margin-left: auto;
   margin-right: auto;
 }
-.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-eyebrow-row,
-.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-meta-row {
+/* Empty-state: three zones. Hide state chip + start-here tooltip; silence card surface. */
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-meta-row,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-state-chip-group,
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-eyebrow-row .help-tip-trigger {
+  display: none;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-eyebrow-row {
   justify-content: center;
 }
 .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-actions {
   justify-content: center;
   width: 100%;
+  margin-top: 88px;
 }
 .hero-info:has(.hero-state-chip[data-state="empty"]) .desc,
 .hero-info:has(.hero-state-chip[data-state="empty"]) .hero-voice-line,
@@ -1287,8 +1295,7 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
 .hero-ghost-graph__svg {
   width: 100%;
   height: auto;
-  max-height: 180px;
-  opacity: 0.32;
+  max-height: 144px;
   pointer-events: none;
 }
 .hero-ghost-graph__caption {

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -140,7 +140,10 @@ body:not([data-map-open="true"]) .map-back-link {
   grid-template-columns: 1fr;
   align-items: start;
   justify-items: center;
-  padding-bottom: 36px;
+  padding-top: 32px;
+  padding-bottom: 32px;
+  background: transparent;
+  box-shadow: none;
 }
 .hero-card:has(.hero-state-chip[data-state="empty"]) #grid-container {
   display: none;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -138,6 +138,9 @@ body:not([data-map-open="true"]) .map-back-link {
 }
 .hero-card:has(.hero-state-chip[data-state="empty"]) {
   grid-template-columns: 1fr;
+  align-items: start;
+  justify-items: center;
+  padding-bottom: 36px;
 }
 .hero-card:has(.hero-state-chip[data-state="empty"]) #grid-container {
   display: none;
@@ -955,41 +958,33 @@ body:not([data-map-open="true"]) .map-back-link {
 
 .concept-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 32px;
-  padding: 56px 0 28px;
-  border-bottom: 1px solid var(--border);
+  gap: 24px;
+  padding: 20px 0 16px;
 }
 .concept-header-main {
   min-width: 0;
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  flex-direction: row;
+  align-items: center;
+  gap: 14px;
   flex: 1 1 auto;
+  flex-wrap: wrap;
 }
 .concept-header-title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 32px;
+  font-size: 26px;
   line-height: 1.15;
   letter-spacing: -0.02em;
   color: var(--text);
   font-weight: 700;
 }
-.concept-header-summary {
-  margin: 0;
-  font-size: 15px;
-  line-height: 1.55;
-  color: var(--text-sub);
-  max-width: 62ch;
-}
-.concept-header-summary:empty { display: none; }
 .concept-header-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 2px;
 }
 .concept-header-tags:empty { display: none; }
 .concept-header-actions {
@@ -1346,6 +1341,29 @@ body:not([data-map-open="true"]) .map-back-link {
 }
 .graph-svg .graph-node-ripple.is-delayed {
   animation-delay: -1.5s;
+}
+
+/* Next-node breadcrumb — small lavender pip travels focus → suggested next. Bridge modes only.
+   Position driven by RAF in graph-view.js (CSS offset-distance animation is unreliable on SVG). */
+.graph-svg .graph-breadcrumb-pip {
+  pointer-events: none;
+  fill: var(--accent-secondary);
+  opacity: 0;
+  transition: opacity 160ms ease-out;
+}
+
+@keyframes graphBreadcrumbArrival {
+  0%   { transform: scale(1);   opacity: 0; }
+  25%  { opacity: 0.5; }
+  100% { transform: scale(2.2); opacity: 0; }
+}
+.graph-svg .graph-breadcrumb-arrival {
+  transform-box: fill-box;
+  transform-origin: center;
+  vector-effect: non-scaling-stroke;
+  animation: graphBreadcrumbArrival 600ms ease-out infinite;
+  animation-delay: var(--arrival-delay, 2.88s);
+  pointer-events: none;
 }
 
 /* Beam arrival pulse — small ring lands at target each dash cycle. Active-path only. */
@@ -1854,8 +1872,16 @@ body:not([data-map-open="true"]) .map-back-link {
 
   .graph-svg .graph-beam,
   .graph-svg .graph-beam-arrival,
-  .graph-svg .graph-node-ripple {
+  .graph-svg .graph-node-ripple,
+  .graph-svg .graph-breadcrumb-pip,
+  .graph-svg .graph-breadcrumb-arrival {
     animation: none !important;
+    display: none !important;
+  }
+  .graph-svg .graph-edge.is-next-suggestion line,
+  .graph-svg .graph-edge.is-next-suggestion path {
+    stroke-dasharray: 6 4;
+    opacity: 0.72 !important;
   }
 
   .graph-node .graph-node-halo,
@@ -1970,10 +1996,9 @@ body:not([data-map-open="true"]) .map-back-link {
     flex-direction: column;
     align-items: stretch;
     gap: 16px;
-    padding: 64px 0 20px;
+    padding: 16px 0 16px;
   }
-  .concept-header-title { font-size: 24px; }
-  .concept-header-summary { font-size: 14px; }
+  .concept-header-title { font-size: 22px; }
   .concept-header-actions {
     flex-direction: column;
     align-items: stretch;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -141,6 +141,8 @@ body:not([data-map-open="true"]) .map-back-link {
   align-items: start;
   justify-items: center;
   padding-bottom: 36px;
+  background: transparent;
+  box-shadow: none;
 }
 .hero-card:has(.hero-state-chip[data-state="empty"]) #grid-container {
   display: none;

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -135,6 +135,10 @@
   --graph-node-amber-core: #7a4a05;
   --graph-node-solid-core: #4d2e7d;
 
+  /* Focus aura — small + soft on paper so it highlights the node without bleeding into siblings */
+  --graph-focus-glow-radius:  55;
+  --graph-focus-glow-opacity: 0.22;
+
   --graph-panel-bg:     var(--surface-card-theme);
   --graph-panel-border: var(--border-subtle);
   --graph-panel-shadow: var(--shadow-soft);
@@ -355,6 +359,7 @@
   --graph-arrival-glow-duration:    400ms;
   --graph-beam-pulse-duration:      2.4s;
   --graph-stars-drift-duration:     40s;
+  --graph-breadcrumb-duration:      3.6s;
 
   /* Additional type */
   --text-display:     clamp(3.85rem, 2.8rem + 5.2vw, 5.6rem);
@@ -463,6 +468,10 @@
   --graph-node-cyan-core:  #d6f1fb;
   --graph-node-amber-core: #ffe5b4;
   --graph-node-solid-core: #f1e3ff;
+
+  /* Focus aura — large + atmospheric on obsidian stage */
+  --graph-focus-glow-radius:  120;
+  --graph-focus-glow-opacity: 0.5;
 
   --graph-panel-bg:
     radial-gradient(ellipse 80% 40% at 50% 0%, rgba(var(--violet-600-rgb), 0.14), transparent 70%),

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="styles.css?v=51">
+  <link rel="stylesheet" href="styles.css?v=52">
 </head>
 
 <body>
@@ -231,22 +231,74 @@
           </button>
         </div>
         <figure class="hero-ghost-graph" role="presentation" aria-hidden="true">
-          <!-- Ghost-graph preview. Center node uses --success (solidified) by design-system legend; peripherals use primed/drilled/locked. Not interactive, not user data. -->
+          <!-- Lifted Route ghost graph: decorative preview only, not user data. Opacity is capped per layer so the input field stays primary. -->
           <svg class="hero-ghost-graph__svg" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
-            <g fill="none" stroke="var(--accent-primary)" stroke-width="1.2" stroke-linecap="round">
-              <line x1="160" y1="90" x2="70" y2="42"/>
-              <line x1="160" y1="90" x2="250" y2="42"/>
-              <line x1="160" y1="90" x2="54" y2="138"/>
-              <line x1="160" y1="90" x2="266" y2="138"/>
-              <line x1="160" y1="90" x2="160" y2="158"/>
+            <g class="hero-ghost-graph__platform">
+              <ellipse cx="160" cy="151" rx="105" ry="19" fill="var(--ink-900)" opacity="0.10"/>
+              <path d="M 55 90 L 107.5 120 L 160 150 L 212.5 120 L 265 90 L 265 99 L 212.5 129 L 160 159 L 107.5 129 L 55 99 Z"
+                    fill="rgba(var(--mauve-200-rgb), 0.28)" opacity="0.28"/>
+              <g fill="rgba(var(--cream-50-rgb), 0.62)"
+                 stroke="var(--ink-900)"
+                 stroke-width="1.05"
+                 stroke-linejoin="round"
+                 stroke-dasharray="5 5"
+                 opacity="0.30">
+                <path d="M 160 30 L 212.5 60 L 160 90 L 107.5 60 Z"/>
+                <path d="M 107.5 60 L 160 90 L 107.5 120 L 55 90 Z"/>
+                <path d="M 212.5 60 L 265 90 L 212.5 120 L 160 90 Z"/>
+                <path d="M 160 90 L 212.5 120 L 160 150 L 107.5 120 Z"/>
+              </g>
+              <path d="M 160 30 L 212.5 60 L 160 90 L 107.5 60 Z"
+                    fill="rgba(var(--violet-600-rgb), 0.07)"
+                    stroke="var(--accent-primary)"
+                    stroke-width="1"
+                    stroke-dasharray="5 5"
+                    opacity="0.32"/>
             </g>
-            <g>
-              <circle cx="160" cy="90" r="14" fill="var(--success)" stroke="var(--success)" stroke-width="1.4"/>
-              <circle cx="70" cy="42" r="9" fill="var(--accent-primary)" stroke="var(--accent-primary)" stroke-width="1.4"/>
-              <circle cx="250" cy="42" r="9" fill="var(--accent-primary)" stroke="var(--accent-primary)" stroke-width="1.4"/>
-              <circle cx="266" cy="138" r="9" fill="var(--lavender-500)" stroke="var(--lavender-500)" stroke-width="1.4"/>
-              <circle cx="54" cy="138" r="9" fill="none" stroke="var(--mauve-200)" stroke-width="1.4" stroke-dasharray="3 3"/>
-              <circle cx="160" cy="158" r="9" fill="none" stroke="var(--mauve-200)" stroke-width="1.4" stroke-dasharray="3 3"/>
+
+            <g class="hero-ghost-graph__edges"
+               fill="none"
+               stroke="var(--ink-900)"
+               stroke-width="1.15"
+               stroke-linecap="round"
+               stroke-linejoin="round"
+               opacity="0.30">
+              <path d="M 62 90 L 108 63 L 137 74 L 146 78"/>
+              <path d="M 174 78 L 188 68 L 207 63"/>
+              <path d="M 168 88 L 188 105 L 210 116"/>
+              <path d="M 209 121 L 184 136 L 162 148"/>
+              <path d="M 110 61 L 136 72" stroke-dasharray="4 6" opacity="0.72"/>
+            </g>
+
+            <g class="hero-ghost-graph__nodes" fill="var(--cream-50)" stroke-linecap="round" stroke-linejoin="round">
+              <g class="hero-ghost-graph__node hero-ghost-graph__node--center" opacity="0.70">
+                <ellipse cx="160" cy="82" rx="17" ry="9.5" fill="rgba(var(--cream-50-rgb), 0.58)" stroke="var(--accent-primary)" stroke-width="1.45"/>
+                <ellipse cx="160" cy="82" rx="8" ry="4.4" fill="none" stroke="var(--accent-primary)" stroke-width="1" opacity="0.62"/>
+                <ellipse cx="160" cy="88" rx="19" ry="5.2" fill="var(--accent-primary)" stroke="none" opacity="0.08"/>
+              </g>
+
+              <g class="hero-ghost-graph__node hero-ghost-graph__node--primed" opacity="0.60">
+                <ellipse cx="107.5" cy="64" rx="10" ry="3.2" fill="var(--graph-node-primed-ring)" stroke="none" opacity="0.10"/>
+                <circle cx="107.5" cy="58" r="8.8" fill="rgba(var(--cream-50-rgb), 0.55)" stroke="var(--graph-node-primed-ring)" stroke-width="1.3"/>
+                <circle cx="107.5" cy="58" r="3.6" fill="none" stroke="var(--graph-node-primed-ring)" stroke-width="0.9" opacity="0.72"/>
+              </g>
+              <g class="hero-ghost-graph__node hero-ghost-graph__node--primed" opacity="0.60">
+                <ellipse cx="212.5" cy="123" rx="10" ry="3.2" fill="var(--graph-node-primed-ring)" stroke="none" opacity="0.10"/>
+                <circle cx="212.5" cy="117" r="8.8" fill="rgba(var(--cream-50-rgb), 0.55)" stroke="var(--graph-node-primed-ring)" stroke-width="1.3"/>
+                <circle cx="212.5" cy="117" r="3.6" fill="none" stroke="var(--graph-node-primed-ring)" stroke-width="0.9" opacity="0.72"/>
+              </g>
+
+              <g class="hero-ghost-graph__node hero-ghost-graph__node--solidified" opacity="0.62">
+                <circle cx="212.5" cy="60" r="9.2" fill="rgba(var(--cream-50-rgb), 0.55)" stroke="var(--accent-primary)" stroke-width="1.3"/>
+                <circle cx="212.5" cy="60" r="3" fill="var(--accent-primary)" stroke="none" opacity="0.82"/>
+              </g>
+
+              <g class="hero-ghost-graph__node hero-ghost-graph__node--locked" opacity="0.40">
+                <circle cx="55" cy="90" r="8.6" fill="none" stroke="var(--ink-900)" stroke-width="1.2" stroke-dasharray="3 3"/>
+              </g>
+              <g class="hero-ghost-graph__node hero-ghost-graph__node--locked" opacity="0.40">
+                <circle cx="160" cy="150" r="8.6" fill="none" stroke="var(--ink-900)" stroke-width="1.2" stroke-dasharray="3 3"/>
+              </g>
             </g>
           </svg>
           <figcaption class="hero-ghost-graph__caption">Your map starts empty. Each concept earns its place.</figcaption>

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="styles.css?v=51">
+  <link rel="stylesheet" href="styles.css?v=53">
 </head>
 
 <body>
@@ -202,25 +202,14 @@
       <div class="hero-info" id="hero-info">
         <div class="hero-meta-row">
           <div class="hero-state-chip-group">
+            <!-- #hero-state-chip is the data-state hook that CSS :has() rules depend on.
+                 In empty state we hide the wrapping .hero-meta-row entirely (see components.css).
+                 Non-empty states render the chip text via renderHero(). -->
             <div class="hero-state-chip" id="hero-state-chip" data-state="empty">Board Empty</div>
-            <button type="button"
-                    class="help-tip-trigger js-tooltip-trigger"
-                    aria-label="What is the board?"
-                    aria-describedby="tip-board-state"
-                    data-tooltip-id="tip-board-state">
-              <span class="material-symbols-outlined" aria-hidden="true">info</span>
-            </button>
           </div>
         </div>
         <div class="hero-eyebrow-row">
           <div class="hero-eyebrow" id="hero-eyebrow">Start here</div>
-          <button type="button"
-                  class="help-tip-trigger js-tooltip-trigger"
-                  aria-label="What is Start here?"
-                  aria-describedby="tip-start-here"
-                  data-tooltip-id="tip-start-here">
-            <span class="material-symbols-outlined" aria-hidden="true">info</span>
-          </button>
         </div>
         <h1 class="hero-title" id="title">What do you want to understand?</h1>
         <p class="desc hero-guidance" id="desc" aria-live="polite">Name one concept. We'll help you drill it until you can explain it from memory — no slides, no skim-reading.</p>
@@ -230,6 +219,31 @@
             <span class="hero-primary-action__label">Begin</span>
           </button>
         </div>
+        <!-- Empty-state single input: routes by input shape (short line → concept name, long/punctuated → passage). Shown only when hero-state-chip[data-state="empty"]; hidden otherwise via CSS. -->
+        <form class="hero-single-input" id="hero-single-input" onsubmit="return App.runHeroAction(event)" autocomplete="off">
+          <textarea class="hero-single-input__field"
+                    id="hero-single-input-field"
+                    rows="1"
+                    placeholder='e.g. "Entropy" — or paste a passage'
+                    aria-label="What do you want to understand?"></textarea>
+          <div class="hero-single-input__row">
+            <button type="button"
+                    class="hero-single-input__clipboard"
+                    id="hero-single-input-clipboard"
+                    hidden>
+              <span class="hero-single-input__clipboard-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="8" y="3" width="8" height="4" rx="1"/>
+                  <path d="M6 6H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-1"/>
+                </svg>
+              </span>
+              <span>or pick from clipboard</span>
+            </button>
+            <button type="submit" class="hero-single-input__submit" disabled>Begin</button>
+          </div>
+          <p class="hero-single-input__reassure">The first room is small.</p>
+        </form>
+
         <figure class="hero-ghost-graph" role="presentation" aria-hidden="true">
           <!-- Ghost-graph preview. Center node uses --success (solidified) by design-system legend; peripherals use primed/drilled/locked. Not interactive, not user data. -->
           <svg class="hero-ghost-graph__svg" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
@@ -251,6 +265,7 @@
           </svg>
           <figcaption class="hero-ghost-graph__caption">Your map starts empty. Each concept earns its place.</figcaption>
         </figure>
+
         <div id="timer-display">24:00:00</div>
 
         <!-- Action Controls (Hidden for Board-First UX) -->
@@ -527,7 +542,7 @@
   <div id="tooltip-root" aria-hidden="true"></div>
 
   <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=33"></script>
+  <script type="module" src="js/app.js?v=35"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>
 
   <!-- Vercel Speed Insights -->

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="styles.css?v=44">
+  <link rel="stylesheet" href="styles.css?v=51">
 </head>
 
 <body>
@@ -154,11 +154,6 @@
             </g>
           </svg>
         </button>
-        <button class="map-back-link" id="map-back-link" type="button" onclick="App.hideMapView()"
-          aria-label="Return to dashboard">
-          <span aria-hidden="true">←</span>
-          <span>Dashboard</span>
-        </button>
       </div>
       <div class="main-header-right">
         <div class="auth-controls" id="auth-controls" hidden>
@@ -229,19 +224,33 @@
         </div>
         <h1 class="hero-title" id="title">What do you want to understand?</h1>
         <p class="desc hero-guidance" id="desc" aria-live="polite">Name one concept. We'll help you drill it until you can explain it from memory — no slides, no skim-reading.</p>
+        <p class="hero-voice-line">The map won't lie to you, even if you want it to.</p>
         <div class="hero-actions">
           <button id="hero-primary-action" class="hero-primary-action" type="button" onclick="App.runHeroAction()">
-            <span class="material-symbols-outlined hero-primary-action__icon" aria-hidden="true">add</span>
-            <span class="hero-primary-action__label">Add a concept</span>
-          </button>
-          <button type="button"
-                  class="help-tip-trigger js-tooltip-trigger"
-                  aria-label="What does Add a concept do?"
-                  aria-describedby="tip-add-concept"
-                  data-tooltip-id="tip-add-concept">
-            <span class="material-symbols-outlined" aria-hidden="true">info</span>
+            <span class="hero-primary-action__label">Begin</span>
           </button>
         </div>
+        <figure class="hero-ghost-graph" role="presentation" aria-hidden="true">
+          <!-- Ghost-graph preview. Center node uses --success (solidified) by design-system legend; peripherals use primed/drilled/locked. Not interactive, not user data. -->
+          <svg class="hero-ghost-graph__svg" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
+            <g fill="none" stroke="var(--accent-primary)" stroke-width="1.2" stroke-linecap="round">
+              <line x1="160" y1="90" x2="70" y2="42"/>
+              <line x1="160" y1="90" x2="250" y2="42"/>
+              <line x1="160" y1="90" x2="54" y2="138"/>
+              <line x1="160" y1="90" x2="266" y2="138"/>
+              <line x1="160" y1="90" x2="160" y2="158"/>
+            </g>
+            <g>
+              <circle cx="160" cy="90" r="14" fill="var(--success)" stroke="var(--success)" stroke-width="1.4"/>
+              <circle cx="70" cy="42" r="9" fill="var(--accent-primary)" stroke="var(--accent-primary)" stroke-width="1.4"/>
+              <circle cx="250" cy="42" r="9" fill="var(--accent-primary)" stroke="var(--accent-primary)" stroke-width="1.4"/>
+              <circle cx="266" cy="138" r="9" fill="var(--lavender-500)" stroke="var(--lavender-500)" stroke-width="1.4"/>
+              <circle cx="54" cy="138" r="9" fill="none" stroke="var(--mauve-200)" stroke-width="1.4" stroke-dasharray="3 3"/>
+              <circle cx="160" cy="158" r="9" fill="none" stroke="var(--mauve-200)" stroke-width="1.4" stroke-dasharray="3 3"/>
+            </g>
+          </svg>
+          <figcaption class="hero-ghost-graph__caption">Your map starts empty. Each concept earns its place.</figcaption>
+        </figure>
         <div id="timer-display">24:00:00</div>
 
         <!-- Action Controls (Hidden for Board-First UX) -->
@@ -468,7 +477,6 @@
         <header class="concept-header" id="concept-header">
           <div class="concept-header-main">
             <h2 class="concept-header-title" id="concept-header-title"></h2>
-            <p class="concept-header-summary" id="concept-header-summary"></p>
             <div class="concept-header-tags" id="concept-header-tags"></div>
           </div>
           <div class="concept-header-actions">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -335,18 +335,67 @@ const App = (() => {
     }
   }
 
-  function runHeroAction() {
+  // Classify empty-state input: short, no newline, no sentence-final punctuation → concept name;
+  // otherwise → pasted passage. `.` `?` `!` are the signal; concept names almost never end in them.
+  function classifyHeroInput(raw) {
+    const text = (raw || '').trim();
+    if (!text) return { kind: 'empty', text: '' };
+    const hasNewline = /\n/.test(text);
+    const hasSentenceFinal = /[.?!]/.test(text);
+    if (text.length < 200 && !hasNewline && !hasSentenceFinal) {
+      return { kind: 'name', text };
+    }
+    return { kind: 'passage', text };
+  }
+
+  function runHeroAction(evtOrNothing) {
+    // Empty-state form submit path: a Submit event comes in. Classify and pre-fill the dialog.
+    if (evtOrNothing && typeof evtOrNothing.preventDefault === 'function') {
+      evtOrNothing.preventDefault();
+      const field = document.getElementById('hero-single-input-field');
+      const raw = field ? field.value : '';
+      const classified = classifyHeroInput(raw);
+      if (classified.kind === 'empty') return false;
+      showDashboard();
+      openDrawer();
+      // `startAddConcept` is async (awaits auth), and `buildContentInputUI` mounts the
+      // name input + textarea only after it resolves. Poll for the fields, then pre-fill.
+      startAddConcept();
+      // TODO(v2): LLM-proposed concept name. On `classified.kind === 'passage'`, run a
+      // quick LLM pass on `classified.text` to suggest a name, pre-fill it in the name
+      // field, let the user accept via Begin or edit. Out of scope for v1 due to latency
+      // and cost.
+      const deadline = performance.now() + 2000;
+      const tryFill = () => {
+        const dialog = document.getElementById('creation-dialog');
+        const nameInput = dialog?.querySelector('.creation-name-input');
+        const textarea = dialog?.querySelector('.overlay-textarea');
+        if (!nameInput || !textarea) {
+          if (performance.now() < deadline) requestAnimationFrame(tryFill);
+          return;
+        }
+        if (classified.kind === 'name') {
+          nameInput.value = classified.text;
+          nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+          nameInput.focus();
+          nameInput.setSelectionRange(nameInput.value.length, nameInput.value.length);
+        } else {
+          textarea.value = classified.text;
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+          nameInput.focus();
+        }
+      };
+      requestAnimationFrame(tryFill);
+      return false;
+    }
+
+    // Non-empty-state path: the Begin button drives Begin/Extract/Drill/Open-map.
     const concept = getActiveConcept();
     const action = heroPrimaryActionEl?.dataset.action || (!concept ? 'add' : '');
     if (action === 'add') {
       showDashboard();
       openDrawer();
       startAddConcept();
-      requestAnimationFrame(() => {
-        addTriggerArea.scrollIntoView({ block: 'end', behavior: 'smooth' });
-        const nameInput = addTriggerArea.querySelector('.creation-name-input');
-        if (nameInput instanceof HTMLInputElement) nameInput.focus();
-      });
       return;
     }
     if (action === 'extract') {
@@ -361,6 +410,52 @@ const App = (() => {
       if (!concept?.graphData) return;
       showMapView(concept);
       setMapMode('study');
+    }
+  }
+
+  // Wire up the empty-state single input: autogrow, enable Begin on non-empty,
+  // clipboard button conditional on API availability. Called on DOMContentLoaded.
+  function initHeroSingleInput() {
+    const field = document.getElementById('hero-single-input-field');
+    if (!(field instanceof HTMLTextAreaElement)) return;
+    const form = document.getElementById('hero-single-input');
+    const submit = form?.querySelector('.hero-single-input__submit');
+    const clipBtn = document.getElementById('hero-single-input-clipboard');
+
+    const autogrow = () => {
+      field.style.height = 'auto';
+      field.style.height = Math.min(field.scrollHeight, 240) + 'px';
+    };
+    const sync = () => {
+      if (submit instanceof HTMLButtonElement) {
+        submit.disabled = field.value.trim().length === 0;
+      }
+      autogrow();
+    };
+    field.addEventListener('input', sync);
+    // Cmd/Ctrl+Enter to submit from textarea (since plain Enter adds a newline).
+    field.addEventListener('keydown', (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && field.value.trim()) {
+        e.preventDefault();
+        form?.requestSubmit?.();
+      }
+    });
+    sync();
+
+    if (clipBtn instanceof HTMLButtonElement && navigator.clipboard?.readText) {
+      clipBtn.hidden = false;
+      clipBtn.addEventListener('click', async () => {
+        try {
+          const text = await navigator.clipboard.readText();
+          if (!text) return;
+          field.value = text;
+          sync();
+          field.focus();
+        } catch (err) {
+          // Permission denied or unavailable: stay silent, no pre-emptive prompt surface.
+          console.warn('Clipboard read failed.', err);
+        }
+      });
     }
   }
 
@@ -2300,6 +2395,7 @@ const App = (() => {
   bindMapModeControls();
   renderGrid();
   renderConceptList();
+  initHeroSingleInput();
 
   // Restore selected concept
   const concepts = loadConcepts();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -278,7 +278,7 @@ const App = (() => {
 
   function getHeroActionConfig(concept) {
     if (!concept) {
-      return { label: 'Add a concept', action: 'add', disabled: false };
+      return { label: 'Begin', action: 'add', disabled: false };
     }
     switch (concept.state) {
       case 'instantiated':
@@ -300,7 +300,7 @@ const App = (() => {
           ? { label: 'Review Map', action: 'open-map', disabled: false }
           : { label: 'Open Board', action: 'wait', disabled: true };
       default:
-        return { label: 'Add a concept', action: 'add', disabled: false };
+        return { label: 'Begin', action: 'add', disabled: false };
     }
   }
 
@@ -1849,19 +1849,15 @@ const App = (() => {
     const fws = data.frameworks || [];
 
     const titleEl = document.getElementById('concept-header-title');
-    const summaryEl = document.getElementById('concept-header-summary');
     const tagsEl = document.getElementById('concept-header-tags');
     const drillBtn = document.getElementById('concept-start-drill');
     if (titleEl) titleEl.textContent = meta.source_title || concept.name || '';
-    if (summaryEl) summaryEl.textContent = meta.core_thesis || '';
     if (tagsEl) {
       let tagsHtml = '';
       const stateLabel = getHeroStateLabel(concept.state);
       if (stateLabel && stateLabel !== 'Board Empty') {
         tagsHtml += `<span class="map-badge state" data-state="${escHtml(concept.state || '')}"><span class="map-badge-dot" aria-hidden="true"></span>${escHtml(stateLabel)}</span>`;
       }
-      if (meta.architecture_type) tagsHtml += `<span class="map-badge arch">${escHtml(meta.architecture_type.replace(/_/g, ' '))}</span>`;
-      if (meta.difficulty) tagsHtml += `<span class="map-badge diff">${escHtml(meta.difficulty)}</span>`;
       if (meta.low_density) tagsHtml += `<span class="map-low-density">Lightweight map</span>`;
       tagsEl.innerHTML = tagsHtml;
     }

--- a/public/js/graph-view.js
+++ b/public/js/graph-view.js
@@ -1056,6 +1056,9 @@ function getGraphThemeTokens() {
 
     drillMutedFill: readGraphStyleToken(styles, '--graph-drill-muted-fill', 'rgba(226, 226, 226, 1)'),
     drillMutedEdge: readGraphStyleToken(styles, '--graph-drill-muted-edge', 'rgba(200, 200, 200, 0.10)'),
+
+    focusGlowRadius: readGraphNumberToken(styles, '--graph-focus-glow-radius', 120),
+    focusGlowOpacity: readGraphNumberToken(styles, '--graph-focus-glow-opacity', 0.5),
   };
 }
 
@@ -1758,6 +1761,7 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
   let freshlyFocusedNodeId = null;
   let arrivalGlowTimeoutId = null;
   let panRafId = null;
+  let breadcrumbRafId = null;
   let currentViewBox = { x: 0, y: 0, w: VIEWBOX.width, h: VIEWBOX.height };
   let model = buildModel(transformed);
   let lookup = createLookup(model);
@@ -1911,6 +1915,42 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
       }
     };
     panRafId = requestAnimationFrame(tick);
+  };
+
+  const startBreadcrumbAnimation = () => {
+    if (breadcrumbRafId) { cancelAnimationFrame(breadcrumbRafId); breadcrumbRafId = null; }
+    const pip = svgEl.querySelector('.graph-breadcrumb-pip');
+    if (!pip || prefersReducedMotion) return;
+    const fromX = parseFloat(pip.dataset.fromX);
+    const fromY = parseFloat(pip.dataset.fromY);
+    const toX = parseFloat(pip.dataset.toX);
+    const toY = parseFloat(pip.dataset.toY);
+    if (!Number.isFinite(fromX + fromY + toX + toY)) return;
+    const periodMs = 3600;
+    const t0 = performance.now();
+    const tick = (now) => {
+      if (destroyed) return;
+      const live = svgEl.querySelector('.graph-breadcrumb-pip');
+      if (!live) { breadcrumbRafId = null; return; }
+      const u = ((now - t0) % periodMs) / periodMs;
+      // Travel on 0..0.85; dormant 0.85..1. Ease-in-out along travel window.
+      let progress = 0;
+      let opacity = 0;
+      if (u < 0.85) {
+        const w = u / 0.85;
+        progress = w < 0.5 ? 2 * w * w : 1 - Math.pow(-2 * w + 2, 2) / 2;
+        if (u < 0.08) opacity = u / 0.08 * 0.9;
+        else if (u > 0.75) opacity = Math.max(0, (0.85 - u) / 0.10 * 0.9);
+        else opacity = 0.9;
+      }
+      const cx = fromX + (toX - fromX) * progress;
+      const cy = fromY + (toY - fromY) * progress;
+      live.setAttribute('cx', cx.toFixed(2));
+      live.setAttribute('cy', cy.toFixed(2));
+      live.style.opacity = opacity.toFixed(3);
+      breadcrumbRafId = requestAnimationFrame(tick);
+    };
+    breadcrumbRafId = requestAnimationFrame(tick);
   };
 
   const findNextNodeSuggestion = (activeNodeId) => {
@@ -2117,6 +2157,25 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
     const focusNode = model.nodeById.get(focusNodeId) || model.nodeById.get(model.coreId);
     const focusPalette = focusNode ? resolveNodePalette(graphTheme, focusNode, flashKindsByNodeId.get(focusNode.id)) : null;
 
+    const BRIDGE_MODES = new Set(['inspect', 'post-drill', 'study', 'session-complete', 'repair-reps']);
+    const breadcrumbEdge = (() => {
+      if (!BRIDGE_MODES.has(interactionMode)) return null;
+      // Skip when active drill is running — drill beam owns the edge-motion slot
+      if (DRILL_CONTEXT_MODES.has(interactionMode)) return null;
+      // Focus must be a node the learner has already engaged with (primed/drilled/solidified)
+      // so we don't nag when they're just looking at a fresh graph.
+      const focusNode = model.nodeById.get(focusNodeId);
+      const engaged = focusNode && (focusNode.state === 'primed' || focusNode.state === 'drilled' || focusNode.state === 'solidified');
+      if (!engaged) return null;
+      const suggestion = findNextNodeSuggestion(focusNodeId);
+      if (!suggestion?.id) return null;
+      return model.edges.find((edge) => (
+        edge.classes.includes('edge-structural')
+        && ((edge.source === focusNodeId && edge.target === suggestion.id)
+          || (edge.target === focusNodeId && edge.source === suggestion.id))
+      )) || null;
+    })();
+
     const beamEdge = (() => {
       if (activeDrillNodeId) {
         const parentId = model.structuralParentByNodeId.get(activeDrillNodeId) || '';
@@ -2139,11 +2198,11 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
             <stop offset="100%" stop-color="${graphTheme.nodeSelectionRing}" stop-opacity="0"></stop>
           </linearGradient>
           <radialGradient id="graph-focus-glow" cx="50%" cy="50%" r="50%">
-            <stop offset="0%" stop-color="${focusPalette?.ring || graphTheme.nodeSelectionRing}" stop-opacity="0.5"></stop>
+            <stop offset="0%" stop-color="${focusPalette?.ring || graphTheme.nodeSelectionRing}" stop-opacity="${graphTheme.focusGlowOpacity}"></stop>
             <stop offset="100%" stop-color="${focusPalette?.ring || graphTheme.nodeSelectionRing}" stop-opacity="0"></stop>
           </radialGradient>
         </defs>
-        <circle cx="${positions.get(focusNode.id)?.x ?? VIEWBOX.centerX}" cy="${positions.get(focusNode.id)?.y ?? VIEWBOX.centerY}" r="120" fill="url(#graph-focus-glow)"></circle>`
+        <circle cx="${positions.get(focusNode.id)?.x ?? VIEWBOX.centerX}" cy="${positions.get(focusNode.id)?.y ?? VIEWBOX.centerY}" r="${graphTheme.focusGlowRadius}" fill="url(#graph-focus-glow)"></circle>`
       : '';
 
     const edgeMarkup = model.edges.map((edge, index) => {
@@ -2194,14 +2253,17 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
         strokeWidth = edge.classes.includes('edge-lateral') ? 1.8 : 2.2;
       }
 
+      const isNextSuggestion = breadcrumbEdge && edge.id === breadcrumbEdge.id;
+      const edgeClass = `graph-edge${isNextSuggestion ? ' is-next-suggestion' : ''}`;
+
       if (edge.classes.includes('edge-structural')) {
-        return `<g class="graph-edge" data-graph-kind="edge" data-graph-id="${escHtml(edge.id)}" tabindex="0" role="button" aria-label="${escHtml(edge.label || edge.type || 'Connection')}">
+        return `<g class="${edgeClass}" data-graph-kind="edge" data-graph-id="${escHtml(edge.id)}" tabindex="0" role="button" aria-label="${escHtml(edge.label || edge.type || 'Connection')}">
           <line x1="${sourcePos.x}" y1="${sourcePos.y}" x2="${targetPos.x}" y2="${targetPos.y}" stroke="${stroke}" stroke-width="${strokeWidth}" stroke-linecap="round" opacity="${opacity}"></line>
           <line x1="${sourcePos.x}" y1="${sourcePos.y}" x2="${targetPos.x}" y2="${targetPos.y}" stroke="rgba(255,255,255,0.001)" stroke-width="${Math.max(strokeWidth * 10, 14)}" stroke-linecap="round" opacity="1"></line>
         </g>`;
       }
 
-      return `<g class="graph-edge" data-graph-kind="edge" data-graph-id="${escHtml(edge.id)}" tabindex="0" role="button" aria-label="${escHtml(edge.label || edge.type || 'Connection')}">
+      return `<g class="${edgeClass}" data-graph-kind="edge" data-graph-id="${escHtml(edge.id)}" tabindex="0" role="button" aria-label="${escHtml(edge.label || edge.type || 'Connection')}">
         <path d="${buildCurvePath(sourcePos, targetPos, index % 2 === 0 ? 1 : -1)}" fill="none" stroke="${stroke}" stroke-width="${strokeWidth}" stroke-dasharray="${dashArray}" opacity="${opacity}"></path>
         <path d="${buildCurvePath(sourcePos, targetPos, index % 2 === 0 ? 1 : -1)}" fill="none" stroke="rgba(255,255,255,0.001)" stroke-width="14" opacity="1"></path>
       </g>`;
@@ -2217,6 +2279,22 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
         return `<path class="graph-beam" d="${buildCurvePath(sourcePos, targetPos, 1)}" fill="none" stroke="url(#graph-beam-gradient)" stroke-width="2.5" stroke-dasharray="10 180"></path>${arrivalCircle}`;
       }
       return `<line class="graph-beam" x1="${sourcePos.x}" y1="${sourcePos.y}" x2="${targetPos.x}" y2="${targetPos.y}" stroke="url(#graph-beam-gradient)" stroke-width="2.5" stroke-dasharray="10 180"></line>${arrivalCircle}`;
+    })();
+
+    const breadcrumbMarkup = (() => {
+      if (!breadcrumbEdge || prefersReducedMotion) return '';
+      const src = positions.get(breadcrumbEdge.source);
+      const tgt = positions.get(breadcrumbEdge.target);
+      if (!src || !tgt) return '';
+      const from = breadcrumbEdge.source === focusNodeId ? src : tgt;
+      const to   = breadcrumbEdge.source === focusNodeId ? tgt : src;
+      // Stash endpoints on the element so RAF driver can read them without re-lookup
+      return `
+        <circle class="graph-breadcrumb-pip" r="3.2" cx="${from.x}" cy="${from.y}"
+                data-from-x="${from.x}" data-from-y="${from.y}"
+                data-to-x="${to.x}" data-to-y="${to.y}"></circle>
+        <circle class="graph-breadcrumb-arrival" cx="${to.x}" cy="${to.y}" r="10" fill="none" stroke="var(--accent-secondary)" stroke-width="1.2"></circle>
+      `;
     })();
 
     const nodeMarkup = model.nodes.map((node) => {
@@ -2305,7 +2383,8 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
       </g>`;
     }).join('');
 
-    svgEl.innerHTML = `${focusGlowMarkup}${edgeMarkup}${beamMarkup}${nodeMarkup}`;
+    svgEl.innerHTML = `${focusGlowMarkup}${edgeMarkup}${beamMarkup}${breadcrumbMarkup}${nodeMarkup}`;
+    startBreadcrumbAnimation();
   };
 
   const selectGraphElement = (kind, id, { preserveMode = false } = {}) => {
@@ -2487,6 +2566,7 @@ export function mountKnowledgeGraph({ container, detailEl, rawData, onNodeSelect
       freshSolidIds.clear();
       if (arrivalGlowTimeoutId) window.clearTimeout(arrivalGlowTimeoutId);
       if (panRafId) cancelAnimationFrame(panRafId);
+      if (breadcrumbRafId) cancelAnimationFrame(breadcrumbRafId);
       container.removeEventListener('pointerover', handlePointerOver);
       container.removeEventListener('pointerout', handlePointerOut);
       container.removeEventListener('click', handleClick);

--- a/public/js/tooltips.js
+++ b/public/js/tooltips.js
@@ -5,12 +5,7 @@ import {
 const OPEN_DELAY = 300;
 const CLOSE_DELAY = 150;
 
-const copy = {
-  'tip-start-here':
-    "Name one concept. Drill until you can explain it without notes.",
-  'tip-board-state':
-    "Your board fills as you add concepts. Each tile tracks one idea.",
-};
+const copy = {};
 
 const state = new Map();
 

--- a/public/js/tooltips.js
+++ b/public/js/tooltips.js
@@ -6,8 +6,6 @@ const OPEN_DELAY = 300;
 const CLOSE_DELAY = 150;
 
 const copy = {
-  'tip-add-concept':
-    "Add a topic to map. Drill it until you can reconstruct it from memory.",
   'tip-start-here':
     "Name one concept. Drill until you can explain it without notes.",
   'tip-board-state':

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,6 @@
-@import url('./css/variables.css?v=12');
+@import url('./css/variables.css?v=13');
 @import url('./css/base.css?v=14');
 @import url('./css/crystal.css?v=12');
-@import url('./css/components.css?v=31');
-@import url('./css/layout.css?v=18');
+@import url('./css/components.css?v=37');
+@import url('./css/layout.css?v=21');
 @import url('./css/ai-runs-dashboard.css?v=15');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,6 @@
 @import url('./css/variables.css?v=13');
 @import url('./css/base.css?v=14');
 @import url('./css/crystal.css?v=12');
-@import url('./css/components.css?v=37');
-@import url('./css/layout.css?v=21');
+@import url('./css/components.css?v=39');
+@import url('./css/layout.css?v=23');
 @import url('./css/ai-runs-dashboard.css?v=15');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,6 @@
 @import url('./css/variables.css?v=13');
 @import url('./css/base.css?v=14');
 @import url('./css/crystal.css?v=12');
-@import url('./css/components.css?v=37');
-@import url('./css/layout.css?v=21');
+@import url('./css/components.css?v=39');
+@import url('./css/layout.css?v=22');
 @import url('./css/ai-runs-dashboard.css?v=15');


### PR DESCRIPTION
## Summary

- Collapse empty-state mode selector to single textarea with input-shape routing (short+no punctuation → concept name, else → passage).
- Lifted-route isometric ghost graph preview (2.5D platform, dashed tile facets, cyan primed rings, violet pin-ring, dashed-corner locked nodes).
- Prior UX-voice rounds bundled: graph substrate polish, theme-aware remount, hero a11y (aria-live scope), Socratic empty-state copy, Board Empty chip + `(i)` tooltip removal.
- Supabase Auth swap under `auth/` (from D1 dev auth pass-through).

## Scope note

Branch `codex/UX-voice` has been the staging lane for multiple iterations — this PR bundles all of them. 89 files, +8166/-3773. Reviewable in logical chunks by commit:

- Auth: `d1220ee` (Supabase Auth swap)
- UX copy/chrome: `27a27e4`, `3cbefa2`, `750ced4`, `32208d2`, `156247c`, `3d29229`
- Graph substrate: `459cede`, `ff6645b`
- Empty state final form: `09f555e`, `f61d783`, `d282ff7`

## Test plan

- [ ] Load dashboard as new user → empty state shows: START HERE eyebrow, H1, single textarea, clipboard helper, Begin, reassurance, ghost graph
- [ ] Type `Entropy` + Begin → creation dialog opens with name pre-filled
- [ ] Paste multi-sentence passage + Begin → creation dialog opens with passage pre-filled on Text tab, name field focused
- [ ] Populated states (growing/fractured/etc.) still render old `.hero-actions` Begin button + isometric tile grid
- [ ] Dark mode: palette adapts, ghost graph readable
- [ ] Mobile 375w: layout stacks, no overflow
- [ ] Supabase auth flow: sign in / out / guest mode / exit guest
- [ ] Guest mode empty state: renders but creation dialog forks to starter-maps picker (pre-existing, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)