### PR TITLE
Login design-system polish + UX review pass + meta fixes

### DIFF
--- a/auth/router.py
+++ b/auth/router.py
@@ -319,9 +319,9 @@ input {
 }
 
 .google-mark {
-  width: 20px;
-  height: 20px;
-  flex: 0 0 20px;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
 }
 
 .guest-button {
@@ -597,7 +597,7 @@ def _render_login_html() -> str:
   <meta name="application-name" content="Socratink">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Socratink">
-  <title>Socratink - The Socratic Canvas</title>
+  <title>socratink — the Socratic Canvas</title>
   <link rel="manifest" href="/manifest.webmanifest?v=1">
   <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png?v=6">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">

--- a/auth/router.py
+++ b/auth/router.py
@@ -284,7 +284,7 @@ input {
   padding: 0 22px;
   border-radius: var(--radius-pill);
   background: rgba(255, 255, 255, 0.56);
-  box-shadow: inset 0 0 0 1px var(--outline-soft);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
   color: var(--text);
   font-weight: 700;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
@@ -293,7 +293,7 @@ input {
 .google-button:hover {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.84);
-  box-shadow: inset 0 0 0 1px rgba(var(--mauve-200-rgb), 0.34), 0 12px 28px rgba(var(--ink-900-rgb), 0.05);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.48), 0 12px 28px rgba(var(--ink-900-rgb), 0.05);
 }
 
 .google-button:focus-visible {
@@ -315,7 +315,7 @@ input {
 .google-button.is-disabled:hover {
   transform: none;
   background: rgba(255, 255, 255, 0.56);
-  box-shadow: inset 0 0 0 1px var(--outline-soft);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
 }
 
 .google-mark {
@@ -333,7 +333,7 @@ input {
   padding: 0 22px;
   border-radius: var(--radius-pill);
   background: rgba(255, 255, 255, 0.56);
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
+  box-shadow: inset 0 0 0 1px var(--outline-soft);
   color: var(--text);
   font-weight: 700;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
@@ -342,7 +342,7 @@ input {
 .guest-button:hover {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.78);
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.48), 0 10px 24px rgba(var(--ink-900-rgb), 0.05);
+  box-shadow: inset 0 0 0 1px rgba(var(--mauve-200-rgb), 0.34), 0 10px 24px rgba(var(--ink-900-rgb), 0.05);
   color: var(--text);
 }
 
@@ -404,21 +404,19 @@ input {
   padding: 0;
   border-radius: var(--radius-pill);
   background: transparent;
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.14);
-  color: var(--text-muted);
-  opacity: 0.75;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.22);
+  color: rgba(var(--ink-900-rgb), 0.68);
   flex: 0 0 auto;
   justify-self: auto;
   transition: transform 120ms ease, box-shadow 120ms ease,
-              background 120ms ease, color 120ms ease, opacity 120ms ease;
+              background 120ms ease, color 120ms ease;
 }
 
 .icon-chip-row .coffee-button:hover,
 .icon-chip-row .discord-link:hover {
   transform: translateY(-1px);
-  opacity: 1;
   background: rgba(var(--violet-600-rgb), 0.06);
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.30);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.34);
   color: var(--primary);
 }
 
@@ -636,7 +634,7 @@ def _render_login_html() -> str:
               <span id="google-label">Continue with Google</span>
             </a>
             <a id="guest-continue-link" class="guest-button" href="/">
-              Continue as Guest
+              continue as guest
             </a>
             <div class="icon-chip-row">
               <a class="coffee-button" href="https://buymeacoffee.com/socratink" target="_blank" rel="noopener noreferrer" aria-label="Support the build on Buy Me a Coffee">

--- a/auth/router.py
+++ b/auth/router.py
@@ -19,36 +19,53 @@ GUEST_COOKIE_VALUE = "guest"
 
 
 _EMBEDDED_LOGIN_CSS = """
+/* Light-only surface. Login is pre-auth chrome and always renders in the cream/ink
+   theme; dark mode is not in scope here. HTML locks the theme via `class="light"`. */
 :root {
-  --surface: #fdf9f5;
-  --surface-low: #f7f3ef;
-  --surface-high: #ebe7e4;
-  --surface-card: rgba(255, 255, 255, 0.76);
-  --primary: #63469d;
-  --primary-strong: #7c5fb8;
-  --secondary: #68548d;
-  --text: #1c1c19;
-  --text-muted: #7b7582;
-  --text-soft: #494551;
-  --outline-soft: rgba(203, 196, 210, 0.9);
-  --shadow-card: 0 8px 32px rgba(28, 28, 25, 0.06);
-  --radius-card: 24px;
-  --radius-pill: 999px;
+  /* Login-local aliases over system tokens (tokens.css loaded first). */
+  --surface-card:    rgba(255, 255, 255, 0.76);
+  --primary:         var(--violet-600);
+  --primary-strong:  var(--primary-fill);
+  --secondary:       var(--lavender-500);
+  --text:            var(--ink-900);
+  --text-muted:      rgba(var(--ink-900-rgb), 0.54);
+  --text-soft:       rgba(var(--ink-900-rgb), 0.72);
+  --outline-soft:    rgba(var(--mauve-200-rgb), 0.9);
+  --shadow-ambient:  0 24px 64px rgba(var(--ink-900-rgb), 0.08);
 }
-* { box-sizing: border-box; }
-html, body { margin: 0; min-height: 100%; }
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
 body {
   position: relative;
   overflow: hidden;
   min-height: 100vh;
   background:
-    radial-gradient(circle at 14% 18%, rgba(210, 187, 255, 0.34), transparent 26%),
-    radial-gradient(circle at 88% 86%, rgba(210, 187, 255, 0.26), transparent 24%),
-    linear-gradient(180deg, rgba(253, 249, 245, 0.98), rgba(249, 244, 239, 0.96));
+    radial-gradient(circle at 14% 18%, rgba(144, 103, 198, 0.18), transparent 30%),
+    radial-gradient(circle at 88% 86%, rgba(141, 134, 201, 0.22), transparent 28%),
+    linear-gradient(180deg, #f7ece1, #f2e3d2);
   color: var(--text);
-  font-family: Inter, sans-serif;
+  font-family: var(--font-body);
 }
-a { color: inherit; text-decoration: none; }
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input {
+  font: inherit;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -60,22 +77,32 @@ a { color: inherit; text-decoration: none; }
   white-space: nowrap;
   border: 0;
 }
+
 #stardust-container {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: 1;
 }
+
 .star {
   position: absolute;
   border-radius: 50%;
-  background: rgba(107, 78, 166, 0.34);
+  background: rgba(144, 103, 198, 0.34);
   animation: twinkle var(--duration) ease-in-out infinite;
 }
+
 @keyframes twinkle {
-  0%, 100% { opacity: 0.18; transform: scale(1); }
-  50% { opacity: 0.62; transform: scale(1.16); }
+  0%, 100% {
+    opacity: 0.18;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.62;
+    transform: scale(1.16);
+  }
 }
+
 .aurora {
   position: absolute;
   border-radius: 999px;
@@ -85,27 +112,31 @@ a { color: inherit; text-decoration: none; }
   z-index: 0;
   transition: transform 160ms cubic-bezier(0.1, 0, 0.3, 1);
 }
+
 .aurora-a {
   top: -120px;
   left: -110px;
   width: 420px;
   height: 420px;
-  background: rgba(124, 95, 184, 0.52);
+  background: rgba(144, 103, 198, 0.42);
 }
+
 .aurora-b {
   right: -60px;
   bottom: -60px;
   width: 320px;
   height: 320px;
-  background: rgba(210, 187, 255, 0.6);
+  background: rgba(141, 134, 201, 0.55);
 }
+
 .aurora-c {
   top: 34%;
   left: 24%;
   width: 240px;
   height: 240px;
-  background: rgba(99, 70, 157, 0.32);
+  background: rgba(144, 103, 198, 0.28);
 }
+
 .login-shell {
   position: relative;
   z-index: 2;
@@ -115,6 +146,7 @@ a { color: inherit; text-decoration: none; }
   justify-content: center;
   padding: 40px 24px;
 }
+
 .login-stage {
   width: 100%;
   max-width: 340px;
@@ -122,35 +154,78 @@ a { color: inherit; text-decoration: none; }
   flex-direction: column;
   align-items: center;
 }
+
 .brand-lockup {
   margin-bottom: 26px;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
+
 .brand-mark {
-  width: 58px;
-  height: 58px;
+  width: 68px;
+  height: 68px;
   margin-bottom: 14px;
-  border-radius: 10px;
+  border-radius: 16px;
   object-fit: cover;
-  box-shadow: 0 0 22px rgba(99, 70, 157, 0.18);
+  box-shadow: 0 14px 28px rgba(var(--violet-600-rgb), 0.16);
 }
+
 .brand-title {
   margin: 0;
-  font-family: Manrope, sans-serif;
-  font-size: 2.05rem;
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
   font-weight: 800;
-  letter-spacing: -0.03em;
+  letter-spacing: var(--tracking-hero);
 }
-.brand-kicker {
+
+.brand-title-accent {
+  color: var(--violet-600);
+}
+
+.brand-pronunciation {
   margin: 6px 0 0;
   color: var(--secondary);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
+
+.discord-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  justify-self: center;
+  padding: 6px 12px;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+  font-weight: 600;
+  text-decoration: none;
+  opacity: 0.85;
+  transition: opacity 120ms ease, transform 120ms ease, color 120ms ease;
+}
+
+.discord-link:hover {
+  opacity: 1;
+  transform: translateY(-1px);
+  color: var(--primary);
+}
+
+.discord-link:focus-visible {
+  opacity: 1;
+  outline: 2px solid rgba(var(--violet-600-rgb), 0.58);
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+
+.discord-mark {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
 .login-card {
   width: 100%;
   border-radius: var(--radius-card);
@@ -160,32 +235,46 @@ a { color: inherit; text-decoration: none; }
   -webkit-backdrop-filter: blur(18px);
   box-shadow: var(--shadow-card);
 }
-.login-card-inner { padding: 32px 30px 28px; }
+
+.login-card-inner {
+  padding: 32px 30px 28px;
+}
+
 .auth-status-banner {
   border-radius: 14px;
   font-size: 0.9rem;
   line-height: 1.45;
+}
+
+.auth-status-banner {
   margin-bottom: 18px;
   padding: 12px 14px;
-  background: rgba(99, 70, 157, 0.08);
+  background: rgba(var(--violet-600-rgb), 0.08);
   color: var(--text-soft);
 }
+
 .auth-status-banner.is-error {
   background: rgba(186, 26, 26, 0.1);
   color: #8c2323;
 }
+
 .auth-status-banner.is-success {
-  background: rgba(99, 70, 157, 0.1);
+  background: rgba(var(--violet-600-rgb), 0.1);
   color: var(--primary);
 }
+
 .social-stack {
   display: grid;
   gap: 12px;
   margin-bottom: 28px;
 }
+
 .google-button {
   appearance: none;
   border: 0;
+}
+
+.google-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -200,20 +289,41 @@ a { color: inherit; text-decoration: none; }
   font-weight: 700;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
+
 .google-button:hover {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.84);
-  box-shadow: inset 0 0 0 1px rgba(123, 117, 130, 0.34), 0 12px 28px rgba(28, 28, 25, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(var(--mauve-200-rgb), 0.34), 0 12px 28px rgba(var(--ink-900-rgb), 0.05);
 }
+
+.google-button:focus-visible {
+  outline: 2px solid rgba(var(--violet-600-rgb), 0.58);
+  outline-offset: 3px;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32), 0 0 0 5px rgba(var(--violet-600-rgb), 0.1);
+}
+
 .google-button.is-loading {
   pointer-events: none;
   opacity: 0.88;
 }
+
+.google-button.is-disabled {
+  pointer-events: none;
+  opacity: 0.52;
+}
+
+.google-button.is-disabled:hover {
+  transform: none;
+  background: rgba(255, 255, 255, 0.56);
+  box-shadow: inset 0 0 0 1px var(--outline-soft);
+}
+
 .google-mark {
   width: 20px;
   height: 20px;
   flex: 0 0 20px;
 }
+
 .guest-button {
   display: flex;
   align-items: center;
@@ -222,74 +332,97 @@ a { color: inherit; text-decoration: none; }
   min-height: 52px;
   padding: 0 22px;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.36);
-  box-shadow: inset 0 0 0 1px rgba(123, 117, 130, 0.22);
-  color: var(--text-soft);
-  font-weight: 600;
+  background: rgba(255, 255, 255, 0.56);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
+  color: var(--text);
+  font-weight: 700;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
 }
+
 .guest-button:hover {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.5);
-  box-shadow: inset 0 0 0 1px rgba(123, 117, 130, 0.3), 0 10px 24px rgba(28, 28, 25, 0.04);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.48), 0 10px 24px rgba(var(--ink-900-rgb), 0.05);
   color: var(--text);
 }
+
+.guest-button:focus-visible {
+  outline: 2px solid rgba(var(--violet-600-rgb), 0.58);
+  outline-offset: 3px;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.48), 0 0 0 5px rgba(var(--violet-600-rgb), 0.1);
+}
+
 .coffee-button {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
   width: 100%;
-  min-height: 44px;
+  min-height: 40px;
   padding: 0 18px;
   border-radius: var(--radius-pill);
-  background: rgba(99, 70, 157, 0.06);
-  box-shadow: inset 0 0 0 1px rgba(99, 70, 157, 0.16);
-  color: #4f378b;
-  font-size: 0.9rem;
-  font-weight: 650;
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.14);
+  color: var(--text-muted);
+  font-size: 0.84rem;
+  font-weight: 600;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
 }
+
 .coffee-button:hover {
   transform: translateY(-1px);
-  background: rgba(99, 70, 157, 0.11);
-  box-shadow: inset 0 0 0 1px rgba(99, 70, 157, 0.3), 0 10px 22px rgba(99, 70, 157, 0.08);
+  background: rgba(var(--violet-600-rgb), 0.06);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.22);
   color: var(--primary);
 }
+
 .coffee-button:focus-visible {
-  outline: 2px solid rgba(99, 70, 157, 0.58);
+  outline: 2px solid rgba(var(--violet-600-rgb), 0.58);
   outline-offset: 3px;
-  background: rgba(99, 70, 157, 0.1);
-  box-shadow: inset 0 0 0 1px rgba(99, 70, 157, 0.32), 0 0 0 5px rgba(99, 70, 157, 0.1);
+  background: rgba(var(--violet-600-rgb), 0.1);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32), 0 0 0 5px rgba(var(--violet-600-rgb), 0.1);
 }
+
 .coffee-cup {
   width: 18px;
   height: 18px;
   flex: 0 0 18px;
 }
-.shimmer-btn {
-  position: relative;
-  overflow: hidden;
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  .star {
+    animation: none;
+    opacity: 0.34;
+  }
+
+  .aurora {
+    transition: none;
+  }
+
+  .google-button:hover,
+  .guest-button:hover,
+  .coffee-button:hover,
+  .discord-link:hover {
+    transform: none;
+  }
 }
-.shimmer-btn::after {
-  content: "";
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: linear-gradient(to bottom right, rgba(255,255,255,0) 0%, rgba(255,255,255,0) 40%, rgba(255,255,255,0.35) 50%, rgba(255,255,255,0) 60%, rgba(255,255,255,0) 100%);
-  transform: translateX(-150%) rotate(45deg);
-  animation: shimmer 5s linear infinite;
-}
-@keyframes shimmer {
-  0% { transform: translateX(-150%) rotate(45deg); }
-  20%, 100% { transform: translateX(150%) rotate(45deg); }
-}
+
 @media (max-width: 600px) {
-  .login-shell { padding: 24px 18px; }
-  .login-card-inner { padding: 28px 22px 24px; }
-  .brand-title { font-size: 1.8rem; }
+  .login-shell {
+    padding: 24px 18px;
+  }
+
+  .login-card-inner {
+    padding: 28px 22px 24px;
+  }
 }
 """
 

--- a/auth/router.py
+++ b/auth/router.py
@@ -595,6 +595,7 @@ def _render_login_html() -> str:
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#f7ece1">
   <meta name="application-name" content="Socratink">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Socratink">
   <title>socratink — the Socratic Canvas</title>

--- a/auth/router.py
+++ b/auth/router.py
@@ -389,6 +389,39 @@ input {
   flex: 0 0 18px;
 }
 
+.icon-chip-row {
+  display: flex;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 4px;
+}
+
+.icon-chip-row .coffee-button,
+.icon-chip-row .discord-link {
+  width: 36px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.14);
+  color: var(--text-muted);
+  opacity: 0.75;
+  flex: 0 0 auto;
+  justify-self: auto;
+  transition: transform 120ms ease, box-shadow 120ms ease,
+              background 120ms ease, color 120ms ease, opacity 120ms ease;
+}
+
+.icon-chip-row .coffee-button:hover,
+.icon-chip-row .discord-link:hover {
+  transform: translateY(-1px);
+  opacity: 1;
+  background: rgba(var(--violet-600-rgb), 0.06);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.30);
+  color: var(--primary);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -605,21 +638,21 @@ def _render_login_html() -> str:
             <a id="guest-continue-link" class="guest-button" href="/">
               Continue as Guest
             </a>
-            <a class="coffee-button" href="https://buymeacoffee.com/socratink" target="_blank" rel="noopener noreferrer">
-              <svg class="coffee-cup" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M6.75 8.5h8.5v5.25a4.25 4.25 0 0 1-8.5 0V8.5Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
-                <path d="M15.25 10h1.25a2 2 0 0 1 0 4h-1.25" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-                <path d="M5.5 18.5h11.75" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-                <path d="M8.5 5.5c0-.9.75-1.1.75-2M12 5.5c0-.9.75-1.1.75-2" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
-              </svg>
-              Support the build
-            </a>
-            <a class="discord-link" href="https://discord.gg/ZEHqpC6vMx" target="_blank" rel="noopener noreferrer">
-              <svg class="discord-mark" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M19.54 5.34A17.3 17.3 0 0 0 15.3 4l-.2.38a12.6 12.6 0 0 0-3.1-.38 12.6 12.6 0 0 0-3.1.38L8.7 4a17.3 17.3 0 0 0-4.24 1.34C1.73 9.38.98 13.3 1.36 17.16a17.56 17.56 0 0 0 5.3 2.66l1.08-1.46a11.2 11.2 0 0 1-1.78-.86l.44-.34a12.43 12.43 0 0 0 11.2 0l.44.34c-.56.33-1.15.62-1.78.86l1.08 1.46a17.56 17.56 0 0 0 5.3-2.66c.46-4.48-.72-8.36-3.1-11.82ZM8.52 14.9c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Zm6.96 0c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Z" fill="currentColor"></path>
-              </svg>
-              Join the Discord
-            </a>
+            <div class="icon-chip-row">
+              <a class="coffee-button" href="https://buymeacoffee.com/socratink" target="_blank" rel="noopener noreferrer" aria-label="Support the build on Buy Me a Coffee">
+                <svg class="coffee-cup" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M6.75 8.5h8.5v5.25a4.25 4.25 0 0 1-8.5 0V8.5Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
+                  <path d="M15.25 10h1.25a2 2 0 0 1 0 4h-1.25" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+                  <path d="M5.5 18.5h11.75" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+                  <path d="M8.5 5.5c0-.9.75-1.1.75-2M12 5.5c0-.9.75-1.1.75-2" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+                </svg>
+              </a>
+              <a class="discord-link" href="https://discord.gg/ZEHqpC6vMx" target="_blank" rel="noopener noreferrer" aria-label="Join the socratink Discord">
+                <svg class="discord-mark" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M19.54 5.34A17.3 17.3 0 0 0 15.3 4l-.2.38a12.6 12.6 0 0 0-3.1-.38 12.6 12.6 0 0 0-3.1.38L8.7 4a17.3 17.3 0 0 0-4.24 1.34C1.73 9.38.98 13.3 1.36 17.16a17.56 17.56 0 0 0 5.3 2.66l1.08-1.46a11.2 11.2 0 0 1-1.78-.86l.44-.34a12.43 12.43 0 0 0 11.2 0l.44.34c-.56.33-1.15.62-1.78.86l1.08 1.46a17.56 17.56 0 0 0 5.3-2.66c.46-4.48-.72-8.36-3.1-11.82ZM8.52 14.9c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Zm6.96 0c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
           </div>
         </div>
       </section>

--- a/docs/design/artboards/index-particle-empty-state.html
+++ b/docs/design/artboards/index-particle-empty-state.html
@@ -1,0 +1,844 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>socratink index particle mockup</title>
+  <link rel="stylesheet" href="../colors_and_type.css">
+  <style>
+    :root {
+      --stage-width: min(1120px, calc(100vw - 48px));
+      --sidebar-width: 248px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      min-height: 100%;
+      margin: 0;
+    }
+
+    body {
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+      min-height: 100dvh;
+      padding: 24px;
+      background: var(--page-background);
+      color: var(--text-strong);
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      -webkit-font-smoothing: antialiased;
+      overflow: hidden;
+    }
+
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      pointer-events: none;
+      border-radius: 50%;
+      filter: blur(38px);
+      opacity: 0.74;
+    }
+
+    body::before {
+      width: 360px;
+      height: 360px;
+      top: -120px;
+      right: 8vw;
+      background: radial-gradient(circle, rgba(var(--lavender-500-rgb), 0.24), transparent 66%);
+    }
+
+    body::after {
+      width: 420px;
+      height: 420px;
+      left: -140px;
+      bottom: -150px;
+      background: radial-gradient(circle, rgba(77, 186, 138, 0.14), transparent 68%);
+    }
+
+    .app-frame {
+      position: relative;
+      z-index: 1;
+      width: var(--stage-width);
+      min-height: min(760px, calc(100vh - 48px));
+      display: grid;
+      grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+      overflow: hidden;
+      border: 1px solid rgba(var(--ink-900-rgb), 0.10);
+      border-radius: 28px;
+      background:
+        linear-gradient(180deg, rgba(var(--white-rgb), 0.70), rgba(var(--cream-50-rgb), 0.78));
+      box-shadow:
+        0 42px 96px rgba(var(--ink-900-rgb), 0.11),
+        inset 0 1px 0 rgba(var(--white-rgb), 0.84);
+    }
+
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 22px;
+      padding: 26px 22px;
+      background:
+        linear-gradient(180deg, rgba(var(--white-rgb), 0.36), rgba(var(--mauve-200-rgb), 0.24));
+      border-right: 1px solid rgba(var(--ink-900-rgb), 0.08);
+      backdrop-filter: blur(18px);
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--text-strong);
+      font-family: "Geom", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 21px;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+    }
+
+    .brand-mark {
+      width: 30px;
+      height: 30px;
+      flex: none;
+      border-radius: 9px;
+      background:
+        linear-gradient(145deg, rgba(var(--white-rgb), 0.98), rgba(var(--cream-50-rgb), 0.82));
+      box-shadow: 0 10px 22px rgba(var(--violet-600-rgb), 0.14);
+      display: grid;
+      place-items: center;
+    }
+
+    .brand-mark svg {
+      width: 18px;
+      height: 18px;
+      overflow: visible;
+    }
+
+    .brand-accent {
+      color: var(--accent-primary);
+    }
+
+    .nav {
+      display: grid;
+      gap: 8px;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 42px;
+      padding: 0 12px;
+      border-radius: 12px;
+      color: var(--text-muted);
+      font-size: 14px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .nav-item.active {
+      background: rgba(var(--violet-600-rgb), 0.12);
+      color: var(--accent-primary);
+      box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.12);
+    }
+
+    .nav-icon {
+      width: 18px;
+      height: 18px;
+      flex: none;
+    }
+
+    .sidebar-section {
+      display: grid;
+      gap: 10px;
+      padding-top: 18px;
+      border-top: 1px solid rgba(var(--ink-900-rgb), 0.08);
+    }
+
+    .section-label {
+      margin: 0;
+      color: rgba(var(--ink-900-rgb), 0.54);
+      font-family: "Geom", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    .empty-line {
+      height: 38px;
+      border-radius: 12px;
+      border: 1px dashed rgba(var(--ink-900-rgb), 0.12);
+      background: rgba(var(--white-rgb), 0.24);
+    }
+
+    .sidebar-footer {
+      margin-top: auto;
+      display: grid;
+      gap: 10px;
+      color: var(--text-muted);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .sync-chip {
+      width: fit-content;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      background: rgba(var(--white-rgb), 0.52);
+      border: 1px solid rgba(var(--ink-900-rgb), 0.08);
+      color: rgba(var(--ink-900-rgb), 0.62);
+      font-weight: 700;
+    }
+
+    .sync-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--accent-secondary);
+      box-shadow: 0 0 0 4px rgba(var(--lavender-500-rgb), 0.14);
+    }
+
+    .main {
+      position: relative;
+      display: grid;
+      grid-template-rows: 68px minmax(0, 1fr);
+      min-width: 0;
+      background:
+        radial-gradient(circle at 58% 44%, rgba(var(--lavender-500-rgb), 0.13), transparent 30%),
+        linear-gradient(180deg, rgba(var(--white-rgb), 0.34), rgba(var(--cream-50-rgb), 0.18));
+    }
+
+    .main::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        linear-gradient(rgba(var(--ink-900-rgb), 0.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(var(--ink-900-rgb), 0.035) 1px, transparent 1px);
+      background-size: 36px 36px;
+      mask-image: radial-gradient(circle at center, black, transparent 74%);
+      pointer-events: none;
+    }
+
+    .topbar {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 0 26px;
+      border-bottom: 1px solid rgba(var(--ink-900-rgb), 0.07);
+      background: rgba(var(--white-rgb), 0.30);
+      backdrop-filter: blur(20px);
+    }
+
+    .menu-button,
+    .ghost-button,
+    .primary-button {
+      border: 0;
+      font: inherit;
+      cursor: default;
+    }
+
+    .menu-button {
+      width: 38px;
+      height: 38px;
+      display: inline-grid;
+      place-items: center;
+      border-radius: 12px;
+      background: rgba(var(--white-rgb), 0.56);
+      color: var(--text-muted);
+      box-shadow: 0 12px 24px rgba(var(--ink-900-rgb), 0.08);
+    }
+
+    .top-actions {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .ghost-button,
+    .primary-button {
+      min-height: 38px;
+      padding: 0 15px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .ghost-button {
+      border: 1px solid rgba(var(--ink-900-rgb), 0.10);
+      background: rgba(var(--white-rgb), 0.50);
+      color: var(--text-strong);
+    }
+
+    .primary-button {
+      background: var(--primary-fill);
+      color: var(--text-on-primary);
+      box-shadow: 0 12px 24px rgba(var(--violet-600-rgb), 0.18);
+    }
+
+    .hero {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      place-items: center;
+      padding: 46px 28px 58px;
+      min-height: 0;
+    }
+
+    .particle-wrap {
+      position: absolute;
+      inset: 70px 28px 28px;
+      overflow: hidden;
+      border-radius: 26px;
+      pointer-events: none;
+    }
+
+    .particle-wrap::before,
+    .particle-wrap::after {
+      content: "";
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(42px);
+      transform: translateZ(0);
+    }
+
+    .particle-wrap::before {
+      width: 260px;
+      height: 260px;
+      top: 16%;
+      left: 12%;
+      background: rgba(var(--lavender-500-rgb), 0.23);
+    }
+
+    .particle-wrap::after {
+      width: 300px;
+      height: 300px;
+      right: 10%;
+      bottom: 8%;
+      background: rgba(216, 168, 103, 0.13);
+    }
+
+    #particle-canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0.92;
+    }
+
+    .question-card {
+      position: relative;
+      z-index: 2;
+      width: min(680px, 100%);
+      display: grid;
+      justify-items: center;
+      text-align: center;
+      padding: 24px 10px 0;
+    }
+
+    .kicker {
+      margin: 0 0 18px;
+      color: var(--accent-primary);
+      font-family: "Geom", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 11ch;
+      margin: 0;
+      color: var(--text-strong);
+      font-family: "Geom", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: clamp(44px, 7vw, 72px);
+      font-weight: 760;
+      letter-spacing: -0.055em;
+      line-height: 0.92;
+      text-wrap: balance;
+    }
+
+    .prompt-shell {
+      width: min(590px, 100%);
+      margin-top: 72px;
+      display: grid;
+      gap: 12px;
+      padding: 10px;
+      border-radius: 22px;
+      border: 1px solid rgba(var(--ink-900-rgb), 0.10);
+      background:
+        linear-gradient(180deg, rgba(var(--white-rgb), 0.72), rgba(var(--cream-50-rgb), 0.50));
+      box-shadow:
+        0 28px 72px rgba(var(--ink-900-rgb), 0.10),
+        0 18px 38px rgba(var(--violet-600-rgb), 0.09),
+        inset 0 1px 0 rgba(var(--white-rgb), 0.88);
+      backdrop-filter: blur(22px);
+    }
+
+    .input-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: stretch;
+    }
+
+    .mock-input {
+      min-height: 62px;
+      display: flex;
+      align-items: center;
+      padding: 0 18px;
+      border-radius: 16px;
+      background: rgba(var(--white-rgb), 0.58);
+      border: 1px solid rgba(var(--ink-900-rgb), 0.09);
+      color: rgba(var(--ink-900-rgb), 0.48);
+      font-size: 15px;
+      font-weight: 600;
+      text-align: left;
+      box-shadow: inset 0 1px 0 rgba(var(--white-rgb), 0.76);
+    }
+
+    .begin-button {
+      min-width: 118px;
+      border: 0;
+      border-radius: 16px;
+      background: var(--primary-fill);
+      color: var(--text-on-primary);
+      font-family: "Geom", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+      font-weight: 800;
+      box-shadow:
+        0 16px 32px rgba(var(--violet-600-rgb), 0.22),
+        inset 0 1px 0 rgba(var(--white-rgb), 0.18);
+    }
+
+    .secondary-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      min-height: 34px;
+      padding: 0 4px 2px;
+      color: var(--text-muted);
+      font-size: 13px;
+      font-weight: 650;
+    }
+
+    .clipboard {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+    }
+
+    .caption {
+      margin: 42px 0 0;
+      color: rgba(var(--ink-900-rgb), 0.60);
+      font-size: 14px;
+      font-style: italic;
+      font-weight: 520;
+      line-height: 1.45;
+    }
+
+    .blur-card {
+      position: absolute;
+      z-index: 1;
+      width: 180px;
+      height: 116px;
+      border-radius: 22px;
+      border: 1px solid rgba(var(--white-rgb), 0.52);
+      background: rgba(var(--white-rgb), 0.22);
+      box-shadow:
+        inset 0 1px 0 rgba(var(--white-rgb), 0.64),
+        0 28px 80px rgba(var(--ink-900-rgb), 0.08);
+      backdrop-filter: blur(20px);
+      opacity: 0.72;
+    }
+
+    .blur-card.left {
+      left: 5%;
+      bottom: 16%;
+      transform: rotate(-6deg);
+    }
+
+    .blur-card.right {
+      right: 7%;
+      top: 20%;
+      transform: rotate(5deg);
+    }
+
+    .blur-card::before,
+    .blur-card::after {
+      content: "";
+      position: absolute;
+      left: 18px;
+      right: 18px;
+      height: 10px;
+      border-radius: 999px;
+      background: rgba(var(--ink-900-rgb), 0.08);
+    }
+
+    .blur-card::before {
+      top: 28px;
+      width: 54%;
+    }
+
+    .blur-card::after {
+      top: 50px;
+      opacity: 0.58;
+    }
+
+    @media (max-width: 860px) {
+      body {
+        padding: 0;
+        overflow: auto;
+      }
+
+      .app-frame {
+        width: 100%;
+        min-height: 100vh;
+        min-height: 100dvh;
+        grid-template-columns: 1fr;
+        border: 0;
+        border-radius: 0;
+      }
+
+      .sidebar {
+        display: none;
+      }
+
+      .main {
+        grid-template-rows: 58px minmax(0, 1fr);
+      }
+
+      .topbar {
+        padding: 0 16px;
+      }
+
+      .top-actions {
+        display: none;
+      }
+
+      .hero {
+        padding: 30px 18px 86px;
+      }
+
+      .particle-wrap {
+        inset: 58px 0 68px;
+        border-radius: 0;
+      }
+
+      h1 {
+        font-size: clamp(38px, 12vw, 58px);
+      }
+
+      .prompt-shell {
+        margin-top: 54px;
+        border-radius: 20px;
+      }
+
+      .input-row {
+        grid-template-columns: 1fr;
+      }
+
+      .begin-button {
+        min-height: 50px;
+      }
+
+      .secondary-row {
+        justify-content: center;
+        text-align: center;
+      }
+
+      .blur-card {
+        display: none;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      #particle-canvas {
+        opacity: 0.72;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="app-frame">
+    <aside class="sidebar" aria-label="Mock sidebar">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 40 40" fill="none">
+            <path d="M20 3 31 12 34 24 20 37 6 24 9 12 20 3Z" fill="rgba(144,103,198,0.20)" stroke="var(--accent-primary)" stroke-width="2"/>
+            <path d="M20 3v34M9 12h22M6 24h28M9 12l11 12 11-12" stroke="var(--accent-primary)" stroke-width="1.4" opacity="0.82"/>
+          </svg>
+        </span>
+        <span>socra<span class="brand-accent">tink</span></span>
+      </div>
+
+      <nav class="nav" aria-label="Mock navigation">
+        <a class="nav-item active" href="#">
+          <svg class="nav-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="m12 3 1.7 5.2L19 10l-5.3 1.8L12 17l-1.7-5.2L5 10l5.3-1.8L12 3Z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+          </svg>
+          Dashboard
+        </a>
+        <a class="nav-item" href="#">
+          <svg class="nav-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M7 8h10M7 12h10M7 16h6M5 4h14v16H5z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+          </svg>
+          Library
+        </a>
+        <a class="nav-item" href="#">
+          <svg class="nav-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M4 17 9 12l4 3 7-8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          Your Progress
+        </a>
+        <a class="nav-item" href="#">
+          <svg class="nav-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M12 8.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z" stroke="currentColor" stroke-width="1.8"/>
+            <path d="M19 12h2M3 12h2M12 3v2M12 19v2M17 7l1.4-1.4M5.6 18.4 7 17M7 7 5.6 5.6M18.4 18.4 17 17" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+          Settings
+        </a>
+      </nav>
+
+      <section class="sidebar-section">
+        <p class="section-label">Concepts</p>
+        <div class="empty-line"></div>
+        <div class="empty-line"></div>
+      </section>
+
+      <div class="sidebar-footer">
+        <span class="sync-chip"><span class="sync-dot"></span> Guest mode</span>
+        <span>Your words shape the path. They do not grade you.</span>
+      </div>
+    </aside>
+
+    <section class="main" aria-label="Mock empty index view">
+      <header class="topbar">
+        <button class="menu-button" aria-label="Toggle sidebar">
+          <svg width="19" height="19" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M5 7h14M5 12h14M5 17h14" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+          </svg>
+        </button>
+        <div class="top-actions">
+          <button class="ghost-button">Save &amp; Sync</button>
+          <button class="primary-button">Begin</button>
+        </div>
+      </header>
+
+      <div class="hero">
+        <div class="particle-wrap" aria-hidden="true">
+          <canvas id="particle-canvas"></canvas>
+        </div>
+        <div class="blur-card left" aria-hidden="true"></div>
+        <div class="blur-card right" aria-hidden="true"></div>
+
+        <div class="question-card">
+          <p class="kicker">Start here</p>
+          <h1>What do you want to understand?</h1>
+
+          <div class="prompt-shell">
+            <div class="input-row">
+              <div class="mock-input">e.g. Entropy, price elasticity, CRISPR</div>
+              <button class="begin-button">Begin</button>
+            </div>
+            <div class="secondary-row">
+              <span class="clipboard">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <rect x="8" y="3" width="8" height="4" rx="1.2" stroke="currentColor" stroke-width="1.7"/>
+                  <path d="M6 6H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-1" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/>
+                </svg>
+                Pick from clipboard
+              </span>
+              <span>The first room is small.</span>
+            </div>
+          </div>
+
+          <p class="caption">Nothing is loaded yet. The first signal comes from your attempt.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (() => {
+      const canvas = document.getElementById("particle-canvas");
+      const ctx = canvas.getContext("2d");
+      const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+      const pointer = { active: false, x: 0, y: 0 };
+      let width = 1;
+      let height = 1;
+      let particles = [];
+      let raf = null;
+      let last = 0;
+
+      const colors = [
+        "144,103,198",
+        "141,134,201",
+        "77,186,138",
+        "216,168,103"
+      ];
+
+      function seededRandom() {
+        let seed = 271828;
+        return () => {
+          seed = (seed * 1664525 + 1013904223) >>> 0;
+          return seed / 4294967296;
+        };
+      }
+
+      function resize() {
+        const rect = canvas.getBoundingClientRect();
+        const nextWidth = Math.max(1, Math.round(rect.width));
+        const nextHeight = Math.max(1, Math.round(rect.height));
+        if (nextWidth === width && nextHeight === height) return;
+
+        width = nextWidth;
+        height = nextHeight;
+        const scale = Math.min(window.devicePixelRatio || 1, 2);
+        canvas.width = Math.round(width * scale);
+        canvas.height = Math.round(height * scale);
+        ctx.setTransform(scale, 0, 0, scale, 0, 0);
+
+        const rand = seededRandom();
+        const count = Math.max(42, Math.min(86, Math.round((width * height) / 7400)));
+        particles = Array.from({ length: count }, (_, index) => {
+          const x = width * (0.12 + rand() * 0.76);
+          const y = height * (0.18 + rand() * 0.64);
+          return {
+            x,
+            y,
+            homeX: x,
+            homeY: y,
+            vx: (rand() - 0.5) * 0.18,
+            vy: (rand() - 0.5) * 0.18,
+            r: 1.3 + rand() * 2.4,
+            orbit: 8 + rand() * 28,
+            phase: rand() * Math.PI * 2,
+            speed: 0.38 + rand() * 0.86,
+            color: colors[index % colors.length]
+          };
+        });
+      }
+
+      function update(now) {
+        const dt = last ? Math.min(2.2, (now - last) / 16.67) : 1;
+        last = now;
+        const t = now * 0.001;
+        const focusX = width * 0.50;
+        const focusY = height * 0.52;
+
+        for (const p of particles) {
+          const targetX = p.homeX + Math.sin(t * p.speed + p.phase) * p.orbit;
+          const targetY = p.homeY + Math.cos(t * p.speed * 0.72 + p.phase) * p.orbit * 0.44;
+          p.vx += (targetX - p.x) * 0.006 * dt;
+          p.vy += (targetY - p.y) * 0.006 * dt;
+          p.vx += (focusX - p.x) * 0.00042 * dt;
+          p.vy += (focusY - p.y) * 0.00032 * dt;
+
+          if (pointer.active) {
+            const dx = p.x - pointer.x;
+            const dy = p.y - pointer.y;
+            const distance = Math.hypot(dx, dy);
+            if (distance > 0 && distance < 132) {
+              const force = Math.pow(1 - distance / 132, 2);
+              p.vx += (dx / distance) * force * 1.8 * dt;
+              p.vy += (dy / distance) * force * 1.8 * dt;
+            }
+          }
+
+          p.vx *= Math.pow(0.92, dt);
+          p.vy *= Math.pow(0.92, dt);
+          p.x += p.vx * dt;
+          p.y += p.vy * dt;
+        }
+      }
+
+      function draw(now) {
+        ctx.clearRect(0, 0, width, height);
+        ctx.lineWidth = 0.9;
+        const linkLimit = Math.max(86, Math.min(126, width * 0.16));
+
+        for (let i = 0; i < particles.length; i += 1) {
+          for (let j = i + 1; j < particles.length; j += 1) {
+            const a = particles[i];
+            const b = particles[j];
+            const distance = Math.hypot(a.x - b.x, a.y - b.y);
+            if (distance > linkLimit) continue;
+            const opacity = Math.pow(1 - distance / linkLimit, 2) * 0.20;
+            ctx.strokeStyle = `rgba(${a.color}, ${opacity})`;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+
+        for (const p of particles) {
+          const pulse = 0.75 + Math.sin(now * 0.002 + p.phase) * 0.16;
+          ctx.fillStyle = `rgba(${p.color}, 0.58)`;
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.r * pulse, 0, Math.PI * 2);
+          ctx.fill();
+
+          ctx.fillStyle = "rgba(247,236,225,0.70)";
+          ctx.beginPath();
+          ctx.arc(p.x - p.r * 0.18, p.y - p.r * 0.20, Math.max(0.55, p.r * 0.32), 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+
+      function frame(now) {
+        resize();
+        if (!reduceMotion.matches) update(now);
+        draw(now);
+        raf = requestAnimationFrame(frame);
+      }
+
+      document.addEventListener("pointermove", (event) => {
+        const rect = canvas.getBoundingClientRect();
+        const inside =
+          event.clientX >= rect.left &&
+          event.clientX <= rect.right &&
+          event.clientY >= rect.top &&
+          event.clientY <= rect.bottom;
+        if (!inside) {
+          pointer.active = false;
+          return;
+        }
+        pointer.active = true;
+        pointer.x = event.clientX - rect.left;
+        pointer.y = event.clientY - rect.top;
+      });
+
+      document.addEventListener("pointerleave", () => {
+        pointer.active = false;
+      });
+
+      window.addEventListener("resize", resize);
+      document.addEventListener("visibilitychange", () => {
+        if (document.hidden && raf) {
+          cancelAnimationFrame(raf);
+          raf = null;
+        } else if (!document.hidden && !raf) {
+          raf = requestAnimationFrame(frame);
+        }
+      });
+
+      resize();
+      raf = requestAnimationFrame(frame);
+    })();
+  </script>
+</body>
+</html>

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -263,7 +263,7 @@ input {
   padding: 0 22px;
   border-radius: var(--radius-pill);
   background: rgba(255, 255, 255, 0.56);
-  box-shadow: inset 0 0 0 1px var(--outline-soft);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
   color: var(--text);
   font-weight: 700;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
@@ -272,7 +272,7 @@ input {
 .google-button:hover {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.84);
-  box-shadow: inset 0 0 0 1px rgba(var(--mauve-200-rgb), 0.34), 0 12px 28px rgba(var(--ink-900-rgb), 0.05);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.48), 0 12px 28px rgba(var(--ink-900-rgb), 0.05);
 }
 
 .google-button:focus-visible {
@@ -294,7 +294,7 @@ input {
 .google-button.is-disabled:hover {
   transform: none;
   background: rgba(255, 255, 255, 0.56);
-  box-shadow: inset 0 0 0 1px var(--outline-soft);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
 }
 
 .google-mark {
@@ -312,7 +312,7 @@ input {
   padding: 0 22px;
   border-radius: var(--radius-pill);
   background: rgba(255, 255, 255, 0.56);
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
+  box-shadow: inset 0 0 0 1px var(--outline-soft);
   color: var(--text);
   font-weight: 700;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
@@ -321,7 +321,7 @@ input {
 .guest-button:hover {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.78);
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.48), 0 10px 24px rgba(var(--ink-900-rgb), 0.05);
+  box-shadow: inset 0 0 0 1px rgba(var(--mauve-200-rgb), 0.34), 0 10px 24px rgba(var(--ink-900-rgb), 0.05);
   color: var(--text);
 }
 
@@ -383,21 +383,19 @@ input {
   padding: 0;
   border-radius: var(--radius-pill);
   background: transparent;
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.14);
-  color: var(--text-muted);
-  opacity: 0.75;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.22);
+  color: rgba(var(--ink-900-rgb), 0.68);
   flex: 0 0 auto;
   justify-self: auto;
   transition: transform 120ms ease, box-shadow 120ms ease,
-              background 120ms ease, color 120ms ease, opacity 120ms ease;
+              background 120ms ease, color 120ms ease;
 }
 
 .icon-chip-row .coffee-button:hover,
 .icon-chip-row .discord-link:hover {
   transform: translateY(-1px);
-  opacity: 1;
   background: rgba(var(--violet-600-rgb), 0.06);
-  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.30);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.34);
   color: var(--primary);
 }
 

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -368,6 +368,39 @@ input {
   flex: 0 0 18px;
 }
 
+.icon-chip-row {
+  display: flex;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 4px;
+}
+
+.icon-chip-row .coffee-button,
+.icon-chip-row .discord-link {
+  width: 36px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.14);
+  color: var(--text-muted);
+  opacity: 0.75;
+  flex: 0 0 auto;
+  justify-self: auto;
+  transition: transform 120ms ease, box-shadow 120ms ease,
+              background 120ms ease, color 120ms ease, opacity 120ms ease;
+}
+
+.icon-chip-row .coffee-button:hover,
+.icon-chip-row .discord-link:hover {
+  transform: translateY(-1px);
+  opacity: 1;
+  background: rgba(var(--violet-600-rgb), 0.06);
+  box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.30);
+  color: var(--primary);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -298,9 +298,9 @@ input {
 }
 
 .google-mark {
-  width: 20px;
-  height: 20px;
-  flex: 0 0 20px;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
 }
 
 .guest-button {

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   <meta name="theme-color" content="#f7ece1">
   <meta name="application-name" content="Socratink">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Socratink">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/index.html
+++ b/public/index.html
@@ -545,7 +545,7 @@
 
   <script src="js/ai_service.js"></script>
   <script type="module" src="js/app.js?v=36"></script>
-  <script src="js/intro-particles.js?v=1"></script>
+  <script src="js/intro-particles.js?v=3"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>
 
   <!-- Vercel Speed Insights -->

--- a/public/js/intro-particles.js
+++ b/public/js/intro-particles.js
@@ -7,10 +7,25 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
 
   const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
   const pointer = { active: false, x: 0, y: 0 };
+  const typing = {
+    active: false,
+    x: 0,
+    y: 0,
+    energy: 0,
+    ring: 0,
+    spaceEnergy: 0,
+    spaceWave: 0,
+    spaceX: 0,
+    spaceY: 0,
+    spaceWidth: 1,
+    burstUntil: 0,
+    lastValueLength: 0,
+  };
 
   let width = 1;
   let height = 1;
   let particles = [];
+  let sparks = [];
   let raf = null;
   let last = 0;
 
@@ -65,6 +80,160 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
     });
   }
 
+  function getTypingFocus() {
+    const field = document.getElementById('hero-single-input-field');
+    const canvasRect = canvas.getBoundingClientRect();
+    const fieldRect = field?.getBoundingClientRect?.();
+
+    if (!fieldRect) {
+      return { x: width * 0.5, y: height * 0.58 };
+    }
+
+    const styles = window.getComputedStyle(field);
+    const fontSize = Number.parseFloat(styles.fontSize) || 16;
+    const paddingLeft = Number.parseFloat(styles.paddingLeft) || 16;
+    const paddingRight = Number.parseFloat(styles.paddingRight) || 16;
+    const selectionIndex = typeof field.selectionStart === 'number' ? field.selectionStart : field.value.length;
+    const currentLine = field.value.slice(0, selectionIndex).split('\n').pop() || '';
+    ctx.save();
+    ctx.font = `${styles.fontStyle} ${styles.fontWeight} ${styles.fontSize} ${styles.fontFamily}`;
+    const caretOffset = ctx.measureText(currentLine).width;
+    ctx.restore();
+
+    const caretX = paddingLeft + caretOffset + fontSize * 0.32;
+    const visibleX = Math.max(
+      paddingLeft + 18,
+      Math.min(fieldRect.width - paddingRight - 18, caretX),
+    );
+
+    return {
+      x: Math.max(0, Math.min(width, fieldRect.left - canvasRect.left + visibleX)),
+      y: Math.max(0, Math.min(height, fieldRect.bottom - canvasRect.top + 14)),
+    };
+  }
+
+  function getTypingFieldAnchor() {
+    const field = document.getElementById('hero-single-input-field');
+    const canvasRect = canvas.getBoundingClientRect();
+    const fieldRect = field?.getBoundingClientRect?.();
+
+    if (!fieldRect) {
+      return { x: width * 0.5, y: height * 0.6, width: width * 0.42 };
+    }
+
+    return {
+      x: Math.max(0, Math.min(width, fieldRect.left - canvasRect.left + fieldRect.width * 0.5)),
+      y: Math.max(0, Math.min(height, fieldRect.bottom - canvasRect.top + 18)),
+      width: Math.max(1, Math.min(width, fieldRect.width)),
+    };
+  }
+
+  function addTypingSparks(amount, mode = 'character') {
+    const isSpace = mode === 'space';
+    const count = Math.round(isSpace ? 8 + amount * 5 : 3 + amount * 3);
+    const spread = isSpace ? Math.min(180, typing.spaceWidth * 0.38) : 34;
+
+    for (let index = 0; index < count; index += 1) {
+      const angle = isSpace
+        ? -Math.PI * (0.2 + Math.random() * 0.6)
+        : -Math.PI * (0.22 + Math.random() * 0.58);
+      const speed = (isSpace ? 0.68 : 0.45) + Math.random() * 0.85 + amount * 0.18;
+      sparks.push({
+        x: (isSpace ? typing.spaceX : typing.x) + (Math.random() - 0.5) * spread,
+        y: (isSpace ? typing.spaceY : typing.y) + (Math.random() - 0.5) * (isSpace ? 18 : 12),
+        vx: Math.cos(angle) * speed + (Math.random() - 0.5) * (isSpace ? 0.65 : 0.35),
+        vy: Math.sin(angle) * speed - (isSpace ? 0.34 : 0.18),
+        life: 1,
+        decay: (isSpace ? 0.018 : 0.026) + Math.random() * 0.018,
+        size: (isSpace ? 1.2 : 0.9) + Math.random() * (isSpace ? 2.1 : 1.8),
+        phase: Math.random() * Math.PI * 2,
+        color: colors[Math.floor(Math.random() * colors.length)],
+      });
+    }
+
+    if (sparks.length > 48) {
+      sparks = sparks.slice(sparks.length - 48);
+    }
+  }
+
+  function pulseFromTyping(strength = 1, mode = 'character') {
+    if (reduceMotion.matches) {
+      resize();
+      draw(performance.now());
+      return;
+    }
+
+    const focus = getTypingFocus();
+    const fieldAnchor = getTypingFieldAnchor();
+    const amount = Math.max(0.45, Math.min(1.75, strength));
+    const isSpace = mode === 'space';
+    typing.active = true;
+    typing.x = focus.x;
+    typing.y = focus.y;
+    typing.spaceX = fieldAnchor.x;
+    typing.spaceY = fieldAnchor.y;
+    typing.spaceWidth = fieldAnchor.width;
+    typing.energy = Math.min(1.8, typing.energy + (isSpace ? 0.72 : 0.48) * amount);
+    typing.ring = Math.min(1, typing.ring + (isSpace ? 0.52 : 0.26) * amount);
+    typing.spaceEnergy = Math.min(1.9, typing.spaceEnergy + (isSpace ? 1.05 : 0.12) * amount);
+    typing.spaceWave = Math.min(1, typing.spaceWave + (isSpace ? 0.72 : 0.08) * amount);
+    typing.burstUntil = performance.now() + (isSpace ? 760 : 560);
+    addTypingSparks(amount, mode);
+
+    for (const p of particles) {
+      const sourceX = isSpace ? typing.spaceX : typing.x;
+      const sourceY = isSpace ? typing.spaceY : typing.y;
+      const radius = isSpace ? 306 : 218;
+      const dx = p.x - sourceX;
+      const dy = p.y - sourceY;
+      const distance = Math.hypot(dx, dy);
+      if (distance <= 0 || distance >= radius) continue;
+
+      const force = Math.pow(1 - distance / radius, 2) * amount;
+      if (isSpace) {
+        const direction = dx === 0 ? (Math.random() > 0.5 ? 1 : -1) : dx / Math.abs(dx);
+        p.vx += direction * force * 1.35 + (-dy / distance) * force * 0.22;
+        p.vy += (dy / distance) * force * 0.36 - force * 0.24;
+      } else {
+        p.vx += (dx / distance) * force * 0.9 + (-dy / distance) * force * 0.28;
+        p.vy += (dy / distance) * force * 0.7 + (dx / distance) * force * 0.22;
+      }
+    }
+
+    if (!raf) {
+      last = 0;
+      raf = requestAnimationFrame(frame);
+    }
+  }
+
+  function bindTypingReaction() {
+    const field = document.getElementById('hero-single-input-field');
+    if (!(field instanceof HTMLTextAreaElement)) return;
+
+    typing.lastValueLength = field.value.length;
+    let spaceQueued = false;
+
+    field.addEventListener('focus', () => {
+      pulseFromTyping(0.55);
+    });
+
+    field.addEventListener('keydown', (event) => {
+      spaceQueued = event.code === 'Space' && !event.metaKey && !event.ctrlKey && !event.altKey;
+    });
+
+    field.addEventListener('input', (event) => {
+      const nextLength = field.value.length;
+      const delta = Math.abs(nextLength - typing.lastValueLength);
+      const selectionIndex = typeof field.selectionStart === 'number' ? field.selectionStart : nextLength;
+      const insertedSpace =
+        (typeof InputEvent !== 'undefined' && event instanceof InputEvent && event.inputType === 'insertText' && event.data === ' ') ||
+        (spaceQueued && field.value.charAt(Math.max(0, selectionIndex - 1)) === ' ');
+      typing.lastValueLength = nextLength;
+      spaceQueued = false;
+      pulseFromTyping(delta || 1, insertedSpace ? 'space' : 'character');
+    });
+  }
+
   function update(now) {
     const dt = last ? Math.min(2.2, (now - last) / 16.67) : 1;
     last = now;
@@ -72,6 +241,32 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
     const t = now * 0.001;
     const focusX = width * 0.5;
     const focusY = height * 0.52;
+    const typingLive = typing.energy > 0.015 || typing.spaceEnergy > 0.015 || now < typing.burstUntil;
+
+    if (typingLive) {
+      typing.energy *= Math.pow(0.885, dt);
+      typing.ring *= Math.pow(0.9, dt);
+      typing.spaceEnergy *= Math.pow(0.865, dt);
+      typing.spaceWave *= Math.pow(0.88, dt);
+    } else {
+      typing.active = false;
+      typing.energy = 0;
+      typing.ring = 0;
+      typing.spaceEnergy = 0;
+      typing.spaceWave = 0;
+    }
+
+    sparks = sparks
+      .map((spark) => {
+        spark.life -= spark.decay * dt;
+        spark.x += spark.vx * dt;
+        spark.y += spark.vy * dt;
+        spark.vx *= Math.pow(0.95, dt);
+        spark.vy *= Math.pow(0.96, dt);
+        spark.vy -= 0.006 * dt;
+        return spark;
+      })
+      .filter((spark) => spark.life > 0);
 
     for (const p of particles) {
       const targetX = p.homeX + Math.sin(t * p.speed + p.phase) * p.orbit;
@@ -92,6 +287,36 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
           const force = Math.pow(1 - distance / 132, 2);
           p.vx += (dx / distance) * force * 1.8 * dt;
           p.vy += (dy / distance) * force * 1.8 * dt;
+        }
+      }
+
+      if (typing.active && typing.energy > 0.01) {
+        const dx = p.x - typing.x;
+        const dy = p.y - typing.y;
+        const distance = Math.hypot(dx, dy);
+
+        if (distance > 0 && distance < 224) {
+          const force = Math.pow(1 - distance / 224, 2) * typing.energy;
+          const swirl = 0.42 + Math.sin(t * 5.2 + p.phase) * 0.18;
+          p.vx += (dx / distance) * force * 0.28 * dt;
+          p.vy += (dy / distance) * force * 0.22 * dt;
+          p.vx += (-dy / distance) * force * swirl * dt;
+          p.vy += (dx / distance) * force * swirl * 0.78 * dt;
+        }
+      }
+
+      if (typing.active && typing.spaceEnergy > 0.01) {
+        const dx = p.x - typing.spaceX;
+        const dy = p.y - typing.spaceY;
+        const xRadius = Math.max(96, typing.spaceWidth * 0.54);
+        const yRadius = 156;
+        const distance = Math.hypot(dx / xRadius, dy / yRadius);
+
+        if (distance > 0 && distance < 1.28) {
+          const force = Math.pow(1 - distance / 1.28, 2) * typing.spaceEnergy;
+          const direction = dx === 0 ? 0 : dx / Math.abs(dx);
+          p.vx += direction * force * 0.42 * dt;
+          p.vy += (-0.2 + (dy / yRadius) * 0.16) * force * dt;
         }
       }
 
@@ -124,6 +349,81 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
       }
     }
 
+    if (typing.active && typing.energy > 0.02) {
+      const radius = 32 + typing.ring * 72 + Math.sin(now * 0.006) * 2;
+      const opacity = Math.min(0.26, typing.energy * 0.13);
+      const gradient = ctx.createRadialGradient(typing.x, typing.y, 6, typing.x, typing.y, radius);
+      gradient.addColorStop(0, `rgba(247,236,225,${opacity * 0.72})`);
+      gradient.addColorStop(0.38, `rgba(141,134,201,${opacity})`);
+      gradient.addColorStop(1, 'rgba(141,134,201,0)');
+
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(typing.x, typing.y, radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.strokeStyle = `rgba(144,103,198,${opacity * 0.58})`;
+      ctx.lineWidth = 0.8;
+      ctx.beginPath();
+      ctx.arc(typing.x, typing.y, radius * 0.48, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.lineWidth = 0.9;
+    }
+
+    if (typing.active && typing.spaceEnergy > 0.02) {
+      const opacity = Math.min(0.28, typing.spaceEnergy * 0.16);
+      const waveWidth = Math.min(typing.spaceWidth * 0.74, width * 0.68) * (0.55 + typing.spaceWave * 0.45);
+      const waveAmp = 2.5 + typing.spaceEnergy * 3.2;
+      const waveY = typing.spaceY + 3;
+
+      ctx.save();
+      ctx.strokeStyle = `rgba(144,103,198,${opacity})`;
+      ctx.lineWidth = 1.25;
+      ctx.beginPath();
+      for (let index = 0; index <= 28; index += 1) {
+        const progress = index / 28;
+        const x = typing.spaceX - waveWidth * 0.5 + waveWidth * progress;
+        const y = waveY + Math.sin(progress * Math.PI * 2 + now * 0.012) * waveAmp;
+        if (index === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+      ctx.stroke();
+
+      ctx.strokeStyle = `rgba(247,236,225,${opacity * 0.78})`;
+      ctx.lineWidth = 0.8;
+      ctx.beginPath();
+      ctx.ellipse(
+        typing.spaceX,
+        typing.spaceY + 1,
+        waveWidth * 0.28,
+        10 + typing.spaceWave * 15,
+        0,
+        0,
+        Math.PI * 2,
+      );
+      ctx.stroke();
+      ctx.restore();
+      ctx.lineWidth = 0.9;
+    }
+
+    for (const spark of sparks) {
+      const drift = Math.sin(now * 0.008 + spark.phase) * 1.8;
+      const opacity = Math.max(0, spark.life) * 0.62;
+
+      ctx.fillStyle = `rgba(${spark.color}, ${opacity})`;
+      ctx.beginPath();
+      ctx.arc(spark.x + drift, spark.y, spark.size * (0.7 + spark.life * 0.45), 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = `rgba(247,236,225,${opacity * 0.72})`;
+      ctx.beginPath();
+      ctx.arc(spark.x + drift - 0.3, spark.y - 0.4, Math.max(0.42, spark.size * 0.36), 0, Math.PI * 2);
+      ctx.fill();
+    }
+
     for (const p of particles) {
       const pulse = 0.75 + Math.sin(now * 0.002 + p.phase) * 0.16;
 
@@ -143,6 +443,12 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
     resize();
 
     if (reduceMotion.matches) {
+      typing.active = false;
+      typing.energy = 0;
+      typing.ring = 0;
+      typing.spaceEnergy = 0;
+      typing.spaceWave = 0;
+      sparks = [];
       draw(now);
       raf = null;
       return;
@@ -194,6 +500,7 @@ function mountIntroParticles(canvasId = 'intro-particle-canvas') {
   });
 
   resize();
+  bindTypingReaction();
   raf = requestAnimationFrame(frame);
 }
 

--- a/public/login.html
+++ b/public/login.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#f7ece1">
   <meta name="application-name" content="Socratink">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Socratink">
   <title>socratink — the Socratic Canvas</title>

--- a/public/login.html
+++ b/public/login.html
@@ -7,7 +7,7 @@
   <meta name="application-name" content="Socratink">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Socratink">
-  <title>Socratink - The Socratic Canvas</title>
+  <title>socratink — the Socratic Canvas</title>
   <link rel="manifest" href="/manifest.webmanifest?v=1">
   <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png?v=6">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">

--- a/public/login.html
+++ b/public/login.html
@@ -46,7 +46,7 @@
               <span id="google-label">Continue with Google</span>
             </a>
             <a id="guest-continue-link" class="guest-button" href="/">
-              Continue as Guest
+              continue as guest
             </a>
             <div class="icon-chip-row">
               <a class="coffee-button" href="https://buymeacoffee.com/socratink" target="_blank" rel="noopener noreferrer" aria-label="Support the build on Buy Me a Coffee">

--- a/public/login.html
+++ b/public/login.html
@@ -48,21 +48,21 @@
             <a id="guest-continue-link" class="guest-button" href="/">
               Continue as Guest
             </a>
-            <a class="coffee-button" href="https://buymeacoffee.com/socratink" target="_blank" rel="noopener noreferrer">
-              <svg class="coffee-cup" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M6.75 8.5h8.5v5.25a4.25 4.25 0 0 1-8.5 0V8.5Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
-                <path d="M15.25 10h1.25a2 2 0 0 1 0 4h-1.25" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-                <path d="M5.5 18.5h11.75" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-                <path d="M8.5 5.5c0-.9.75-1.1.75-2M12 5.5c0-.9.75-1.1.75-2" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
-              </svg>
-              Support the build
-            </a>
-            <a class="discord-link" href="https://discord.gg/ZEHqpC6vMx" target="_blank" rel="noopener noreferrer">
-              <svg class="discord-mark" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M19.54 5.34A17.3 17.3 0 0 0 15.3 4l-.2.38a12.6 12.6 0 0 0-3.1-.38 12.6 12.6 0 0 0-3.1.38L8.7 4a17.3 17.3 0 0 0-4.24 1.34C1.73 9.38.98 13.3 1.36 17.16a17.56 17.56 0 0 0 5.3 2.66l1.08-1.46a11.2 11.2 0 0 1-1.78-.86l.44-.34a12.43 12.43 0 0 0 11.2 0l.44.34c-.56.33-1.15.62-1.78.86l1.08 1.46a17.56 17.56 0 0 0 5.3-2.66c.46-4.48-.72-8.36-3.1-11.82ZM8.52 14.9c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Zm6.96 0c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Z" fill="currentColor"></path>
-              </svg>
-              Join the Discord
-            </a>
+            <div class="icon-chip-row">
+              <a class="coffee-button" href="https://buymeacoffee.com/socratink" target="_blank" rel="noopener noreferrer" aria-label="Support the build on Buy Me a Coffee">
+                <svg class="coffee-cup" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M6.75 8.5h8.5v5.25a4.25 4.25 0 0 1-8.5 0V8.5Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
+                  <path d="M15.25 10h1.25a2 2 0 0 1 0 4h-1.25" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+                  <path d="M5.5 18.5h11.75" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+                  <path d="M8.5 5.5c0-.9.75-1.1.75-2M12 5.5c0-.9.75-1.1.75-2" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+                </svg>
+              </a>
+              <a class="discord-link" href="https://discord.gg/ZEHqpC6vMx" target="_blank" rel="noopener noreferrer" aria-label="Join the socratink Discord">
+                <svg class="discord-mark" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M19.54 5.34A17.3 17.3 0 0 0 15.3 4l-.2.38a12.6 12.6 0 0 0-3.1-.38 12.6 12.6 0 0 0-3.1.38L8.7 4a17.3 17.3 0 0 0-4.24 1.34C1.73 9.38.98 13.3 1.36 17.16a17.56 17.56 0 0 0 5.3 2.66l1.08-1.46a11.2 11.2 0 0 1-1.78-.86l.44-.34a12.43 12.43 0 0 0 11.2 0l.44.34c-.56.33-1.15.62-1.78.86l1.08 1.46a17.56 17.56 0 0 0 5.3-2.66c.46-4.48-.72-8.36-3.1-11.82ZM8.52 14.9c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Zm6.96 0c-1.04 0-1.9-.96-1.9-2.14 0-1.18.84-2.14 1.9-2.14s1.92.96 1.9 2.14c0 1.18-.84 2.14-1.9 2.14Z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
Follow-up to #45 — the merge closed before these commits landed.

- `fix(login)`: mirror updated `public/css/login.css` into `_EMBEDDED_LOGIN_CSS` fallback. Vercel was serving the pre-design-system CSS against the new HTML (stale embedded string), producing unstyled Discord glyph + body-font pronunciation.
- `feat(login)`: collapse coffee + discord into a 36×36 icon-chip footer row (`.icon-chip-row`); strip visible labels, keep `aria-label`.
- `fix(login)`: UX review pass — swap primary/secondary border weight (Google owns violet, guest mauve), lowercase "continue as guest", raise icon-chip contrast to WCAG 2.2 3:1 (ink 0.68, violet border 0.22, no opacity dim).
- `fix(login)`: `<title>` → lowercase "socratink — the Socratic Canvas"; demote `.google-mark` 20→18px; verify focus ring clears card padding at 360px.
- `chore(meta)`: add `<meta name="mobile-web-app-capable" content="yes">` alongside the deprecated Apple meta across `/login`, `/index`, and the embedded login template.
- `chore`: sweep local WIP so dev-fresh matches disk — `public/js/intro-particles.js` (new), `intro-particles.js?v=1 → ?v=3` cache-bust in `public/index.html`, `docs/design/artboards/index-particle-empty-state.html`.

## Test plan
- [ ] Visit `/login` on the deploy preview — confirm violet "tink", sō·krə·tink kicker, Google pill has violet inset, guest pill has mauve, icon chips are two round 36px buttons in the card footer (no "Support the build" / "Join the Discord" text).
- [ ] Browser tab shows `socratink — the Socratic Canvas`.
- [ ] Keyboard-tab the Google button at 360px viewport; violet focus ring fully inside the card.
- [ ] Dev-tools: no "apple-mobile-web-app-capable is deprecated" warning.
- [ ] Hero intro-particles v=3 loads and behaves like the codex preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)