### PR TITLE
fix(auth): harden Supabase sessions

### DIFF
--- a/auth/router.py
+++ b/auth/router.py
@@ -734,7 +734,7 @@ def _apply_oauth_state_cookie(
         signed_state,
         secure=service.resolve_cookie_secure(_base_url(request)),
         httponly=True,
-        samesite=service.cookie_samesite,
+        samesite="lax",
         max_age=service.oauth_state_ttl_seconds,
         path="/",
     )
@@ -819,8 +819,16 @@ def auth_guest(request: Request, return_to: str | None = None):
         )
 
     response = RedirectResponse(url=sanitized_return_to, status_code=302)
-    if auth_state.sealed_session:
-        _apply_session_cookie(response, request, auth_state.sealed_session)
+    if not auth_state.authenticated or not auth_state.sealed_session:
+        logger.warning("Anonymous sign-in returned unauthenticated state")
+        return RedirectResponse(
+            url=_build_login_redirect(
+                return_to=sanitized_return_to,
+                auth_error="authentication_failed",
+            ),
+            status_code=302,
+        )
+    _apply_session_cookie(response, request, auth_state.sealed_session)
     response.delete_cookie(GUEST_COOKIE_NAME, path="/")
     return response
 
@@ -914,9 +922,19 @@ def auth_callback(
         _clear_oauth_state_cookie(response, request)
         return response
 
+    if not auth_state.authenticated or not auth_state.sealed_session:
+        logger.warning("Auth callback returned unauthenticated state")
+        response = RedirectResponse(
+            url=_build_login_redirect(
+                return_to=return_to, auth_error="authentication_failed"
+            ),
+            status_code=302,
+        )
+        _clear_oauth_state_cookie(response, request)
+        return response
+
     response = RedirectResponse(url=return_to, status_code=302)
-    if auth_state.sealed_session:
-        _apply_session_cookie(response, request, auth_state.sealed_session)
+    _apply_session_cookie(response, request, auth_state.sealed_session)
     response.delete_cookie(GUEST_COOKIE_NAME, path="/")
     _clear_oauth_state_cookie(response, request)
     return response

--- a/auth/service.py
+++ b/auth/service.py
@@ -99,6 +99,19 @@ def _map_supabase_user(user: Any | None) -> AuthUser | None:
     )
 
 
+def _should_clear_refresh_cookie(error: Exception) -> bool:
+    import httpx
+    from supabase import AuthApiError, AuthRetryableError, AuthSessionMissingError
+
+    if isinstance(error, (AuthRetryableError, httpx.TransportError)):
+        return False
+    if isinstance(error, AuthSessionMissingError):
+        return True
+    if isinstance(error, AuthApiError):
+        return getattr(error, "status", None) in {400, 401, 403}
+    return False
+
+
 class SupabaseAuthService:
     """Server-side Supabase auth flow with sealed-cookie sessions."""
 
@@ -353,12 +366,17 @@ class SupabaseAuthService:
         try:
             client = self._make_supabase_client()
             response = client.auth.refresh_session(refresh_token)
-        except Exception:
+        except Exception as err:
+            should_clear = _should_clear_refresh_cookie(err)
             return AuthSessionState(
                 auth_enabled=True,
                 authenticated=False,
-                should_clear_cookie=True,
-                error_reason="session_refresh_failed",
+                should_clear_cookie=should_clear,
+                error_reason=(
+                    "session_refresh_invalid"
+                    if should_clear
+                    else "session_refresh_unavailable"
+                ),
             )
         return self._state_from_response(response)
 
@@ -384,11 +402,16 @@ class SupabaseAuthService:
                 },
                 key=self.session_cookie_key,
             )
-        is_anon = bool(getattr(user, "is_anonymous", False)) if user is not None else False
+        authenticated = bool(sealed)
+        is_anon = (
+            bool(getattr(user, "is_anonymous", False))
+            if authenticated and user is not None
+            else False
+        )
         return AuthSessionState(
             auth_enabled=True,
-            authenticated=True,
-            user=_map_supabase_user(user),
+            authenticated=authenticated,
+            user=_map_supabase_user(user) if authenticated else None,
             guest_mode=is_anon,
             sealed_session=sealed,
         )

--- a/tests/test_auth_router_supabase.py
+++ b/tests/test_auth_router_supabase.py
@@ -125,6 +125,18 @@ class GoogleAuthStartTests(unittest.TestCase):
             response.headers.get("set-cookie", ""),
         )
 
+    def test_state_cookie_always_uses_lax_samesite(self):
+        service = FakeSupabaseAuthService(enabled=True)
+        service.cookie_samesite = "strict"
+        client = build_client(service)
+
+        response = client.get("/auth/google", follow_redirects=False)
+
+        cookies = response.headers.get("set-cookie", "")
+        self.assertIn(f"{service.oauth_state_cookie_name}=signed-state-cookie", cookies)
+        self.assertIn("SameSite=lax", cookies)
+        self.assertNotIn("SameSite=strict", cookies)
+
     def test_open_redirect_return_to_sanitized(self):
         service = FakeSupabaseAuthService(enabled=True)
         client = build_client(service)
@@ -212,6 +224,22 @@ class CallbackTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertIn("auth_error=authentication_failed", response.headers["location"])
+
+    def test_unauthenticated_exchange_state_redirects_with_error(self):
+        service = FakeSupabaseAuthService(enabled=True)
+        service.callback_state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=False,
+            user=AuthUser(id="user_uuid_123", email="learner@example.com"),
+        )
+        client = build_client(service)
+        client.cookies.set(service.oauth_state_cookie_name, "signed-state-cookie")
+
+        response = client.get("/auth/callback?code=abc", follow_redirects=False)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("auth_error=authentication_failed", response.headers["location"])
+        self.assertNotIn("sb_session=", response.headers.get("set-cookie", ""))
 
 
 class ApiMeAndLogoutTests(unittest.TestCase):
@@ -330,6 +358,21 @@ class AnonymousGuestTests(unittest.TestCase):
         response = client.get("/auth/guest?return_to=/", follow_redirects=False)
         self.assertEqual(response.status_code, 302)
         self.assertIn("auth_error=authentication_failed", response.headers["location"])
+
+    def test_guest_unauthenticated_state_redirects_without_session_cookie(self):
+        service = FakeSupabaseAuthService(enabled=True)
+        service.sign_in_anonymously = lambda: AuthSessionState(  # type: ignore[assignment]
+            auth_enabled=True,
+            authenticated=False,
+            user=AuthUser(id="anon_uuid_456"),
+        )
+        client = build_client(service)
+
+        response = client.get("/auth/guest?return_to=/library", follow_redirects=False)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("auth_error=authentication_failed", response.headers["location"])
+        self.assertNotIn("sb_session=", response.headers.get("set-cookie", ""))
 
 
 if __name__ == "__main__":

--- a/tests/test_supabase_exchange.py
+++ b/tests/test_supabase_exchange.py
@@ -29,7 +29,14 @@ def _build_service() -> SupabaseAuthService:
     )
 
 
-def _fake_response(*, full_name: str | None = "Jon Doe", given_name: str | None = None):
+def _fake_response(
+    *,
+    full_name: str | None = "Jon Doe",
+    given_name: str | None = None,
+    session: bool = True,
+    access_token: str | None = "access.jwt.value",
+    refresh_token: str | None = "refresh-rt-value",
+):
     user_metadata = {}
     if full_name is not None:
         user_metadata["full_name"] = full_name
@@ -40,12 +47,14 @@ def _fake_response(*, full_name: str | None = "Jon Doe", given_name: str | None 
         email="learner@example.com",
         user_metadata=user_metadata,
     )
-    session = SimpleNamespace(
-        access_token="access.jwt.value",
-        refresh_token="refresh-rt-value",
-        expires_at=int(time.time()) + 3600,
-    )
-    return SimpleNamespace(user=user, session=session)
+    session_obj = None
+    if session:
+        session_obj = SimpleNamespace(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=int(time.time()) + 3600,
+        )
+    return SimpleNamespace(user=user, session=session_obj)
 
 
 class ExchangeCodeTests(unittest.TestCase):
@@ -61,6 +70,40 @@ class ExchangeCodeTests(unittest.TestCase):
             )
         self.assertTrue(state.authenticated)
         self.assertIsNotNone(state.sealed_session)
+
+    def test_missing_session_returns_unauthenticated_without_user(self):
+        svc = _build_service()
+        with patch.object(svc, "_make_supabase_client") as factory:
+            client = factory.return_value
+            client.auth.exchange_code_for_session.return_value = _fake_response(
+                session=False
+            )
+            state = svc.exchange_code(
+                code="abc",
+                code_verifier="ver_xyz",
+                redirect_uri="http://localhost:8000/auth/callback",
+            )
+        self.assertFalse(state.authenticated)
+        self.assertIsNone(state.sealed_session)
+        self.assertIsNone(state.user)
+        self.assertFalse(state.guest_mode)
+
+    def test_missing_token_returns_unauthenticated_without_user(self):
+        svc = _build_service()
+        with patch.object(svc, "_make_supabase_client") as factory:
+            client = factory.return_value
+            client.auth.exchange_code_for_session.return_value = _fake_response(
+                access_token=None
+            )
+            state = svc.exchange_code(
+                code="abc",
+                code_verifier="ver_xyz",
+                redirect_uri="http://localhost:8000/auth/callback",
+            )
+        self.assertFalse(state.authenticated)
+        self.assertIsNone(state.sealed_session)
+        self.assertIsNone(state.user)
+        self.assertFalse(state.guest_mode)
 
     def test_sdk_called_with_dict_argument_shape(self):
         svc = _build_service()

--- a/tests/test_supabase_load_session.py
+++ b/tests/test_supabase_load_session.py
@@ -5,8 +5,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import jwt
 from cryptography.fernet import Fernet
+from supabase import AuthApiError
 
 from auth.service import SupabaseAuthService
 from auth.session_seal import seal_session_tokens, unseal_session_tokens
@@ -102,16 +104,29 @@ class LoadSessionTests(unittest.TestCase):
         self.assertEqual(decoded["access_token"], new_access)
         self.assertEqual(decoded["refresh_token"], "rt_rotated")
 
-    def test_refresh_failure_clears_session(self):
+    def test_refresh_network_failure_preserves_session_cookie(self):
         svc = _make_service()
         sealed_in = _seal(exp_offset=-60)
         with patch.object(svc, "_make_supabase_client") as factory:
-            factory.return_value.auth.refresh_session.side_effect = RuntimeError(
-                "refresh denied"
+            factory.return_value.auth.refresh_session.side_effect = httpx.ConnectError(
+                "temporary outage"
+            )
+            state = svc.load_session(sealed_in)
+        self.assertFalse(state.authenticated)
+        self.assertFalse(state.should_clear_cookie)
+        self.assertEqual(state.error_reason, "session_refresh_unavailable")
+
+    def test_refresh_invalid_token_clears_session(self):
+        svc = _make_service()
+        sealed_in = _seal(exp_offset=-60)
+        with patch.object(svc, "_make_supabase_client") as factory:
+            factory.return_value.auth.refresh_session.side_effect = AuthApiError(
+                "refresh denied", 400, "bad_refresh_token"
             )
             state = svc.load_session(sealed_in)
         self.assertFalse(state.authenticated)
         self.assertTrue(state.should_clear_cookie)
+        self.assertEqual(state.error_reason, "session_refresh_invalid")
 
     def test_disabled_service_returns_disabled_state(self):
         svc = SupabaseAuthService(


### PR DESCRIPTION
## Context & Intent
- Fixes Supabase OAuth/session bugs where failed exchanges could be treated as authenticated, transient refresh failures could clear cookies, and OAuth state cookies could inherit an incompatible SameSite policy.
- Stems from MVP auth stabilization after deployed Preview OAuth testing.

## Implementation Details
- Auth state now requires a sealable session before reporting `authenticated=true`.
- Refresh failures now clear cookies only for invalid/revoked refresh-token cases, while preserving cookies for transient provider/network failures.
- OAuth state cookies are always `SameSite=lax`.
- Callback and guest routes fail closed when auth state lacks both `authenticated` and `sealed_session`.
- Adds focused regression coverage for exchange mapping, refresh behavior, OAuth state cookie attributes, and unauthenticated route states.

## MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [x] Are there SSRF or error leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

## UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Validation:
- `python -m unittest tests.test_supabase_exchange tests.test_supabase_load_session tests.test_auth_router_supabase`
- `python -m unittest discover -s tests`
- Preview browser QA on `dev-fresh` OAuth flow passed.