### PR TITLE
Lego-ification Phase 2.1 + 2.2: ai_service.js → ESM, drop unused window.startSettings

### DIFF
--- a/docs/superpowers/plans/2026-04-26-lego-ification-roadmap.md
+++ b/docs/superpowers/plans/2026-04-26-lego-ification-roadmap.md
@@ -214,7 +214,7 @@ Imports use ad-hoc `?v=N` query strings (`graph-view.js?v=7`, `auth.js?v=2`, `ap
 4. **Convert `intro-particles.js` to `type="module"` (or leave alone).** It's a one-shot visual effect; if it doesn't set globals or have peers, no benefit to converting. Verify with grep, then decide.
 
 **Phase 2 ordering (revised):**
-- 2.1 — Convert `ai_service.js` to ESM, replace `window.AIService` in `app.js`. (~1 session)
+- 2.1 — ✅ Complete (`68383b1`). Converted `ai_service.js` to ESM; dropped `window.AIService` global; replaced the single call site in `app.js`. Bumped `app.js` cache version 41 → 42.
 - 2.2 — Audit and clean up the `window.App` / `SocratinkApp` / `startSettings` globals; drop redundancies; document the surviving bridge.
 - 2.3 — Begin intra-`app.js` extracts: API client first (cleanest leaf), then persistence, then drill state reducer.
 - 2.4 — DOM/render helpers extract.

--- a/docs/superpowers/plans/2026-04-26-lego-ification-roadmap.md
+++ b/docs/superpowers/plans/2026-04-26-lego-ification-roadmap.md
@@ -215,7 +215,7 @@ Imports use ad-hoc `?v=N` query strings (`graph-view.js?v=7`, `auth.js?v=2`, `ap
 
 **Phase 2 ordering (revised):**
 - 2.1 — ✅ Complete (`68383b1`). Converted `ai_service.js` to ESM; dropped `window.AIService` global; replaced the single call site in `app.js`. Bumped `app.js` cache version 41 → 42.
-- 2.2 — Audit and clean up the `window.App` / `SocratinkApp` / `startSettings` globals; drop redundancies; document the surviving bridge.
+- 2.2 — ✅ Complete (`c7858d3`). Dropped unused `window.startSettings`. **Audit was wrong about `SocratinkApp`** — Gemini-verified that `graph-view.js` reads it 17 times via optional chaining; it's the de facto renderer→app intent bridge that Phase 3 formalizes. Both surviving globals (`App`, `SocratinkApp`) now have a documented contract above the assignment with the silent-failure risk called out explicitly. Bumped `app.js` cache version 42 → 43.
 - 2.3 — Begin intra-`app.js` extracts: API client first (cleanest leaf), then persistence, then drill state reducer.
 - 2.4 — DOM/render helpers extract.
 - (Defer: HTML inline-handler cleanup — own micro-phase if pursued.)

--- a/public/index.html
+++ b/public/index.html
@@ -543,8 +543,7 @@
 
   <div id="tooltip-root" aria-hidden="true"></div>
 
-  <script src="js/ai_service.js"></script>
-  <script type="module" src="js/app.js?v=41"></script>
+  <script type="module" src="js/app.js?v=42"></script>
   <script src="js/intro-particles.js?v=3"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -543,7 +543,7 @@
 
   <div id="tooltip-root" aria-hidden="true"></div>
 
-  <script type="module" src="js/app.js?v=42"></script>
+  <script type="module" src="js/app.js?v=43"></script>
   <script src="js/intro-particles.js?v=3"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>
 

--- a/public/js/ai_service.js
+++ b/public/js/ai_service.js
@@ -1,22 +1,18 @@
 // ai_service.js
 // Calls the local Python backend for AI extraction.
 
-const AIService = {
-  async generateKnowledgeMap(rawText, onProgress) {
-    if (onProgress) onProgress('Mapping knowledge...');
-    const apiKey = localStorage.getItem('gemini_key') || undefined;
-    const response = await fetch('/api/extract', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: rawText, api_key: apiKey }),
-    });
-    if (!response.ok) {
-      const err = await response.text().catch(() => '');
-      throw new Error(`Server error ${response.status}: ${err}`);
-    }
-    const data = await response.json();
-    return data.knowledge_map;
+export async function generateKnowledgeMap(rawText, onProgress) {
+  if (onProgress) onProgress('Mapping knowledge...');
+  const apiKey = localStorage.getItem('gemini_key') || undefined;
+  const response = await fetch('/api/extract', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: rawText, api_key: apiKey }),
+  });
+  if (!response.ok) {
+    const err = await response.text().catch(() => '');
+    throw new Error(`Server error ${response.status}: ${err}`);
   }
-};
-
-window.AIService = AIService;
+  const data = await response.json();
+  return data.knowledge_map;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4054,6 +4054,28 @@ const App = (() => {
   };
 
 })();
+
+// Two deliberate browser globals (HTML and graph-view bridges).
+// Removing either silently breaks production user flows — see below
+// for the inventory of readers. Any new global on `window` MUST be
+// justified the same way and added to this comment block.
+//
+// window.App — read by 18 inline onclick="App.foo()" handlers in
+// public/index.html (bottom-nav, drawer, hero CTAs, drill controls,
+// theme toggle, tile selection). HTML→JS bridge. Phase 2 keeps this
+// intentional; a future micro-phase could rewrite the inline handlers
+// as addEventListener wiring and drop the global.
+//
+// window.SocratinkApp — read by 17 call sites in graph-view.js as
+// optional-chained intents (e.g. window.SocratinkApp?.startRepairReps,
+// ?.runInspectAction, ?.completeStudy). Because every reader uses
+// optional chaining (`?.`), removing this assignment will fail
+// SILENTLY rather than throw — you would not see an error in the
+// console, but repair-reps, study-completion, and inspect flows
+// would all become no-ops. Graph-view is the renderer; it never
+// owns truth. SocratinkApp is the intent-bridge that lets Cytoscape
+// interaction events trigger app.js mutations without a circular
+// import. Phase 3 of the lego-ification roadmap formalizes this
+// contract (see docs/superpowers/plans/2026-04-26-lego-ification-roadmap.md).
 window.App = App;
 window.SocratinkApp = App;
-window.startSettings = () => App.showSettings();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,5 @@
 import { Bus } from './bus.js';
+import { generateKnowledgeMap } from './ai_service.js?v=1';
 import { escHtml, mountKnowledgeGraph } from './graph-view.js?v=7';
 import { bootstrapAuthUi, buildLoginHref, fetchAuthSession, logout, redirectToLogin } from './auth.js?v=2';
 import { mountLearnerAnalyticsDashboard } from './learner-analytics.js?v=4';
@@ -1507,7 +1508,7 @@ const App = (() => {
           extractOverlay.classList.add('eo-mapping');
           startTrickle();
           startMetaCycle();
-          const jsonPayload = await window.AIService.generateKnowledgeMap(sourceText);
+          const jsonPayload = await generateKnowledgeMap(sourceText);
           const durationMs = Math.round(performance.now() - extractStartedPerf);
 
           // INVARIANT: failed or malformed extraction must never mutate


### PR DESCRIPTION
## Summary

Phase 2 of the lego-ification roadmap (`docs/superpowers/plans/2026-04-26-lego-ification-roadmap.md`). Two small frontend cleanups that close the only real implicit-global dependencies app.js had on its peers.

- **Phase 2.1** (`68383b1`): Convert `public/js/ai_service.js` from a classic `<script>` (assigning `window.AIService`) to an ES module (`export async function generateKnowledgeMap`). app.js now imports the function directly. The synchronous parser-blocking script tag is removed from index.html. One reader, one call site, zero remaining `window.AIService` references in the codebase.
- **Phase 2.2** (`c7858d3`): Drop unused `window.startSettings` (zero readers anywhere). Keep `window.App` (18 inline `onclick=` handlers in index.html) and `window.SocratinkApp` (17 optional-chained call sites in graph-view.js) — both now have a documented contract above the assignment in app.js explaining what they do and why removing them would silently break production user flows.

Plus two roadmap docs commits (`ba8e4d3`, `025d8b2`) marking each sub-phase complete and correcting a claim in the original Phase 2 audit (`SocratinkApp` is NOT redundant — Gemini-verified that graph-view.js reads it 17 times via optional chaining).

## How it was verified

- 113 Python tests passing across the change set.
- Phase 2.1 reviewed by Gemini after commit (✅ sound): behavior preservation, no missed readers, no load-order risk, cache-busting consistent.
- Phase 2.2 reviewed by Gemini *before* commit (per new "propose → verify → execute" forward policy). Gemini caught that the original audit's "drop SocratinkApp as redundant" recommendation would have silently broken repair-reps, study-completion, and inspect-action flows. Proposal was adjusted accordingly.
- Both deployed cleanly to Vercel preview on dev-fresh.

## Net effect on the roadmap success metric

- Custom `window.*` globals READ by app.js: 1 (`AIService`) → 0
- Custom `window.*` globals SET by app.js: 3 (`App`, `SocratinkApp`, `startSettings`) → 2 (both deliberate, both contracts now)
- Classic `<script>` files in public/js/: 2 (`ai_service.js`, `intro-particles.js`) → 1

## Test plan

- [ ] Sign in (Google or guest) on production after merge
- [ ] Trigger the extract flow (paste source → click extract) — verifies the Phase 2.1 ESM conversion executes end-to-end
- [ ] Open the graph view and trigger an inspect / start-repair-reps / complete-study action — verifies the SocratinkApp bridge still functions
- [ ] Smoke check the bottom-nav inline onclicks (Dashboard / Library / Analytics / Settings) — verifies the App bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)