### PR TITLE
wip(dashboard): concept-pin refactor + gitignore scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ scripts/run-checks.sh
 *.excalidraw
 c4-mobile-*.png
 map-header-*.png
+
+# Local knowledge-base + scratch (not for version control)
+.socratink-brain/.obsidian/
+docs/research/
+docs/design/artboards/platform-grid-loaded-concept-mockups.html

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -193,11 +193,16 @@ body[data-drawer-open="true"] .icon-collapse {
 }
 
 /* ── 8. Transition animation classes ─────────────────────── */
-.crystal-anim.anim-emerge    { animation:gridEmerge    500ms ease forwards; }
-.crystal-anim.anim-crack     { animation:gridCrack     650ms ease forwards; }
-.crystal-anim.anim-cocoon    { animation:gridCocoon    700ms ease forwards; }
-.crystal-anim.anim-actualize { animation:gridActualize 750ms ease forwards; }
-.crystal-anim.anim-repair    { animation:gridRepair    550ms ease forwards; }
+.crystal-anim.anim-emerge,
+.concept-marker-anim.anim-emerge    { animation:gridEmerge    500ms ease forwards; }
+.crystal-anim.anim-crack,
+.concept-marker-anim.anim-crack     { animation:gridCrack     650ms ease forwards; }
+.crystal-anim.anim-cocoon,
+.concept-marker-anim.anim-cocoon    { animation:gridCocoon    700ms ease forwards; }
+.crystal-anim.anim-actualize,
+.concept-marker-anim.anim-actualize { animation:gridActualize 750ms ease forwards; }
+.crystal-anim.anim-repair,
+.concept-marker-anim.anim-repair    { animation:gridRepair    550ms ease forwards; }
 
 /* ── 9. Focus ring — a11y ────────────────────────────────── */
 /* Every interactive element inherits --accent-ring (violet light,

--- a/public/css/crystal.css
+++ b/public/css/crystal.css
@@ -30,9 +30,14 @@
 }
 
 /* Tile polygons */
-.tile-left  { fill:var(--tile-left);  transition:fill var(--theme-transition-ms) var(--theme-transition-ease); }
-.tile-right { fill:var(--tile-right); transition:fill var(--theme-transition-ms) var(--theme-transition-ease); }
-.tile-top   { fill:var(--tile-top);   transition:fill var(--theme-transition-ms) var(--theme-transition-ease); }
+.tile-left  { fill:var(--tile-left);  transition:fill var(--theme-transition-ms) var(--theme-transition-ease), opacity var(--theme-transition-ms) var(--theme-transition-ease); }
+.tile-right { fill:var(--tile-right); transition:fill var(--theme-transition-ms) var(--theme-transition-ease), opacity var(--theme-transition-ms) var(--theme-transition-ease); }
+.tile-top   {
+  fill:var(--tile-top);
+  stroke:var(--primary);
+  stroke-width:1.7;
+  transition:fill var(--theme-transition-ms) var(--theme-transition-ease), stroke var(--theme-transition-ms) var(--theme-transition-ease);
+}
 
 /* Click-catch polygon on each tile */
 .tile-hit {
@@ -44,8 +49,8 @@
 /* Selection highlight */
 .tile-highlight {
   fill:none;
-  stroke:var(--primary);
-  stroke-width:2.5;
+  stroke:rgba(var(--violet-600-rgb), 0.38);
+  stroke-width:1;
   opacity:0;
   transition:opacity 0.25s ease, stroke var(--theme-transition-ms) var(--theme-transition-ease);
   pointer-events:none;
@@ -54,19 +59,39 @@
 
 /* Empty slot */
 .tile-group.empty .tile-left,
-.tile-group.empty .tile-right { opacity:0.48; }
+.tile-group.empty .tile-right { opacity:0.34; }
 .tile-group.empty .tile-top-empty {
-  fill: rgba(var(--mauve-200-rgb), 0.24);
+  fill: rgba(var(--cream-50-rgb), 0.58);
   transition: fill var(--theme-transition-ms) var(--theme-transition-ease), opacity var(--theme-transition-ms) var(--theme-transition-ease);
 }
 .tile-group.empty .tile-top-dash {
   fill:none;
-  stroke:var(--locked);
-  stroke-width:1.5;
-  stroke-dasharray:4 3;
-  opacity:0.58;
+  stroke:rgba(var(--ink-900-rgb), 0.18);
+  stroke-width:1.2;
+  stroke-dasharray:3 4;
+  opacity:0.72;
 }
 .tile-group.empty .tile-hit { cursor:default; }
+
+/* Concept placement marker. This is intentionally not a progress/status glyph. */
+.concept-marker-anim { transition: opacity 0.3s ease, filter 0.3s ease; }
+.concept-pin-shadow {
+  fill: rgba(var(--ink-900-rgb), 0.10);
+  filter: blur(2px);
+}
+.concept-pin-line {
+  stroke: var(--primary);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+.concept-pin-head {
+  fill: rgba(var(--cream-50-rgb), 0.94);
+  stroke: var(--primary);
+  stroke-width: 2;
+}
+.concept-pin-core {
+  fill: var(--primary);
+}
 
 /* Crystal instance polygons — CSS transitions for color changes */
 .crystal-instance polygon {
@@ -81,6 +106,10 @@
   .tile-right,
   .tile-top,
   .tile-highlight,
+  .concept-marker-anim,
+  .concept-pin-line,
+  .concept-pin-head,
+  .concept-pin-core,
   .crystal-instance polygon {
     transition-duration: 0ms !important;
     animation-duration: 0ms !important;
@@ -116,8 +145,26 @@ body[data-theme="dark"] .tile-group.empty .tile-top-dash {
 }
 body.night .tile-group.selected .tile-highlight,
 body[data-theme="dark"] .tile-group.selected .tile-highlight {
-  stroke-width: 3;
+  stroke-width: 1.4;
   filter: drop-shadow(0 0 10px rgba(var(--lavender-500-rgb), 0.18));
+}
+body.night .concept-pin-shadow,
+body[data-theme="dark"] .concept-pin-shadow {
+  fill: rgba(7, 5, 15, 0.34);
+}
+body.night .concept-pin-line,
+body[data-theme="dark"] .concept-pin-line,
+body.night .concept-pin-head,
+body[data-theme="dark"] .concept-pin-head {
+  stroke: var(--lavender-500);
+}
+body.night .concept-pin-head,
+body[data-theme="dark"] .concept-pin-head {
+  fill: rgba(var(--ink-900-rgb), 0.82);
+}
+body.night .concept-pin-core,
+body[data-theme="dark"] .concept-pin-core {
+  fill: var(--lavender-500);
 }
 
 /* ── 5. Crystal state color selectors ────────────────────── */

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,6 +1,4 @@
 import { Bus } from './bus.js';
-import { GEO, easeInOutCubic, interpCoords, coordsToPoints } from './geo.js';
-import { Morph, crystalPolygons } from './morph.js';
 import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=7';
 import { bootstrapAuthUi, buildLoginHref, fetchAuthSession, logout, redirectToLogin } from './auth.js?v=2';
 import { mountLearnerAnalyticsDashboard } from './learner-analytics.js?v=4';
@@ -14,7 +12,7 @@ import {
   card, titleEl, descEl, primaryControls, drillControls,
   heroStateChipEl, heroPrimaryActionEl, consolidateControls, timerDisplay, devBtn, drawer, drawerToggle, conceptListEl,
   addTriggerArea, heroInfo, drillUi, chatHistory, chatInput, drillTitle,
-  TILE_IDS, tileEls, POLYGON_IDS
+  TILE_IDS, tileEls
 } from './dom.js';
 import { recordExtractRun, recordDrillRun } from './browser-analytics.js';
 
@@ -469,7 +467,7 @@ const App = (() => {
   function playAnim(name, tileIdx) {
     const cls = ANIM_CLASSES[name];
     if (!cls) return;
-    const el = document.getElementById('crystal-anim-' + tileIdx);
+    const el = document.getElementById('concept-marker-anim-' + tileIdx);
     if (!el) return;
     function done() {
       el.classList.remove(cls);
@@ -483,6 +481,8 @@ const App = (() => {
   }
 
   // ── 8. Grid rendering ──────────────────────────────────────
+  // Dashboard tiles are inventory/navigation. The pin marks that a concept
+  // has earned a place here; it does not encode proof or mastery.
   const TILE_PLATFORM = `
     <polygon class="tile-left"  points="0,40 70,80 70,90 0,50"/>
     <polygon class="tile-right" points="140,40 70,80 70,90 140,50"/>
@@ -497,31 +497,16 @@ const App = (() => {
     <polygon class="tile-top-dash"  points="70,0 140,40 70,80 0,40"/>
     <polygon class="tile-hit"       points="70,0 140,40 70,80 0,40"/>`;
 
-  function crystalSVG(idx, state) {
-    const G = GEO[state];
-    const p = coordsToPoints;
-    // Visual paint order: glow → lower faces → upper faces → tip → top → specular
+  function conceptPinSVG(idx, state) {
     return `
-    <g class="crystal-anim" id="crystal-anim-${idx}">
-      <g class="crystal-instance" id="crystal-${idx}" data-state="${state}"
-         transform="translate(35,-39.8) scale(0.35)" style="pointer-events:none;">
-        <ellipse cx="100" cy="228" rx="46" ry="7" fill="rgba(60,40,120,0.10)"/>
-        <polygon id="c${idx}-cp-glow"        class="cp-glow"        points="${p(G[7])}" fill="hsl(270,20%,60%)" opacity="0.10" filter="url(#glow-filter)"/>
-        <polygon id="c${idx}-cp-lower-left"  class="cp-lower-left"  points="${p(G[3])}" fill="hsl(270,16%,46%)" opacity="0.82"/>
-        <polygon id="c${idx}-cp-lower-right" class="cp-lower-right" points="${p(G[4])}" fill="hsl(270,14%,38%)" opacity="0.82"/>
-        <polygon id="c${idx}-cp-upper-left"  class="cp-upper-left"  points="${p(G[1])}" fill="hsl(270,18%,55%)" opacity="0.82"/>
-        <polygon id="c${idx}-cp-upper-right" class="cp-upper-right" points="${p(G[2])}" fill="hsl(270,16%,46%)" opacity="0.82"/>
-        <polygon id="c${idx}-cp-bottom-tip"  class="cp-bottom-tip"  points="${p(G[5])}" fill="hsl(270,14%,38%)" opacity="0.82"/>
-        <polygon id="c${idx}-cp-top"         class="cp-top"         points="${p(G[0])}" fill="hsl(270,20%,68%)" opacity="0.88"/>
-        <polygon id="c${idx}-cp-specular"    class="cp-specular"    points="${p(G[6])}" fill="hsl(270,30%,85%)" opacity="0.35"/>
+    <g class="concept-marker-anim" id="concept-marker-anim-${idx}">
+      <g class="concept-pin" id="concept-pin-${idx}" data-state="${state}" style="pointer-events:none;">
+        <ellipse class="concept-pin-shadow" cx="70" cy="43" rx="17" ry="3.5"/>
+        <line class="concept-pin-line" x1="70" y1="-15" x2="70" y2="38"/>
+        <circle class="concept-pin-head" cx="70" cy="-15" r="8.5"/>
+        <circle class="concept-pin-core" cx="70" cy="-15" r="3.1"/>
       </g>
     </g>`;
-  }
-
-  function refreshPolygonRefs(tileIdx) {
-    crystalPolygons[tileIdx] = POLYGON_IDS.map(id =>
-      document.getElementById('c' + tileIdx + '-' + id)
-    );
   }
 
   function renderGrid(concepts = loadConcepts()) {
@@ -539,10 +524,8 @@ const App = (() => {
 
       if (isEmpty) {
         tileEl.innerHTML = EMPTY_TILE;
-        crystalPolygons[idx] = null;
       } else {
-        tileEl.innerHTML = TILE_PLATFORM + crystalSVG(idx, concept.state);
-        refreshPolygonRefs(idx);
+        tileEl.innerHTML = TILE_PLATFORM + conceptPinSVG(idx, concept.state);
       }
     });
   }
@@ -1651,11 +1634,10 @@ const App = (() => {
     if (newState !== 'hibernating') patch.timerStart = null;
     updateActiveConcept(patch);
 
-    // Update crystal group's data-state (drives CSS color transitions)
-    const crystalEl = document.getElementById('crystal-' + tileIdx);
-    if (crystalEl) {
-      crystalEl.dataset.state = newState;
-      if (prevState !== newState) Morph.start(tileIdx, prevState, newState);
+    // Keep the dashboard marker in sync without turning the board into a proof/status surface.
+    const markerEl = document.getElementById('concept-pin-' + tileIdx);
+    if (markerEl) {
+      markerEl.dataset.state = newState;
     }
 
     // Update dot in list


### PR DESCRIPTION
## Summary

- **WIP**: concept-pin refactor replacing crystal SVG on dashboard tiles. Pin marks concept placement as inventory/navigation, not proof of mastery. Mid-refactor — drops `morph.js`/`GEO`/`crystalPolygons` imports, swaps `crystalSVG` → `conceptPinSVG`, renames anim IDs (`crystal-anim-*` → `concept-marker-anim-*`).
- **Chore**: `.gitignore` entries for local scratch (`.socratink-brain/.obsidian/`, `docs/research/`, `docs/design/artboards/platform-grid-loaded-concept-mockups.html`).

## Why

Branch reconciliation landed PR #43 into `main`. Uncommitted in-flight refactor work surfaced during worktree cleanup — captured on `dev` so it's not lost. Not ready for main — dashboard tile visuals still settling; `conceptPinSVG` body not yet finalized in this commit.

## Reviewer notes

- Do NOT merge until concept-pin refactor is complete. Tile rendering paths (`renderGrid` / `playAnim`) still reference the old `crystal-anim` IDs in some code paths — verify before ship.
- `morph.js`, `geo.js`, `dom.js#POLYGON_IDS` become candidates for removal once refactor lands. Not deleted yet.
- Visual polish branch is cleared — `main` and `dev` are the only branches. All other work (codex/*, claude/*, worktree-*) merged or deleted.

## Test plan

- [ ] Dashboard empty state renders (unchanged by this PR)
- [ ] Populated state tiles render `conceptPinSVG` without console errors
- [ ] Animations on tile state change still fire (check `playAnim` targets)
- [ ] No orphan imports from `morph.js` / `geo.js` remain once refactor finalizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)