### PR TITLE
feat: local auth preflight, drawer/library/delete UX fixes, vocabulary glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ bash scripts/dev.sh
 # Direct fallback if you already ran the preflight:
 python scripts/check-local-auth.py
 uvicorn main:app --reload
+
+# Opt out of .env.local on a localhost shell (test the production code path):
+SOCRATINK_DISABLE_DOTENV_LOCAL=1 uvicorn main:app --reload
 ```
 
 ### Tests
@@ -75,6 +78,7 @@ bash scripts/verify-deploy.sh HEAD
 
 ## Big-picture architecture
 - Runtime surface is a single FastAPI app (`main.py`) deployed as a Vercel Python serverless entrypoint via `api/index.py`.
+- Env loading is centralized in `runtime_env.py` (`load_app_env`); precedence is `process env > .env.local > .env`, and `.env.local` is skipped on Vercel/CI or when `SOCRATINK_DISABLE_DOTENV_LOCAL` is set. Auth startup depends on this ordering.
 - `main.py` wires:
   - CORS middleware
   - sensitive static-file blocking middleware

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@ playwright install chromium
 
 ### Run locally
 ```bash
+# Preferred: validates local auth env before starting the login-gated app.
+bash scripts/dev.sh
+
+# Direct fallback if you already ran the preflight:
+python scripts/check-local-auth.py
 uvicorn main:app --reload
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,9 @@ bash scripts/qa-smoke.sh https://custom-url.com       # explicit URL
 bash scripts/qa-smoke.sh                              # local (default)
 ```
 
-Stack: pytest + playwright-python. Suite: `tests/e2e/test_smoke.py` (6 tests, ~10s warm / ~30s cold). Read-only — safe against prod.
+Stack: pytest + playwright-python. Suite: `tests/e2e/test_smoke.py` (9 tests, ~15s warm / ~40s cold). Read-only — safe against prod.
 
-6 checks: `/api/health` shape, homepage critical DOM (`#drawer`, `#bottom-nav`, `#concept-list`, brand mark), guest sessions labeled as guest, zero same-origin console errors on first paint, zero same-origin asset failures, theme-preloader resilient to blank `localStorage`.
+9 checks: `/api/health` shape, homepage critical DOM (`#drawer`, `#bottom-nav`, `#concept-list`, brand mark), guest sessions labeled as guest, drawer toggle stays visible after entering a concept, saved library cards reopen the concept-map view, deleting the active concept confirms then resets to the desk, zero same-origin console errors on first paint, zero same-origin asset failures, theme-preloader resilient to blank `localStorage`.
 
 Run WITHOUT being asked when:
 - After deploy / merge to main / `git push origin main` + any verification framing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Rules:
 - Same-origin failures are real bugs. Cross-origin noise is already filtered — don't allow-list it unless proven third-party.
 - On failure: paste the pytest output verbatim. Trace at `test-results/<test>/trace.zip` (`playwright show-trace ...`).
 - Project doctrine: **local success ≠ hosted validation**. The smoke is the cheapest hosted-validation signal we have.
-- Extension: `authenticated_page` fixture (see `tests/e2e/README.md`) for future flow tests against `selectTile` / `runHeroAction` / `toggleTheme` / `importLibraryConcept`.
+- Extension: `authenticated_page` fixture (see `tests/e2e/README.md`) for non-guest authenticated flows. Still-uncovered critical flows: `selectTile` / `runHeroAction` / `toggleTheme`. (`openLibraryConcept` and active-concept delete are partially covered by tests 5–6 via the guest session.)
 
 Three entry points:
 - `/verify-deploy` (skill) — waits for Vercel to finish then runs smoke. Use after a push to confirm a specific commit is live. Wrapper: `scripts/verify-deploy.sh`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@
 
 ## 1. The product, in one paragraph
 
-**socratink** is a metacognitive learning tool. It teaches by **student generation**: the learner attempts a concept cold, receives targeted study, then re-drills the same concept after a deliberate spacing interval. The interface exists to support that loop and nothing else. There is no content browser, no completion checklist, no streak tracker — the **graph itself is the only profile that exists**, and it changes only when verified understanding is real.
+**socratink** is a metacognitive learning tool. It teaches by **student generation**: the learner attempts a concept cold, receives targeted study, then re-drills the same concept after a deliberate spacing interval. The interface exists to support that loop and nothing else. There is no content browser, no completion checklist, no streak tracker — the **graph itself is the only profile that exists**, and graph truth changes only when learner-generated evidence is recorded.
 
 The product's promise is small, specific, and load-bearing: **see what you can actually explain.**
 
@@ -21,7 +21,7 @@ Every UX decision descends from a single mental model:
 - The **cold attempt** is stepping through the door before you know what's inside.
 - **Targeted study** is the room revealing itself *after* the attempt.
 - The **spaced re-drill** is the room's boss fight.
-- New rooms open only when prerequisite understanding has been proven.
+- Traversal opens from recorded engagement evidence; mastery-gated progression waits for `solidified` evidence.
 
 This metaphor is why the graph reads as **trustable**. A state change has to feel earned, not decorative. The reward layer is not a popup — it is the room itself changing shape.
 
@@ -92,7 +92,7 @@ The graph's vocabulary is small on purpose. Only these phrases appear as graph-s
 | Study completed | repair artifact | stays `primed`; re-drill timer set |
 | Interleaving bridge shown | next-choice set + break | **none** |
 | Repair rep completed | practice history grows | **none** |
-| Spaced re-drill — solid | proof through reconstruction | `primed / drilled → solidified` |
+| Spaced re-drill — solid | solid spaced reconstruction recorded | `primed / drilled → solidified` |
 | Spaced re-drill — non-solid | "worth revisiting" | `primed → drilled` (warm, never red) |
 
 The graph is **the only public profile**. Routing signals, source-dependence scores, causal-depth estimates exist internally — the learner **never sees their own schema label**. No beginner/intermediate/advanced tier, no "your learning style," no curriculum claim.
@@ -107,7 +107,7 @@ The core motif is a **dual-diamond crystal polygon** with a vertical axis. It is
 - **The product wordmark.**
 - **Each tile on the isometric graph board.**
 
-The crystal's appearance *is* the truthful record of understanding. It morphs across five states — `locked` (mauve, dim), `primed` (lavender mid-plane, faint glow), `drilled` (warm, returnable), `solidified` (success-green, crisp facets), `fractured` (subdued danger glow, rare). Color choice for `drilled` is deliberate: **warm and return-worthy, never red, never punitive.** Struggle is honored, not hidden.
+The crystal's appearance *is* the truthful projection of recorded evidence. It morphs across five states — `locked` (mauve, dim), `primed` (lavender mid-plane, faint glow), `drilled` (warm, returnable), `solidified` (success-green, crisp facets), `fractured` (subdued danger glow, rare). Color choice for `drilled` is deliberate: **warm and return-worthy, never red, never punitive.** Struggle is honored, not hidden.
 
 The graph board is **always isometric**, **always cream**. Never flat. Never a force-directed node-and-edge diagram. The isometric view enforces the dungeon-map reading and resists being mistaken for a content browser.
 
@@ -127,7 +127,7 @@ The product has no human teacher to manage attributions in real time. The interf
 - Title Case for section headings only.
 - UPPERCASE with wide tracking only on eyebrow kickers — the lone exception.
 - Plain, complete sentences. Periods, not telegraph style.
-- Verbs over adjectives. The promise shows up as things the learner *does*: "Bring your material. Get a map. Clear rooms."
+- Verbs over adjectives. The promise shows up as things the learner *does*: "Bring your material. Build a map. Record evidence."
 - No exclamation marks. Ever.
 - No emoji. Ever.
 - No hype jargon — *revolutionary, AI-powered, supercharge, 10×, unlock, crush, game-changing.*
@@ -138,13 +138,13 @@ The product has no human teacher to manage attributions in real time. The interf
 | Surface | Tone | Example |
 |---|---|---|
 | Marketing hero | Invitation, not pitch | "See what you can **actually explain.**" |
-| Value strip | Plain declarative | "No fake progress — the map updates only when you actually get it." |
-| How it works | Imperative, low-volume | "Bring your material. Get a map. Clear rooms." |
+| Value strip | Plain declarative | "No fake state changes — the map updates when Socratink records learner-generated evidence." |
+| How it works | Imperative, low-volume | "Bring your material. Build a map. Record evidence." |
 | Drill prompt | Sparse, gap-identifying | "Explain why node B matters in the system." |
 | `primed` state | Quiet acknowledgment | "You've stepped inside. The real challenge is ahead." |
 | `drilled` state | Honored, not punitive | "Worth revisiting. The next gain is here." |
-| `solidified` state | Earned, brief | "Cleared. You proved it." |
-| Session cap | Warm, scientific | "Progress locked in. Your neurons do the rest while you're away." |
+| `solidified` state | Earned, brief | "Solidified. Spaced reconstruction recorded." |
+| Session cap | Warm, scientific | "Evidence recorded. Let spacing do its work while you're away." |
 | Error / non-solid | Strategy, never ability | "The causal link between step 2 and step 3 needs a different angle." |
 
 ### What is forbidden in copy
@@ -163,7 +163,7 @@ The product has no human teacher to manage attributions in real time. The interf
 
 ## 8. The trajectory bands (post-attempt only)
 
-A reflective vocabulary — `spark → link → chain → clear → tetris` — surfaces *only* as post-attempt growth framing, always paired with interpretation: *"Your cold attempt was a spark. Your re-drill hit chain. That jump is real learning."* It is **never a live score** during an attempt. The bands describe trajectory, not standing.
+A reflective vocabulary — `spark → link → chain → clear → tetris` — surfaces *only* as post-attempt growth framing, always paired with interpretation: *"Your cold attempt was a spark. Your re-drill hit chain. Stronger reconstruction evidence is on record."* It is **never a live score** during an attempt. The bands describe trajectory, not standing.
 
 ---
 
@@ -224,10 +224,10 @@ Defer:
 The product is defined as much by what it will not do. The following are hard exclusions, not preferences:
 
 - **No streaks. No XP. No badges. No leaderboards. No achievement popups.** The reward is the crystal state change itself.
-- **No content browser.** The graph is not a library; it is a record of verified understanding.
-- **No completion checklist.** Reading does not advance state. Only generation and verified retrieval do.
+- **No content browser.** The graph is not a library; it is a record of evidence Socratink has seen.
+- **No completion checklist.** Reading does not advance state. Only generation and spaced reconstruction evidence do.
 - **No "diagnostic" framing.** The threshold is a starting map, not an evaluation.
-- **No mastery claims** from graph generation, from reading, or from fluent prose. Only spaced reconstruction proves.
+- **No mastery claims** from graph generation, from reading, or from fluent prose. Only spaced reconstruction can record `solidified`.
 - **No learner-visible schema labels.** The system may infer; the learner never sees a tier.
 - **No punitive surface for struggle.** `drilled` is warm, return-worthy, honored.
 - **No hype.** No exclamation marks, no superlatives, no "AI-powered" boilerplate.
@@ -241,6 +241,6 @@ The product is defined as much by what it will not do. The following are hard ex
 
 ## 12. The one-line summary
 
-> **The graph proposes. The cold attempt creates something to repair. Study makes the repair inspectable. The spaced re-drill is the only proof.**
+> **The graph proposes. The cold attempt creates something to repair. Study makes the repair inspectable. The spaced re-drill records the strongest evidence.**
 
 Every surface in socratink is in service of that sentence. If a screen does not advance one of those four moves, it does not belong in the product.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,6 +2,8 @@
 
 > A capture of the user experience this design system encodes. Not a style sheet — a description of how the product **feels** to use, why each surface behaves the way it does, and what the system refuses to do.
 
+> **Vocabulary.** This document uses the project's ubiquitous language. The authoritative term list — binding definitions for **Graph truth**, **Recorded evidence**, **Reconstruction evidence**, the four learning-loop states, and **Aliases to avoid** — lives in [/UBIQUITOUS_LANGUAGE.md](./UBIQUITOUS_LANGUAGE.md). Copy edits to this file must conform.
+
 ---
 
 ## 1. The product, in one paragraph

--- a/README.md
+++ b/README.md
@@ -28,10 +28,15 @@ The product doctrine is stable even while implementation is still moving:
 ## Local Run
 
 ```bash
-uvicorn main:app --reload
+bash scripts/dev.sh
 ```
 
 Then open [http://localhost:8000](http://localhost:8000).
+
+`scripts/dev.sh` runs `python scripts/check-local-auth.py` before starting
+Uvicorn. That catches the common local failure where `.env` disables auth or
+omits Supabase/session values while `.env.local` has the real development
+configuration.
 
 ## Testing
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,0 +1,64 @@
+# Ubiquitous Language
+
+## Learning Loop
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Evidence-weighted map** | The graph projection of proposed domain structure plus learner-generated evidence Socratink has recorded. | Knowledge map as diagnosis, mastery map |
+| **Draft map** | A newly extracted map with no learner evidence attached. | Diagnosis, understanding map |
+| **Provisional map** | A map shaped by starting-map input but still carrying no graph-truth mutation. | Evaluated map, personalized mastery map |
+| **Cold attempt** | An unscored first generation attempt on a local node before explanatory content appears. | Quiz, test, assessment |
+| **Targeted study** | Attempt-scoped corrective study unlocked by a substantive cold attempt. | Proof, mastery, completion |
+| **Repair Reps** | Optional typed micro-practice for causal bridges that never mutates graph truth. | Drill shortcut, mastery practice |
+| **Spaced re-drill** | A later reconstruction attempt after spacing/interleaving that can record `solidified` if solid. | Review, immediate retry, final test |
+
+## Graph Truth
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Graph truth** | The persisted node-state record of evidence Socratink has seen. | What the learner knows |
+| **`locked`** | No substantive attempt is on record for the node. | Not known, failed |
+| **`primed`** | A substantive cold attempt is on record and study is unlocked. | Learned, partially mastered |
+| **`drilled`** | A spaced reconstruction was attempted and was not solid. | Failed, bad, weak learner |
+| **`solidified`** | At least one solid spaced reconstruction is on record. | Mastered forever, actualized, cleared as knowledge |
+| **Traversal unlock** | Permission to move through the map based on engagement evidence. | Mastery unlock |
+| **Mastery-gated progression** | Progression that requires `solidified` evidence. | Basic branch opening |
+
+## Product Claims
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Recorded evidence** | A machine-checkable event from learner action, such as an attempt or reconstruction result. | Proof of knowledge |
+| **Current model** | The learner's expressed starting point or attempted explanation. | Understanding, ability level |
+| **Routing hint** | Internal signal used to shape the path or prompt emphasis. | Diagnostic label |
+| **Reconstruction evidence** | Evidence from the learner rebuilding a mechanism in their own words. | Real learning, proved it |
+| **Gap** | A missing or incorrect causal bridge in an attempt. | Misconception detected, weakness |
+
+## Relationships
+
+- A **Draft map** can become a **Provisional map** without mutating **Graph truth**.
+- A **Cold attempt** can move a node from **`locked`** to **`primed`** only when substantive.
+- **Targeted study** and **Repair Reps** may help the learner, but neither mutates **Graph truth**.
+- A **Spaced re-drill** is the only event that can move **`primed`** or **`drilled`** to **`solidified`**.
+- A **Traversal unlock** can happen before **`solidified`** when the product is creating interleaving, but **Mastery-gated progression** requires **`solidified`**.
+
+## Example Dialogue
+
+> **Dev:** "Can this screen say the learner mastered the room?"
+>
+> **Domain expert:** "Only if the room is **`solidified`**, and even then say Socratink has a solid spaced reconstruction on record."
+>
+> **Dev:** "What about after study?"
+>
+> **Domain expert:** "That is **Targeted study**. It is a repair opportunity, not **Graph truth**."
+>
+> **Dev:** "So the graph can open the next room after **`primed`**?"
+>
+> **Domain expert:** "Yes, as a **Traversal unlock** for interleaving. Do not call it mastery."
+
+## Flagged Ambiguities
+
+- "Mastery" is overloaded between product shorthand and evidence claims. Prefer **`solidified`** or "solid spaced reconstruction on record" when referring to a node.
+- "Cleared" can work as visual shorthand, but it must not imply knowledge. Prefer **`solidified`** in product copy unless a local UI spec explicitly frames "cleared" as display shorthand.
+- "Actualized" and "hibernating" are legacy concept-shell terms. The live learning-state language is **`locked`**, **`primed`**, **`drilled`**, and **`solidified`**.
+- "Diagnostic" implies Socratink knows the learner's mind. Prefer **Routing hint** or **Starting-map anchor**.

--- a/auth/service.py
+++ b/auth/service.py
@@ -136,7 +136,14 @@ class SupabaseAuthService:
     def _require_enabled(self) -> None:
         if not self.enabled:
             raise AuthConfigurationError("Auth is disabled.")
-        missing = [
+        missing = self.missing_required_settings()
+        if missing:
+            raise AuthConfigurationError(
+                f"Auth is enabled but missing: {', '.join(missing)}"
+            )
+
+    def missing_required_settings(self) -> list[str]:
+        return [
             name
             for name, value in [
                 ("SUPABASE_URL", self.supabase_url),
@@ -147,10 +154,6 @@ class SupabaseAuthService:
             ]
             if not value
         ]
-        if missing:
-            raise AuthConfigurationError(
-                f"Auth is enabled but missing: {', '.join(missing)}"
-            )
 
     def build_oauth_state(self, *, return_to: str) -> tuple[str, str, str]:
         """Build (verifier, challenge, signed_state_cookie) for /auth/google.

--- a/docs/design/brand-reference.md
+++ b/docs/design/brand-reference.md
@@ -1,6 +1,6 @@
 # socratink Design System
 
-> **socratink.ai** — a metacognitive learning tool that increases signal, reduces cognitive load, and enhances real learning derived from **student generation**. The product strengthens active recall and mitigates the illusion of understanding that comes from mere familiarity.
+> **socratink.ai** — a metacognitive learning tool that increases signal, reduces cognitive load, and records reconstruction evidence derived from **student generation**. The product strengthens active recall and mitigates the illusion of understanding that comes from mere familiarity.
 
 This design system is the binding contract for how socratink looks, sounds, and moves. It is rooted in the product's single unifying principle: **metacognitive UX** — every surface is designed for the learner's awareness of their own cognitive process, not just the content. The aesthetic mirrors the work the product asks of its learners: **quiet, scholarly, crystalline.**
 
@@ -25,7 +25,7 @@ Assume the reader of this file does **not** have access to the above. If that as
 
 socratink is (today) a single product surface with two faces:
 
-1. **The app** (`app.socratink.ai`) — a React SPA. A sidebar of concepts, an isometric **grid board** of tiles, and on each tile a **crystal polygon** whose visual state (instantiated → growing → hibernating → fractured → actualized) is a **truthful record of verified understanding**. A drill chat panel drives the three-phase loop: **cold attempt → targeted study → spaced re-drill**. See `ui_kits/app/`.
+1. **The app** (`app.socratink.ai`) — a vanilla JS/FastAPI product surface. A sidebar of concepts, an isometric **grid board** of tiles, and concept-shell visuals project recorded evidence while node drill status remains the graph-truth layer: `locked → primed → drilled → solidified`. A drill chat panel drives the three-phase loop: **cold attempt → targeted study → spaced re-drill**.
 
 2. **The marketing site** (`socratink.ai`) — a React landing page introducing the thesis, the loop, and the FAQ. Quiet type, cream page, violet accent. See `ui_kits/website/`.
 
@@ -33,7 +33,7 @@ Both surfaces share a single token set (`colors_and_type.css`).
 
 ### The product's unifying metaphor
 
-The graph behaves like a **dungeon map**. Every node is a **room**. The cold attempt is stepping through the door before you know what's inside. Targeted study is the room revealing itself *after* the attempt. The spaced re-drill is the room's boss fight. New rooms open only when prerequisite understanding is real. The **graph tells the truth** — it is not a content browser or a completion checklist.
+The graph behaves like a **dungeon map**. Every node is a **room**. The cold attempt is stepping through the door before you know what's inside. Targeted study is the room revealing itself *after* the attempt. The spaced re-drill is the room's boss fight. Traversal opens from recorded engagement evidence; mastery-gated progression waits for `solidified` evidence. The **graph tells the truth** — it is not a content browser or a completion checklist.
 
 ### What the visual language has to carry
 
@@ -53,9 +53,9 @@ This is the binding narrative for **how the learner is onboarded into a concept*
 > The graph **proposes** where to look.
 > The cold attempt **creates something to repair.**
 > The study view makes the repair **inspectable.**
-> The spaced re-drill is **the only proof.**
+> The spaced re-drill records **the strongest evidence.**
 
-A concept page is not where the learner goes to read. It is where **their understanding becomes inspectable.** socratink asks for the learner's **starting map** before showing explanatory content. That starting map shapes routing and repair — it must never create mastery claims.
+A concept page is not where the learner goes to read. It is where **their current model becomes inspectable.** socratink asks for the learner's **starting map** before showing explanatory content. That starting map shapes routing and repair — it must never create mastery claims.
 
 ### Friction fixes the flow must avoid
 
@@ -177,7 +177,7 @@ The product has **no human teacher** to manage attributions in real time. The in
 - **Second person, singular.** Copy talks to *you*. "You own the content." "You reconstruct from memory." The product rarely says "we." When it does, it's meta ("we ask you to build yours").
 - **Lowercase product name.** `socratink` — even at the start of sentences. The wordmark is lowercase too.
 - **Plain, complete sentences.** No telegraph style. Periods. Short paragraphs. The sentence "The floor dropped out." is the maximum drama the brand gets.
-- **Verbs over adjectives.** "Bring your material." "Get a map." "Clear rooms." The product's promise shows up as things the learner *does*, never as things the product *is*.
+- **Verbs over adjectives.** "Bring your material." "Build a map." "Record evidence." The product's promise shows up as things the learner *does*, never as things the product *is*.
 - **Zero jargon that signals hype.** No "revolutionary," "AI-powered," "supercharge," "10×," "unlock your potential," "crush your goals." No exclamation marks. No emoji in product copy. Ever.
 - **Admit the state of the product honestly.** The live site reads: *"Still testing. Still learning. socratink is in active development."* That kind of line is load-bearing brand, not filler.
 
@@ -186,13 +186,13 @@ The product has **no human teacher** to manage attributions in real time. The in
 | Surface | Tone | Example |
 |---|---|---|
 | Marketing hero | Invitation, not pitch | "See what you can **actually explain.**" |
-| Value strip | Plain declarative | "No fake progress — the map updates only when you actually get it." |
-| How it works | Imperative, low-volume | "Bring your material. Get a map. Clear rooms." |
+| Value strip | Plain declarative | "No fake state changes — the map updates when Socratink records learner-generated evidence." |
+| How it works | Imperative, low-volume | "Bring your material. Build a map. Record evidence." |
 | Drill prompt (AI) | Sparse, gap-identifying | "Explain why node B matters in the system." |
 | `primed` state copy | Quiet acknowledgment | "You've stepped inside. The real challenge is ahead." |
 | `drilled` state copy | Honored, not punitive | "Worth revisiting. The next gain is here." |
-| `solidified` state copy | Earned, brief | "Cleared. You proved it." |
-| Session cap / break | Warm, scientific, transparent | "Progress locked in. Your neurons do the rest while you're away." |
+| `solidified` state copy | Earned, brief | "Solidified. Spaced reconstruction recorded." |
+| Session cap / break | Warm, scientific, transparent | "Evidence recorded. Let spacing do its work while you're away." |
 | Error / non-solid | Strategy, never ability | "The causal link between step 2 and step 3 needs a different angle." |
 
 ### Casing
@@ -211,7 +211,7 @@ The product has **no human teacher** to manage attributions in real time. The in
 
 ### Trajectory vocabulary (internal only, shown as bands after the attempt)
 
-The tier system `spark → link → chain → clear → tetris` is the product's **prediction-contrast** surface. It is shown only as *post-attempt* reflection on growth, always paired with interpretive framing ("Your cold attempt was a spark. Your re-drill hit chain. That jump is real learning."). Never a live score.
+The tier system `spark → link → chain → clear → tetris` is the product's **prediction-contrast** surface. It is shown only as *post-attempt* reflection on growth, always paired with interpretive framing ("Your cold attempt was a spark. Your re-drill hit chain. Stronger reconstruction evidence is on record."). Never a live score.
 
 ---
 
@@ -225,11 +225,11 @@ Warm-muted jewel tones on a cream-paper page. Five primitives, plus two reserved
 |---|---|---|---|
 | Ink | `--ink-900` | `#242038` | All text, deep shadows, crystal lower edges. Treat as near-black; never use true black. |
 | Primary | `--violet-600` | `#9067C6` | Accent strokes, active states, most interactive hover glow. The "crystalline" warm violet. |
-| Secondary | `--lavender-500` | `#8D86C9` | Kicker text, dust on surfaces, crystal mid-planes, locked/hibernating state. |
+| Secondary | `--lavender-500` | `#8D86C9` | Kicker text, dust on surfaces, crystal mid-planes, locked and legacy spacing shell states. |
 | Neutral | `--mauve-200` | `#CAC4CE` | Locked tiles, empty-tile dashes, inactive chips. Calm, never sad. |
 | Page | `--cream-50` | `#F7ECE1` | Every page background. **Never pure white** in the light theme. |
 | White | `--white` | `#FFFFFF` | Raised card faces only; never a page. |
-| Success | `--success` | `#4DBA8A` | `solidified` / actualized state. Single celebrant color. |
+| Success | `--success` | `#4DBA8A` | `solidified` state. Single celebrant color. |
 | Danger | `--danger` | `#E05C6B` | Reserved. Used only on `fractured` crystal glow — rarely, and muted. |
 
 The palette explicitly **excludes**: neon purples, pure white pages, clinical SaaS blues, gradient-bluish-to-purple hero washes, gold trim.

--- a/docs/design/colors_and_type.css
+++ b/docs/design/colors_and_type.css
@@ -83,7 +83,7 @@
   --white-rgb:        255, 255, 255;
 
   /* product-specific semantics */
-  --success:        #4dba8a;   /* solidified / actualized state */
+  --success:        #4dba8a;   /* solidified evidence state */
   --danger:         #e05c6b;   /* fractured state — only for non-solid */
   --pill-success-text: #397a59;
   --pill-danger-text:  #bf4f68;
@@ -190,7 +190,7 @@
   --crystal-fractured-specular:    rgba(var(--cream-50-rgb), 0.78);
   --crystal-fractured-glow:        rgba(224, 92, 107, 0.18);
 
-  /* hibernating = parked for spaced return */
+  /* legacy spacing shell state */
   --crystal-hibernating-top:         rgba(var(--lavender-500-rgb), 0.72);
   --crystal-hibernating-upper-left:  rgba(var(--violet-600-rgb),   0.58);
   --crystal-hibernating-upper-right: rgba(var(--ink-900-rgb),      0.92);
@@ -200,7 +200,7 @@
   --crystal-hibernating-specular:    rgba(var(--cream-50-rgb),     0.70);
   --crystal-hibernating-glow:        rgba(var(--lavender-500-rgb), 0.30);
 
-  /* actualized = solidified, verified understanding */
+  /* legacy actualized shell state; prefer solidified evidence language */
   --crystal-actualized-top:         rgba(var(--cream-50-rgb), 0.98);
   --crystal-actualized-upper-left:  rgba(var(--lavender-500-rgb), 0.86);
   --crystal-actualized-upper-right: rgba(var(--violet-600-rgb),   0.88);

--- a/docs/design/socratink-design-system.md
+++ b/docs/design/socratink-design-system.md
@@ -133,7 +133,7 @@ Calm, precise, Socratic. Reading room, not dashboard.
 - **Strategy over ability.** Errors describe the missing link ("The causal connection between step 2 and step 3 needs a different angle"), never the learner ("You got it wrong").
 - **No streaks, no XP, no badges, no leaderboards.** The reward is the crystal state change itself.
 - **Admit the product's honest state.** Lines like "Still testing. Still learning." are load-bearing brand.
-- **Imperative + verb-led marketing copy.** "Bring your material. Get a map. Clear rooms."
+- **Imperative + verb-led marketing copy.** "Bring your material. Build a map. Record evidence."
 
 Casing: lowercase for product name and state tokens (`primed`, `drilled`, `solidified`); Title Case for section headings; UPPERCASE with `--tracking-kicker` only on eyebrow labels.
 

--- a/docs/product/ux-framework.md
+++ b/docs/product/ux-framework.md
@@ -408,7 +408,7 @@ Applied: "This concept is designed to be challenging. We know you can master it.
 
 The tier/band system (`spark → link → chain → clear → tetris`) serves as the trajectory contrast mechanism.
 
-Showing the learner their own improvement — "Your cold attempt was a spark. Your re-drill hit chain. That jump is real learning." — motivates through visible growth AND calibrates metacognitive accuracy.
+Showing the learner their own improvement — "Your cold attempt was a spark. Your re-drill hit chain. Stronger reconstruction evidence is on record." — motivates through visible growth AND calibrates metacognitive accuracy.
 
 Learners systematically undervalue pretesting even after experiencing better outcomes (Pan & Rivers 2023). The only intervention that updated their beliefs was explicit prediction-contrast.
 
@@ -508,9 +508,9 @@ The graph's visual state changes *are* the primary reward mechanism.
 
 ### Endowed Progress Through Truthful Prerequisites
 
-When a learner enters a new cluster or branch, the graph should visually connect and illuminate prerequisite nodes they have already legitimately mastered from earlier work. Frame the new territory as a partially completed structure: "You already possess the foundational mechanisms for this area."
+When a learner enters a new cluster or branch, the graph should visually connect and illuminate prerequisite nodes that already carry `solidified` records from earlier work. Frame the new territory as a partially completed structure: "Socratink already has solid reconstruction evidence for the foundational mechanisms in this area."
 
-This triggers the endowed progress effect (Nunes & Dreze 2006: 34% vs 19% completion) without faking mastery. The 10-25% initial progress sweet spot applies — over-endowment undermines the effect because the effort feels unearned. The advancement must reflect real, previously verified understanding.
+This triggers the endowed progress effect (Nunes & Dreze 2006: 34% vs 19% completion) without faking mastery. The 10-25% initial progress sweet spot applies — over-endowment undermines the effect because the effort feels unearned. The advancement must reflect previously recorded solid spaced reconstructions.
 
 ### Streaks, Badges, and Points
 
@@ -534,14 +534,14 @@ No streaks in MVP. If ever implemented, only as **spaced session streaks** — r
 
 - As progress indicators (not currency) can work. (Mekler et al. 2017.)
 - Never purchasable, tradeable, or gating.
-- Represent verified understanding, not activity volume.
+- Represent solid spaced reconstructions recorded, not activity volume.
 - Variable/surprise point bonuses may be applied to engagement behaviors (returning to the app, completing a spaced session) but never to accuracy — variable reinforcement on accuracy distorts metacognitive calibration and undermines the learner's ability to judge what they actually know.
 
 ### Trajectory Contrast
 
 The `spark → link → chain → clear → tetris` progression serves as the primary metacognitive and motivational mechanism.
 
-- Show trajectory, not score: "Your cold attempt was a spark. Your re-drill hit chain. That jump is real learning."
+- Show trajectory, not score: "Your cold attempt was a spark. Your re-drill hit chain. Stronger reconstruction evidence is on record."
 - Never show during the attempt. Show as post-attempt reflection on growth.
 - Always pair with interpretive framing. Raw analytics without meaning frames show null or negative effects.
 - Temporal self-comparison raises pride and calibrates metacognitive accuracy. (Chiviacowsky et al. 2018; Butler, Karpicke & Roediger 2008.)
@@ -554,7 +554,7 @@ The study view does not unlock until the cold attempt is complete. AI must not r
 
 ### 2. One Active Cognitive Target
 
-At any moment, the learner should know what they are working on, where it sits, what phase it is in, and whether it is primed, drilled, or cleared. No silent target switching. No mode bleed. The interleaving rhythm must feel guided — if the learner loses orientation, the interface has failed.
+At any moment, the learner should know what they are working on, where it sits, what phase it is in, and whether it is primed, drilled, or solidified. No silent target switching. No mode bleed. The interleaving rhythm must feel guided — if the learner loses orientation, the interface has failed.
 
 ### 3. The Graph Must Tell The Truth
 

--- a/docs/product/ux-framework.md
+++ b/docs/product/ux-framework.md
@@ -462,7 +462,7 @@ Three successful retrievals per node per session. Beyond three, halt and schedul
 
 ### Session Ending: Leave Them Hungry
 
-End sessions at a point of engagement, not exhaustion. Use absolute limits (less reactance than flexible). Explain the science transparently. Frame warmly: "Progress locked in. Your neurons do the rest while you're away." Never end on a failure state.
+End sessions at a point of engagement, not exhaustion. Use absolute limits (less reactance than flexible). Explain the science transparently. Frame warmly: "Evidence recorded. Let spacing do its work while you're away." Never end on a failure state.
 
 This triggers episodic anticipation — stopping the learner while their dopaminergic "wanting" system is still active. The learner leaves with unresolved nodes visible (Ovsiankina resumption drive), clear progress data (competence satisfaction), and a physiological drive to return. Over time, they recognize the cap serves their mastery goal, supporting long-term autonomy. The instruction to "come back tomorrow" becomes a scientifically validated prescription, not a restriction.
 
@@ -568,7 +568,7 @@ Selective visual and sensory change on `solidified`, calibrated to cognitive loa
 
 - `primed`: "You've stepped inside. The real challenge is ahead."
 - `drilled`: "Worth revisiting. The next gain is here."
-- `solidified`: "Cleared. You proved it."
+- `solidified`: "Solidified. Spaced reconstruction recorded."
 
 The Ovsiankina effect makes incomplete nodes a natural return driver.
 

--- a/docs/project/auth-rollout.md
+++ b/docs/project/auth-rollout.md
@@ -74,6 +74,10 @@ Release gate:
 
 ## Test Plan
 
+Local readiness:
+
+- `bash scripts/dev.sh` (wraps `python scripts/check-local-auth.py`) validates Supabase + session env on localhost before starting Uvicorn, catching `.env` vs `.env.local` misconfiguration that breaks the Phase 0 release gate.
+
 Automate first:
 
 - auth router behavior

--- a/docs/project/auth-rollout.md
+++ b/docs/project/auth-rollout.md
@@ -77,6 +77,7 @@ Release gate:
 Local readiness:
 
 - `bash scripts/dev.sh` (wraps `python scripts/check-local-auth.py`) validates Supabase + session env on localhost before starting Uvicorn, catching `.env` vs `.env.local` misconfiguration that breaks the Phase 0 release gate.
+- `python scripts/check-local-auth.py --probe-guest` additionally calls `sign_in_anonymously()` against the configured Supabase project, proving the anon key actually works end-to-end — the strongest local check for the Phase 0 guest-session path.
 
 Automate first:
 

--- a/docs/project/doc-map.md
+++ b/docs/project/doc-map.md
@@ -27,6 +27,7 @@ On all other topics (three-phase loop, four-state model implementation, routing,
 
 | Doc | Status | Binding | Purpose | Superseded By |
 | --- | --- | --- | --- | --- |
+| [/UBIQUITOUS_LANGUAGE.md](../../UBIQUITOUS_LANGUAGE.md) | canonical | yes | Project-wide DDD glossary: binding terms (Graph truth, Recorded evidence, Reconstruction evidence, the four learning-loop states) and explicit Aliases to avoid. Authoritative term list referenced by the Precedence block above. | — |
 | [product/evidence-weighted-map.md](../product/evidence-weighted-map.md) | canonical | yes | Defines the evidence-weighted map doctrine, true game loop, starting-map-as-anchor, map-maturity language, and graph-claim rules. Overrides other docs on graph-truth claims. | — |
 | [product/spec.md](../product/spec.md) | canonical | yes | Binding product contract: three-phase loop, four-state model, panel modes, traversal, guardrails, evaluation checklist. | — |
 | [product/ux-framework.md](../product/ux-framework.md) | canonical | yes | Metacognitive UX philosophy, reward/sensory rules, attribution management, session guardrails, ethical engagement boundary. | — |

--- a/docs/project/mvp-happy-path.md
+++ b/docs/project/mvp-happy-path.md
@@ -33,8 +33,10 @@ For this branch, a workable MVP means a freshly created concept with a clear cau
 Run:
 
 ```bash
-uvicorn main:app --reload
+bash scripts/dev.sh
 ```
+
+`scripts/dev.sh` runs the local-auth preflight (`scripts/check-local-auth.py`) before starting Uvicorn, catching the common `.env` vs `.env.local` Supabase/session misconfiguration that would otherwise break guest sign-in mid-smoke.
 
 Open:
 

--- a/docs/superpowers/plans/2026-04-28-pipette.md
+++ b/docs/superpowers/plans/2026-04-28-pipette.md
@@ -60,6 +60,12 @@ Verified at `dd90e50` on `dev-fresh`. The plan accommodates the gaps below.
 
 **Open dependency:** The repo has no `pyproject.toml` or `requirements-dev.txt` — Python deps live in pyenv user site. Plan adds a tiny `tools/pipette/requirements.txt` (Task **B1.b**) so the package's deps are explicit and `pipette doctor` can `pip install -r` them on a fresh clone.
 
+> **Resolution (post-merge, 2026-04-29):** A root `requirements-dev.txt` now
+> exists, and `pydantic>=2.0` / `pyyaml>=6.0` were folded into it. The
+> per-package `tools/pipette/requirements.txt` was deleted; install pipette's
+> dev deps via `pip install -r requirements-dev.txt`. Task **B1** below is
+> retained as historical record of the original plan.
+
 ---
 
 ## 2. §9 open questions — resolved

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from urllib.request import Request as UrlRequest, urlopen
 
 from html import unescape
 
-from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -33,8 +32,9 @@ from ai_service import (
     generate_repair_reps,
     get_drill_session_time_limit_seconds,
 )
+from runtime_env import load_app_env
 
-load_dotenv()
+load_app_env()
 
 app = FastAPI()
 app.state.auth_service = build_auth_service_from_env()

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -164,6 +164,7 @@ button:disabled { background-color:var(--locked); cursor:not-allowed; transform:
 }
 
 .drawer-toggle {
+  display:inline-flex; align-items:center; justify-content:center;
   background:none; border:none; cursor:pointer;
   padding:9px; border-radius:8px; color:var(--text-sub);
   line-height:1; flex:none;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -74,10 +74,10 @@ body[data-map-open="true"] .auth-controls,
 body[data-map-open="true"] .dev-skip {
   display: none !important;
 }
-/* Map-view chrome — single back control (UX-todo #10). In map view,
-   hide the ambiguous < drawer-toggle and redundant × close-btn; show
-   the explicit "← Dashboard" text link instead. */
-body[data-map-open="true"] .drawer-toggle,
+/* Map-view chrome keeps the app shell drawer toggle available. */
+body[data-map-open="true"] .drawer-toggle {
+  display: inline-flex !important;
+}
 body[data-map-open="true"] .map-close-btn {
   display: none !important;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="styles.css?v=69">
+  <link rel="stylesheet" href="styles.css?v=70">
 </head>
 
 <body>
@@ -386,7 +386,7 @@
 
   <div id="tooltip-root" aria-hidden="true"></div>
 
-  <script type="module" src="js/app.js?v=48"></script>
+  <script type="module" src="js/app.js?v=50"></script>
   <script src="js/intro-particles.js?v=3"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>
   <script type="module" src="js/feedback.js?v=1"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -616,7 +616,7 @@ const App = (() => {
           </svg>
         </button>`;
       item.addEventListener('click', e => {
-        if (e.target.classList.contains('concept-delete')) return;
+        if (e.target instanceof Element && e.target.closest('.concept-delete')) return;
         showDashboard();
         selectConcept(c.id);
         if (c.graphData) showMapView(c);
@@ -1574,21 +1574,48 @@ const App = (() => {
   }
 
   function deleteConcept(id, btnEl) {
-    const item = btnEl.closest('.concept-item');
+    const concept = loadConcepts().find(c => c.id === id);
+    if (!concept) return;
+
+    const conceptName = concept.name || 'this concept';
+    const confirmed = window.confirm(`Delete "${conceptName}"?\n\nThis removes its draft path and recorded evidence from this browser.`);
+    if (!confirmed) return;
+
+    const wasActive = getActiveId() === id;
+    const item = btnEl?.closest?.('.concept-item');
     if (item) { item.style.transition = 'all 0.2s ease'; item.style.opacity = '0'; item.style.transform = 'translateX(-12px)'; }
 
-    setTimeout(() => {
+    const finishDelete = () => {
       const concepts = loadConcepts().filter(c => c.id !== id);
       saveConcepts(concepts);
       clearRepairRepsStateForConcept(id);
 
-      if (getActiveId() === id) {
-        if (concepts.length > 0) { selectConcept(concepts[0].id); }
-        else { setActiveId(null); showEmptyState(); }
+      try {
+        sessionStorage.removeItem(getPhaseBSessionStorageKey(id));
+      } catch (err) {
+        console.warn('Unable to clear deleted concept session state.', err);
       }
-      renderGrid();
-      renderConceptList();
-    }, 200);
+
+      const resumeState = loadPhaseBResumeState();
+      if (resumeState?.conceptId === id) {
+        persistPhaseBResumeState(null);
+      }
+
+      if (wasActive) {
+        setActiveId(null);
+        sessionState = getDefaultPhaseBSessionState();
+        showDashboard();
+        showEmptyState();
+      }
+      renderGrid(concepts);
+      renderConceptList(concepts);
+    };
+
+    if (item) {
+      setTimeout(finishDelete, 200);
+    } else {
+      finishDelete();
+    }
   }
 
   function selectTile(tileIdx) {
@@ -2321,7 +2348,7 @@ const App = (() => {
       html += `<div class="library-vault-grid">` + concepts.map(c => {
         const meta = getLibraryConceptMeta(c);
         return `
-          <div class="library-card library-card-vault" style="cursor:pointer;" onclick="App.selectConcept('${c.id}'); App.hideLibrary();">
+          <div class="library-card library-card-vault" style="cursor:pointer;" onclick="App.openLibraryConcept('${c.id}')">
             <div class="library-card-header">
               <div>
                 <div class="library-card-kicker">${escHtml(meta.sourceLabel)}</div>
@@ -2351,6 +2378,19 @@ const App = (() => {
   function hideLibrary() {
     const libraryView = document.getElementById('library-view');
     if (libraryView) libraryView.classList.remove('visible');
+  }
+
+  function openLibraryConcept(id) {
+    const concept = activateConceptSelection(id);
+    if (!concept) return;
+    hideLibrary();
+    setNavActive('nav-dashboard');
+    if (concept.graphData) {
+      showMapView(concept);
+      setMapMode('graph');
+    } else {
+      showDashboard();
+    }
   }
 
   function toggleCluster(el) {
@@ -4014,7 +4054,7 @@ const App = (() => {
     extract, drill, drillFail, drillPass, consolidate,
     fastForward,
     hideMapView, setMapMode, toggleCluster,
-    showLibrary, hideLibrary, showDashboard, showSettings,
+    showLibrary, hideLibrary, openLibraryConcept, showDashboard, showSettings,
     importLibraryConcept,
     toggleTheme, runHeroAction
   };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3462,8 +3462,8 @@ const App = (() => {
     const nodeData = resolveNodeData(km, nodeContext.id) || {};
     if (nodeData.drill_status === 'solidified') {
       currentGraphController?.showBlockedMessage?.(
-        'Node already cleared',
-        'This room is already solidified. Pick an unresolved node to keep the graph truthful.'
+        'Solid evidence already recorded',
+        'This room already has a solid spaced reconstruction on record. Pick a node without that record to keep the graph truthful.'
       );
       return;
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,5 +1,5 @@
 @import url('./css/variables.css?v=15');
-@import url('./css/base.css?v=15');
+@import url('./css/base.css?v=16');
 @import url('./css/crystal.css?v=12');
 @import url('./css/components.css?v=50');
-@import url('./css/layout.css?v=28');
+@import url('./css/layout.css?v=29');

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,7 @@ playwright>=1.45.0
 
 # /api/health probing in test_smoke.py
 requests>=2.31.0
+
+# tools/pipette internal dev tooling (cli, subagent_stop, e2e harness)
+pydantic>=2.0
+pyyaml>=6.0

--- a/runtime_env.py
+++ b/runtime_env.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import dotenv_values, load_dotenv
+
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class EnvLoadReport:
+    """Safe-to-log summary of app env loading.
+
+    Precedence is intentionally:
+    process env > .env.local > .env
+
+    That keeps deployed/server-provided secrets authoritative while allowing
+    ignored local overrides to replace template values from .env.
+    """
+
+    loaded_files: tuple[str, ...]
+    skipped_local_reason: str | None = None
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _should_load_dotenv_local() -> tuple[bool, str | None]:
+    if _truthy_env("SOCRATINK_DISABLE_DOTENV_LOCAL"):
+        return False, "SOCRATINK_DISABLE_DOTENV_LOCAL is set"
+    if _truthy_env("VERCEL") or os.getenv("VERCEL_ENV"):
+        return False, "Vercel runtime env detected"
+    if _truthy_env("CI"):
+        return False, "CI runtime env detected"
+    return True, None
+
+
+def _apply_dotenv_local(path: Path, *, protected_keys: set[str]) -> bool:
+    values = dotenv_values(path)
+    applied = False
+    for key, value in values.items():
+        if not key or value is None:
+            continue
+        if key in protected_keys:
+            continue
+        os.environ[key] = value
+        applied = True
+    return applied
+
+
+def load_app_env(root: str | Path | None = None) -> EnvLoadReport:
+    """Load the app's dotenv files with production-safe local precedence.
+
+    python-dotenv's plain override modes are not quite right for this app:
+    `.env.local` must beat checked-in/template `.env` values on localhost, but
+    a real process env var from Vercel, CI, or a developer's shell must still
+    win. This helper preserves that ordering and is tested because auth startup
+    depends on it.
+    """
+
+    repo_root = Path(root) if root is not None else Path(__file__).resolve().parent
+    protected_keys = set(os.environ)
+    loaded: list[str] = []
+
+    env_path = repo_root / ".env"
+    if env_path.exists():
+        load_dotenv(env_path, override=False)
+        loaded.append(".env")
+
+    local_path = repo_root / ".env.local"
+    should_load_local, skip_reason = _should_load_dotenv_local()
+    if not local_path.exists():
+        skip_reason = ".env.local not found"
+    elif should_load_local:
+        if _apply_dotenv_local(local_path, protected_keys=protected_keys):
+            loaded.append(".env.local")
+        skip_reason = None
+
+    return EnvLoadReport(
+        loaded_files=tuple(loaded),
+        skipped_local_reason=skip_reason,
+    )

--- a/scripts/check-local-auth.py
+++ b/scripts/check-local-auth.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from auth.service import AuthConfigurationError, build_auth_service_from_env
+from runtime_env import load_app_env
+
+
+def _is_local_app_base_url(value: str | None, *, port: str) -> bool:
+    if value is None:
+        return False
+    normalized = value.rstrip("/")
+    return normalized in {
+        f"http://localhost:{port}",
+        f"http://127.0.0.1:{port}",
+    }
+
+
+def _status_line(name: str, present: bool) -> str:
+    return f"  {name}: {'present' if present else 'missing'}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate localhost auth config without printing secrets."
+    )
+    parser.add_argument(
+        "--probe-guest",
+        action="store_true",
+        help="Also call Supabase anonymous sign-in to prove guest login works.",
+    )
+    parser.add_argument(
+        "--port",
+        default=os.getenv("PORT", "8000"),
+        help="Local server port expected in APP_BASE_URL.",
+    )
+    args = parser.parse_args(argv)
+
+    report = load_app_env(REPO_ROOT)
+    service = build_auth_service_from_env()
+    missing = service.missing_required_settings()
+    issues: list[str] = []
+
+    print("Local auth preflight")
+    print("Loaded env files: " + (", ".join(report.loaded_files) or "none"))
+    if report.skipped_local_reason:
+        print("Skipped .env.local: " + report.skipped_local_reason)
+    print(f"AUTH_ENABLED: {str(service.enabled).lower()}")
+    for name, present in [
+        ("SUPABASE_URL", bool(service.supabase_url)),
+        ("SUPABASE_PUBLISHABLE_KEY", bool(service.publishable_key)),
+        ("SUPABASE_JWT_SECRET", bool(service.jwt_secret)),
+        ("SESSION_COOKIE_KEY", bool(service.session_cookie_key)),
+        ("APP_BASE_URL", bool(service.app_base_url)),
+    ]:
+        print(_status_line(name, present))
+
+    if not service.enabled:
+        issues.append("AUTH_ENABLED must be true for the localhost login wall.")
+    if missing:
+        issues.append("Missing required auth settings: " + ", ".join(missing))
+    if service.app_base_url and not _is_local_app_base_url(
+        service.app_base_url, port=args.port
+    ):
+        issues.append(
+            f"APP_BASE_URL should be http://localhost:{args.port} for this local server."
+        )
+
+    if issues:
+        print("\nFAIL")
+        for issue in issues:
+            print(f"- {issue}")
+        print("\nFix .env or .env.local, then restart uvicorn.")
+        return 1
+
+    try:
+        callback_uri = service.callback_redirect_uri()
+    except AuthConfigurationError as err:
+        print("\nFAIL")
+        print(f"- {err}")
+        return 1
+
+    print(f"Callback URI: {callback_uri}")
+
+    if args.probe_guest:
+        try:
+            state = service.sign_in_anonymously()
+        except Exception as err:
+            print("\nFAIL")
+            print(f"- Guest sign-in probe failed: {type(err).__name__}")
+            return 1
+        if not (state.authenticated and state.guest_mode and state.sealed_session):
+            print("\nFAIL")
+            print("- Guest sign-in did not return an anonymous session.")
+            return 1
+        print("Guest sign-in probe: ok")
+
+    print("\nOK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+python scripts/check-local-auth.py --port "${PORT:-8000}"
+exec uvicorn main:app --reload --port "${PORT:-8000}"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -131,8 +131,9 @@ def authenticated_page(browser: Browser, storage_state: Path) -> Page:
 ```
 
 Then a sibling `tests/e2e/test_critical_flows.py` can use
-`authenticated_page` and exercise the four critical flows without paying the
-login tax in every test.
+`authenticated_page` and exercise the still-uncovered critical flows
+(`selectTile`, `runHeroAction`, `toggleTheme`) without paying the login tax
+in every test.
 
 ## Why this stack
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -6,7 +6,7 @@ one shell command, against local dev / Vercel preview / production.
 
 ## What's covered
 
-6 tests, runtime ~10s warm + ~30s cold, in source order:
+9 tests, runtime ~15s warm + ~40s cold, in source order:
 
 1. **`test_health_endpoint_ok`** — backend reachable, `/api/health` shape valid.
    Runs first to absorb serverless cold-start latency.
@@ -14,17 +14,28 @@ one shell command, against local dev / Vercel preview / production.
    `#concept-list`, `.sidebar-brand-mark` all attached after navigation.
 3. **`test_guest_session_is_labeled_as_guest`** — anonymous Supabase sessions
    render as guest, not as signed-in users.
-4. **`test_no_console_errors_on_first_paint`** — zero same-origin
+4. **`test_drawer_toggle_remains_visible_in_concept_view`** — sidebar toggle
+   stays available after opening a library concept (regression gate for the
+   drawer-toggle visibility fix).
+5. **`test_saved_library_concept_reopens_map_view`** — library cards reopen
+   the concept-map view, not a stale shell, on the second click (regression
+   gate for the library reopen fix).
+6. **`test_active_concept_delete_confirms_then_returns_to_desk`** — deleting
+   the open concept confirms via dialog and resets the workspace to the desk
+   (regression gate for the active-concept delete flow).
+7. **`test_no_console_errors_on_first_paint`** — zero same-origin
    `console.error` during first paint.
-5. **`test_no_failed_critical_asset_requests`** — zero same-origin
+8. **`test_no_failed_critical_asset_requests`** — zero same-origin
    `requestfailed` events during first paint.
-6. **`test_theme_preloader_resilient_on_blank_localstorage`** — inline IIFE
+9. **`test_theme_preloader_resilient_on_blank_localstorage`** — inline IIFE
    at top of `<body>` produces no errors on a fresh visit.
 
 What's deliberately out of scope:
-- Authenticated flows (extension point: `authenticated_page` fixture)
-- Critical-flow exercise (`selectTile`, `runHeroAction`, `toggleTheme`,
-  `importLibraryConcept`) — that's a deeper e2e suite, separate file
+- Non-guest authenticated flows (extension point: `authenticated_page`
+  fixture). Tests 4–6 use a guest Supabase session, so they exercise some
+  in-app behavior, but real signed-in flows still need a separate suite.
+- Full critical-flow exercise (`selectTile`, `runHeroAction`, `toggleTheme`)
+  — only library reopen and concept delete are partially covered here.
 - Visual regression — Playwright captures a trace on failure for debugging
 - Performance / Lighthouse
 
@@ -43,7 +54,8 @@ The wrapper at `scripts/qa-smoke.sh` does setup + run in one command and is the
 preferred entry point:
 
 ```bash
-# Local — needs `uvicorn main:app --reload` in another shell
+# Local — needs `bash scripts/dev.sh` in another shell (runs the
+# local-auth preflight, then `uvicorn main:app --reload`)
 bash scripts/qa-smoke.sh local
 
 # Production (https://app.socratink.ai)
@@ -56,7 +68,7 @@ bash scripts/qa-smoke.sh https://socratink-app-git-dev-fresh-jon-devlapaz.vercel
 Raw pytest invocations (when you need flags the wrapper doesn't pass through):
 
 ```bash
-# Local — needs `uvicorn main:app --reload` in another shell
+# Local — needs `bash scripts/dev.sh` in another shell
 pytest tests/e2e/test_smoke.py -v
 
 # Against any URL via env var
@@ -74,13 +86,17 @@ PWDEBUG=1 pytest tests/e2e/test_smoke.py -v
 Pass:
 
 ```
-tests/e2e/test_smoke.py::test_health_endpoint_ok PASSED                 [ 20%]
-tests/e2e/test_smoke.py::test_homepage_loads_with_critical_dom PASSED   [ 40%]
-tests/e2e/test_smoke.py::test_no_console_errors_on_first_paint PASSED   [ 60%]
-tests/e2e/test_smoke.py::test_no_failed_critical_asset_requests PASSED  [ 80%]
+tests/e2e/test_smoke.py::test_health_endpoint_ok PASSED                              [ 11%]
+tests/e2e/test_smoke.py::test_homepage_loads_with_critical_dom PASSED                [ 22%]
+tests/e2e/test_smoke.py::test_guest_session_is_labeled_as_guest PASSED               [ 33%]
+tests/e2e/test_smoke.py::test_drawer_toggle_remains_visible_in_concept_view PASSED   [ 44%]
+tests/e2e/test_smoke.py::test_saved_library_concept_reopens_map_view PASSED          [ 55%]
+tests/e2e/test_smoke.py::test_active_concept_delete_confirms_then_returns_to_desk PASSED [ 66%]
+tests/e2e/test_smoke.py::test_no_console_errors_on_first_paint PASSED                [ 77%]
+tests/e2e/test_smoke.py::test_no_failed_critical_asset_requests PASSED               [ 88%]
 tests/e2e/test_smoke.py::test_theme_preloader_resilient_on_blank_localstorage PASSED [100%]
 
-============================== 5 passed in 8.21s ==============================
+============================== 9 passed in 14.7s ==============================
 ```
 
 Fail: pytest prints the offending console errors / failed requests verbatim,

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -2,24 +2,30 @@
 
 What this catches
 -----------------
-- Backend is up and the FastAPI app booted (health endpoint reachable)
+- Backend is up and the FastAPI app booted (`/api/health` shape valid)
 - Frontend renders without a blank-page regression (critical DOM IDs present)
+- Anonymous Supabase sessions are labeled as guest, not signed-in users
+- Drawer toggle stays visible after opening a library concept
+- Library cards reopen the concept-map view (not a stale shell) on second click
+- Deleting the active concept confirms via dialog and resets to the desk
 - No same-origin console errors during first paint
 - No same-origin asset request failures during first paint
 - The inline theme-preloader IIFE is resilient to a blank localStorage
 
 What this deliberately does NOT cover
 -------------------------------------
-- Authenticated flows (will live in test_authenticated_flows.py later, using
-  an `authenticated_page` fixture in conftest.py with stored storageState)
-- The 4 critical flows: selectTile, runHeroAction, toggleTheme,
-  importLibraryConcept (deeper e2e suite)
+- Non-guest authenticated flows (extension point: `authenticated_page`
+  fixture in conftest.py with stored storageState). The guest-session tests
+  here exercise some in-app behavior, but real signed-in flows still need a
+  separate suite.
+- Full critical-flow exercise (`selectTile`, `runHeroAction`, `toggleTheme`)
+  — only library reopen and active-concept delete are partially covered here.
 - Visual regression (screenshots are only saved on failure for debugging)
 - Performance / lighthouse metrics
 
 Run
 ---
-    # local (uvicorn main:app --reload running)
+    # local (start the app first: `bash scripts/dev.sh`)
     pytest tests/e2e/test_smoke.py -v
 
     # against a deployed environment

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -137,6 +137,94 @@ def test_guest_session_is_labeled_as_guest(
     expect(clean_page.locator("#auth-logout-btn")).to_have_text("Exit Guest")
 
 
+def test_drawer_toggle_remains_visible_in_concept_view(
+    clean_page: Page, base_url: str
+) -> None:
+    """The sidebar control must stay available after entering a concept."""
+    clean_page.evaluate(
+        """localStorage.setItem(
+            'socratink:firstSeenAt:v1:guest',
+            new Date().toISOString()
+        );"""
+    )
+    _enter_app_shell_as_guest(clean_page, base_url)
+
+    toggle = clean_page.locator("#drawer-toggle")
+    expect(toggle).to_be_visible()
+
+    clean_page.locator("#nav-library").click()
+    expect(clean_page.get_by_text("Documentation Concepts")).to_be_visible()
+
+    clean_page.locator(".library-card-vault", has_text="Hermes Agent").click()
+    expect(clean_page.locator("#concept-header-title")).to_contain_text("Hermes Agent")
+    expect(toggle).to_be_visible()
+
+
+def test_saved_library_concept_reopens_map_view(
+    clean_page: Page, base_url: str
+) -> None:
+    """Library entry points should both open the concept map, not a stale shell."""
+    clean_page.evaluate(
+        """localStorage.setItem(
+            'socratink:firstSeenAt:v1:guest',
+            new Date().toISOString()
+        );"""
+    )
+    _enter_app_shell_as_guest(clean_page, base_url)
+
+    clean_page.locator("#nav-library").click()
+    clean_page.locator(".library-card-vault", has_text="Hermes Agent").click()
+    expect(clean_page.locator("#concept-header-title")).to_contain_text("Hermes Agent")
+    assert clean_page.locator("body").get_attribute("data-map-open") == "true"
+
+    clean_page.locator("#nav-library").click()
+    your_library = clean_page.locator("#library-content .library-section", has_text="Your Library")
+    your_library.locator(".library-card-vault", has_text="Hermes Agent").click()
+
+    expect(clean_page.locator("#concept-header-title")).to_contain_text("Hermes Agent")
+    assert clean_page.locator("body").get_attribute("data-map-open") == "true"
+    expect(clean_page.locator("#map-mode-graph")).to_have_attribute("aria-pressed", "true")
+
+
+def test_active_concept_delete_confirms_then_returns_to_desk(
+    clean_page: Page, base_url: str
+) -> None:
+    """Deleting the open concept must not leave stale concept content visible."""
+    clean_page.evaluate(
+        """localStorage.setItem(
+            'socratink:firstSeenAt:v1:guest',
+            new Date().toISOString()
+        );"""
+    )
+    _enter_app_shell_as_guest(clean_page, base_url)
+
+    clean_page.locator("#nav-library").click()
+    clean_page.locator(".library-card-vault", has_text="Hermes Agent").click()
+    expect(clean_page.locator("#concept-header-title")).to_contain_text("Hermes Agent")
+
+    delete_button = clean_page.locator(".concept-item.active .concept-delete")
+
+    def dismiss_delete(dialog) -> None:
+        assert "Delete \"Hermes Agent\"?" in dialog.message
+        dialog.dismiss()
+
+    clean_page.once("dialog", dismiss_delete)
+    delete_button.click()
+    expect(clean_page.locator("#concept-header-title")).to_contain_text("Hermes Agent")
+    expect(clean_page.locator(".concept-item.active")).to_have_count(1)
+
+    def accept_delete(dialog) -> None:
+        assert "Delete \"Hermes Agent\"?" in dialog.message
+        dialog.accept()
+
+    clean_page.once("dialog", accept_delete)
+    delete_button.click()
+    expect(clean_page.locator("#title")).to_have_text("What do you want to understand?")
+    expect(clean_page.locator(".concept-item")).to_have_count(0)
+    expect(clean_page.locator("#concept-header-title")).not_to_be_visible()
+    assert clean_page.locator("body").get_attribute("data-map-open") != "true"
+
+
 # --- 3. No console errors on first paint ---------------------------------
 
 

--- a/tests/test_runtime_env.py
+++ b/tests/test_runtime_env.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from runtime_env import load_app_env
+
+
+ENV_KEYS = {
+    "AUTH_ENABLED",
+    "SUPABASE_URL",
+    "SUPABASE_PUBLISHABLE_KEY",
+    "SUPABASE_JWT_SECRET",
+    "SESSION_COOKIE_KEY",
+    "APP_BASE_URL",
+    "VERCEL",
+    "VERCEL_ENV",
+    "CI",
+    "SOCRATINK_DISABLE_DOTENV_LOCAL",
+}
+
+
+class RuntimeEnvTests(unittest.TestCase):
+    def setUp(self):
+        self.original = {key: os.environ.get(key) for key in ENV_KEYS}
+        for key in ENV_KEYS:
+            os.environ.pop(key, None)
+
+    def tearDown(self):
+        for key in ENV_KEYS:
+            if self.original[key] is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = self.original[key]
+
+    def _root(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        return Path(tmp.name)
+
+    def test_dotenv_local_overrides_dotenv_without_overriding_process_env(self):
+        root = self._root()
+        (root / ".env").write_text(
+            "\n".join(
+                [
+                    "AUTH_ENABLED=false",
+                    "SUPABASE_URL=https://from-dotenv.supabase.co",
+                    "SESSION_COOKIE_KEY=",
+                    "APP_BASE_URL=http://localhost:8000",
+                ]
+            )
+            + "\n"
+        )
+        (root / ".env.local").write_text(
+            "\n".join(
+                [
+                    "AUTH_ENABLED=true",
+                    "SUPABASE_URL=https://from-local.supabase.co",
+                    "SUPABASE_PUBLISHABLE_KEY=pk_local",
+                    "SUPABASE_JWT_SECRET=jwt_local",
+                    "SESSION_COOKIE_KEY=session_local",
+                ]
+            )
+            + "\n"
+        )
+        os.environ["SUPABASE_URL"] = "https://from-process.supabase.co"
+
+        report = load_app_env(root)
+
+        self.assertEqual(report.loaded_files, (".env", ".env.local"))
+        self.assertEqual(os.environ["AUTH_ENABLED"], "true")
+        self.assertEqual(
+            os.environ["SUPABASE_URL"], "https://from-process.supabase.co"
+        )
+        self.assertEqual(os.environ["SESSION_COOKIE_KEY"], "session_local")
+
+    def test_dotenv_local_is_skipped_on_vercel(self):
+        root = self._root()
+        (root / ".env").write_text("AUTH_ENABLED=false\n")
+        (root / ".env.local").write_text("AUTH_ENABLED=true\n")
+        os.environ["VERCEL"] = "1"
+
+        report = load_app_env(root)
+
+        self.assertEqual(report.loaded_files, (".env",))
+        self.assertEqual(report.skipped_local_reason, "Vercel runtime env detected")
+        self.assertEqual(os.environ["AUTH_ENABLED"], "false")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/pipette/requirements.txt
+++ b/tools/pipette/requirements.txt
@@ -1,3 +1,0 @@
-# tools/pipette/requirements.txt
-pydantic>=2.0
-pyyaml>=6.0


### PR DESCRIPTION
## Summary

- Add local auth preflight: new `runtime_env.py` centralizes env precedence (process env > `.env.local` > `.env`, skipped on Vercel/CI, with `SOCRATINK_DISABLE_DOTENV_LOCAL` opt-out), wired through `auth/service.py`; `scripts/check-local-auth.py` (with `--probe-guest`) and `scripts/dev.sh` catch the common `.env` vs `.env.local` Supabase misconfig before guest sign-in breaks.
- Fix three UX regressions in `public/js/app.js`: drawer toggle stays visible in map view, saved library cards reopen the concept-map view, deleting the active concept confirms then resets to the desk; covered by three new behavioral checks in `tests/e2e/test_smoke.py` (suite now 9 tests).
- Introduce `UBIQUITOUS_LANGUAGE.md` as the binding project glossary and migrate `DESIGN.md`, `docs/design/brand-reference.md`, `docs/design/socratink-design-system.md`, and `docs/product/ux-framework.md` to the canonical vocabulary (Recorded evidence, Reconstruction evidence, Solidified); register it in `doc-map.md` and refresh README, AGENTS, e2e README, mvp-happy-path, auth-rollout, and the smoke-test docstring to point at `bash scripts/dev.sh` and document `--probe-guest`. Folds `tools/pipette/requirements.txt` into `requirements-dev.txt`.

## Risk Assessment

✅ Low: Bounded UI bug fixes plus brand/copy refresh and a tested local auth preflight; no correctness, security, or behavioral risks identified in the changed code.

## Testing

- Summary: Backend unit tests including the new runtime_env coverage all pass; the new e2e assertions are well-formed and intentionally fail against undeployed live, while local e2e is gated by Supabase anonymous sign-in rate limits.
- `pytest tests/test_runtime_env.py -v`
- <code>`pytest tests/ --ignore=tests/e2e --ignore=tests/pipette -v` (160 tests, all pass)</code>
- <code>`bash scripts/qa-smoke.sh live` (read-only smoke against https://app.socratink.ai — pre-deploy run; 3 new assertions fail as expected because the fix hasn&#39;t shipped yet)</code>
- <code>`SOCRATINK_BASE_URL=http://localhost:8001 pytest tests/e2e/test_smoke.py -v` (local uvicorn from this worktree — blocked by Supabase 429 rate limit, environmental)</code>
- Outcome: ✅ passed across 1 run (9m2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pytest tests/test_runtime_env.py -v`
- <code>`pytest tests/ --ignore=tests/e2e --ignore=tests/pipette -v` (160 tests, all pass)</code>
- <code>`bash scripts/qa-smoke.sh live` (read-only smoke against https://app.socratink.ai — pre-deploy run; 3 new assertions fail as expected because the fix hasn&#39;t shipped yet)</code>
- <code>`SOCRATINK_BASE_URL=http://localhost:8001 pytest tests/e2e/test_smoke.py -v` (local uvicorn from this worktree — blocked by Supabase 429 rate limit, environmental)</code>

</details>

<details>
<summary>🔧 **Document** - 8 issues found → auto-fixed (9)</summary>

**Round 1** - found 8 issues (4 warnings, 4 infos)
- ⚠️ `CLAUDE.md:77` - The QA smoke section claims `tests/e2e/test_smoke.py` has &#34;6 tests&#34;. This branch adds three new tests (`test_drawer_toggle_remains_visible_in_concept_view`, `test_saved_library_concept_reopens_map_view`, `test_active_concept_delete_confirms_then_returns_to_desk`), bringing the suite to 9 tests. Update the count.
- ⚠️ `CLAUDE.md:79` - The &#34;6 checks&#34; enumeration that follows the test-count line lists only the original six (health, critical DOM, guest labeling, console errors, asset failures, theme preloader). It does not include the three new behavioral checks added by this branch (drawer toggle visibility in concept view, library card reopens map view, active-concept delete confirm + reset). Either expand the enumeration to cover all 9, or rephrase to a forward-compatible summary.
- ⚠️ `tests/e2e/README.md:9` - Header reads &#34;6 tests, runtime ~10s warm + ~30s cold, in source order&#34;. Suite is now 9 tests; runtime estimate likely also needs revising upward since the new tests load the app shell, click through library, and trigger delete dialogs.
- ⚠️ `tests/e2e/README.md:11` - The numbered &#34;What&#39;s covered&#34; list (items 1–6) does not include the three new tests added in `tests/e2e/test_smoke.py`: `test_drawer_toggle_remains_visible_in_concept_view`, `test_saved_library_concept_reopens_map_view`, and `test_active_concept_delete_confirms_then_returns_to_desk`. Add them to the list with their intent (drawer-toggle gate fix, library reopen fix, delete confirmation + reset) so readers see what the suite actually verifies.
- ℹ️ `tests/e2e/README.md:76` - The sample &#34;Pass&#34; output block lists only 5 PASSED lines and ends with `============================== 5 passed in 8.21s ==============================`. The block predates even the guest-session test (#3) and certainly the three new ones; it should reflect the current 9-test output (or be trimmed to a representative excerpt).
- ℹ️ `tests/e2e/README.md:24` - &#34;What&#39;s deliberately out of scope&#34; lists &#34;Authenticated flows (extension point: `authenticated_page` fixture)&#34; and &#34;Critical-flow exercise (`selectTile`, `runHeroAction`, `toggleTheme`, `importLibraryConcept`) — that&#39;s a deeper e2e suite, separate file&#34;. The three new tests use a guest Supabase session and exercise library-card click (importLibraryConcept-adjacent) and concept delete inside the app shell. The exclusion claim is now partially stale and should be narrowed (e.g., authenticated-non-guest flows remain out of scope; some critical-flow coverage is now in the smoke).
- ℹ️ `tests/e2e/README.md:46` - Local-run instructions still say &#34;Local — needs `uvicorn main:app --reload` in another shell&#34; (lines 46 and 59). Both `README.md` and `AGENTS.md` were updated this branch to recommend `bash scripts/dev.sh`, which runs the new local-auth preflight before starting Uvicorn. Update the e2e README to point at `scripts/dev.sh` for consistency, especially since the new tests rely on a working guest-auth setup that the preflight verifies.
- ℹ️ `docs/superpowers/plans/2026-04-28-pipette.md:61` - The plan&#39;s §1 &#34;Open dependency&#34; note (line 61) and Task B1 (lines 226–266) describe creating and installing `tools/pipette/requirements.txt`. This branch deletes that file and folds `pydantic&gt;=2.0` / `pyyaml&gt;=6.0` into the root `requirements-dev.txt`. As a historical plan it documents past intent, but the &#34;Open dependency&#34; framing now misleads readers about current state — add a short resolution note pointing to `requirements-dev.txt`.

**Round 2** (auto-fix) - found 1 info
- ℹ️ `docs/project/mvp-happy-path.md:36` - Step &#34;1. Start The App&#34; instructs the manual MVP smoke to run `uvicorn main:app --reload` directly. This branch added `scripts/dev.sh` (and `scripts/check-local-auth.py`) and updated README.md, AGENTS.md, and tests/e2e/README.md to recommend `bash scripts/dev.sh` as the preferred entry point, since it runs the local-auth preflight that catches the common `.env` vs `.env.local` Supabase/session misconfiguration. The MVP happy-path doc — explicitly the manual release-gate doc — should match: replace the `uvicorn main:app --reload` block with `bash scripts/dev.sh` (or note both, with the dev.sh path as preferred), so a manual smoke run benefits from the same preflight.

**Round 3** (auto-fix) - found 2 infos
- ℹ️ `docs/project/doc-map.md:26` - This branch adds a brand-new project-wide DDD glossary at /UBIQUITOUS_LANGUAGE.md (64 lines, defines binding terms like &#39;Graph truth&#39;, &#39;Recorded evidence&#39;, &#39;Reconstruction evidence&#39;, the four learning-loop states, and explicit &#39;Aliases to avoid&#39;). doc-map.md is the project&#39;s doc registry, but UBIQUITOUS_LANGUAGE.md does not appear in it. The &#39;Precedence (Binding)&#39; block at line 22 even lists exactly the legacy shorthand that the new glossary now formally replaces (&#39;verified understanding&#39;, &#39;cleared&#39;, &#39;mastered&#39;, &#39;proved it&#39;, &#39;real learning&#39;, &#39;possess&#39;), but defers to evidence-weighted-map.md §13. Add a row for UBIQUITOUS_LANGUAGE.md (canonical, binding) under Canonical Doctrine — or a dedicated &#39;Project Glossary&#39; section — so readers find the authoritative term list. The &#39;Registry Maintenance&#39; section&#39;s &#39;When a new doc is added under docs/, register it here&#39; is technically scoped to docs/, but a project-wide binding glossary is exactly the kind of file the registry is meant to surface.
- ℹ️ `DESIGN.md:9` - This branch rewrites a dozen DESIGN.md surfaces to swap legacy shorthand for the new ubiquitous-language vocabulary: &#39;verified understanding&#39; → &#39;learner-generated evidence&#39;, &#39;truthful record of understanding&#39; → &#39;truthful projection of recorded evidence&#39;, &#39;No fake progress — the map updates only when you actually get it.&#39; → &#39;No fake state changes — the map updates when Socratink records learner-generated evidence.&#39;, &#39;Bring your material. Get a map. Clear rooms.&#39; → &#39;Bring your material. Build a map. Record evidence.&#39;, &#39;&#34;Cleared. You proved it.&#34;&#39; → &#39;&#34;Solidified. Spaced reconstruction recorded.&#34;&#39;, etc. These phrasings are defined and aliased explicitly in the new /UBIQUITOUS_LANGUAGE.md, but DESIGN.md never links to it. Without the cross-reference, future copy edits will drift from the glossary and the &#39;Aliases to avoid&#39; column has no enforcement surface in the design doc readers actually open. Add a short &#39;Vocabulary&#39; callout near the top of DESIGN.md (e.g., next to §1 or §6 Voice &amp; language) pointing to /UBIQUITOUS_LANGUAGE.md as the authoritative term list.

**Round 4** (auto-fix) - found 3 infos
- ℹ️ `AGENTS.md:76` - This branch adds a brand-new top-level module `runtime_env.py` (86 lines) that replaces the bare `load_dotenv()` call in `main.py` and implements production-safe env precedence (process env &gt; .env.local &gt; .env, with explicit skip on Vercel/CI). The module&#39;s docstring is explicit that &#39;auth startup depends on it.&#39; AGENTS.md&#39;s &#39;Big-picture architecture&#39; section enumerates main.py, ai_service.py, auth/, public/, and tools/pipette/, but `runtime_env.py` is absent. Add a short bullet so a reader of AGENTS.md alone knows env loading is centralized there and what its precedence rules are. Without this, future agents touching auth or env config will not know to look at this module.
- ℹ️ `AGENTS.md:22` - This branch introduces a new opt-out env var `SOCRATINK_DISABLE_DOTENV_LOCAL` (runtime_env.py:33) that lets a developer suppress `.env.local` loading on a localhost shell where it would otherwise apply (useful for testing the Vercel/production code path locally). It is not mentioned in any human-facing doc — README.md, AGENTS.md, docs/project/auth-rollout.md, or scripts/check-local-auth.py output. Document it once next to the env-setup or local-run section in AGENTS.md (or README.md) so the flag is discoverable; otherwise the only way to find it is by reading the implementation.
- ℹ️ `docs/project/auth-rollout.md:75` - docs/project/auth-rollout.md is the binding implementation contract for the Supabase auth rollout (Phase 0 release gate explicitly says &#39;login, callback, /api/me, and logout work in local and Vercel preview&#39;). This branch adds the local-auth preflight (`scripts/check-local-auth.py`) and the wrapper (`scripts/dev.sh`) specifically to catch the common `.env` vs `.env.local` Supabase/session misconfiguration that breaks local guest sign-in — exactly the failure mode the Phase 0 gate cares about. README.md, AGENTS.md, tests/e2e/README.md, and docs/project/mvp-happy-path.md were updated to point at `bash scripts/dev.sh`, but auth-rollout.md was not. Add a short note (Test Plan or a new &#39;Local development&#39; subsection) pointing at `scripts/check-local-auth.py` / `scripts/dev.sh` so the auth contract documents how to validate local readiness.

**Round 5** (auto-fix) - found 3 warnings
- ⚠️ `docs/product/ux-framework.md:571` - Section 5 (&#34;In-Progress Must Not Feel Punitive&#34;) still gives the `solidified` example as `&#34;Cleared. You proved it.&#34;`. This branch&#39;s vocabulary migration replaced exactly that phrasing in DESIGN.md (line 144) and docs/design/brand-reference.md (line 195) with `&#34;Solidified. Spaced reconstruction recorded.&#34;`, and the new /UBIQUITOUS_LANGUAGE.md flags `&#34;actualized, cleared as knowledge&#34;` and `&#34;proved it&#34;` as aliases-to-avoid. &#34;proved it&#34; is also explicitly listed in evidence-weighted-map.md §13 as a legacy phrase to replace. doc-map.md tags ux-framework.md as canonical/binding, so the design layer and the binding spec layer are now out of sync. Update the `solidified` example to the new phrasing (or annotate it as legacy display shorthand) so future copy work pulled from this doc doesn&#39;t reintroduce the deprecated framing.
- ⚠️ `docs/product/ux-framework.md:465` - The session-cap framing example reads `&#34;Progress locked in. Your neurons do the rest while you&#39;re away.&#34;`. This branch updated the same example in DESIGN.md (line 145, &#34;Session cap&#34; row of the state-tone table) to `&#34;Evidence recorded. Let spacing do its work while you&#39;re away.&#34;`. The motivation in /UBIQUITOUS_LANGUAGE.md is that &#34;progress&#34; reads as capability growth (an aliased term: &#34;evidence accumulation&#34; per evidence-weighted-map.md §13). Bring this canonical doc&#39;s example in line with the design-layer copy that was just standardized.
- ⚠️ `docs/design/socratink-design-system.md:136` - Voice rule cites the marketing-copy exemplar as `&#34;Bring your material. Get a map. Clear rooms.&#34;` This branch replaced exactly that string in DESIGN.md (lines 130, 145) and docs/design/brand-reference.md (lines 180, 192) with `&#34;Bring your material. Build a map. Record evidence.&#34;` to match the new ubiquitous language (Recorded evidence, Reconstruction evidence). socratink-design-system.md is the design-skill doc loaded by agents producing marketing/in-app copy — leaving the legacy exemplar here is precisely what the glossary&#39;s &#34;reject new occurrences at write time&#34; rule (doc-map.md line 22) is meant to prevent, since agents will lift this exemplar verbatim into new copy. Update the example to match the now-canonical phrasing.

**Round 6** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `CLAUDE.md:91` - The `Extension:` bullet still reads `for future flow tests against selectTile / runHeroAction / toggleTheme / importLibraryConcept`, but the README it points to (tests/e2e/README.md, lines 31–37 after the round-1 fix) now narrows this: tests 4–6 use a guest Supabase session and partially cover `importLibraryConcept`-adjacent behavior (via the new `App.openLibraryConcept` public function) and active-concept delete. So (a) `importLibraryConcept` no longer belongs in the &#39;future flow tests&#39; list — it has partial coverage now; (b) the new public surface `openLibraryConcept` (added to App&#39;s exposed API in public/js/app.js:4054–4057, exercised by smoke test #5) is missing from the list entirely. Either drop `importLibraryConcept` from the list and add `openLibraryConcept`, or rephrase to match the README&#39;s narrowed framing (&#39;non-guest authenticated flows&#39; as the extension point, with `selectTile`/`runHeroAction`/`toggleTheme` as still-uncovered critical flows). Otherwise CLAUDE.md and the README it cites disagree about what the smoke covers.
- ℹ️ `docs/project/auth-rollout.md:78` - `scripts/check-local-auth.py` exposes a `--probe-guest` flag (script lines 36–40, 94–105) that calls `service.sign_in_anonymously()` against the configured Supabase project to prove that the guest-session path actually works end-to-end — not just that the env vars are present. None of the human-facing docs that point at the preflight (README.md §Local Run, AGENTS.md §Run locally, docs/project/mvp-happy-path.md §1, docs/project/auth-rollout.md §Test Plan) mention `--probe-guest`. auth-rollout.md is the binding contract whose Phase 0 release gate is &#39;login, callback, /api/me, and logout work in local and Vercel preview&#39; — exactly what this flag verifies. Add a one-line mention next to the existing `bash scripts/dev.sh` reference (e.g., `python scripts/check-local-auth.py --probe-guest` to verify Supabase actually accepts the configured anon key) so the flag is discoverable and the auth contract documents the strongest local readiness check.

**Round 7** (auto-fix) - found 1 warning
- ⚠️ `docs/product/ux-framework.md:511` - Round 5 migrated two ux-framework.md surfaces (line 465 session-cap copy, line 571 `solidified` state copy) to match the new /UBIQUITOUS_LANGUAGE.md glossary, but several other legacy-shorthand instances in the same canonical/binding doc were left untouched. Per /UBIQUITOUS_LANGUAGE.md &#34;Aliases to avoid&#34; and evidence-weighted-map.md §13 (which doc-map.md line 22 elevates to authoritative for translation), and doc-map.md&#39;s rule that agents must &#34;reject new occurrences at write time,&#34; these phrases should be migrated for consistency with the now-authoritative vocabulary: (a) line 411 — &#34;That jump is real learning.&#34; should become §13&#39;s &#34;Stronger reconstruction evidence is on record.&#34; (this is the same string already corrected in DESIGN.md line 168 and brand-reference.md line 214); (b) line 511 — &#34;already legitimately mastered&#34; and &#34;You already possess the foundational mechanisms for this area.&#34; both use the §13/glossary-flagged terms &#34;mastered&#34; and &#34;possess&#34;; (c) line 513 — &#34;reflect real, previously verified understanding&#34; uses &#34;verified understanding,&#34; the canonical legacy phrase replaced with &#34;solid spaced reconstruction recorded&#34;; (d) line 537 — &#34;Represent verified understanding, not activity volume.&#34; repeats the same legacy phrase; (e) line 544 — the trajectory-contrast example string still ends with &#34;That jump is real learning.&#34; (paired duplicate of line 411); (f) line 557 — &#34;whether it is primed, drilled, or cleared&#34; mixes node-state names with the §13/glossary-flagged shorthand &#34;cleared&#34;; node-state lists elsewhere in this same doc (e.g., the §568 state-copy block) use `solidified`. Replace each per evidence-weighted-map.md §13 (or annotate as legacy display shorthand where intended) so the partial migration completes and the binding doc stops contradicting the glossary it now defers to.

**Round 8** (auto-fix) - found 1 info
- ℹ️ `tests/e2e/README.md:134` - The &#39;Extending later&#39; section&#39;s prose says `a sibling tests/e2e/test_critical_flows.py can use authenticated_page and exercise the four critical flows without paying the login tax in every test.` The &#39;four critical flows&#39; framing predates this branch&#39;s narrowing of the out-of-scope list (line 37) from four flows (`selectTile`, `runHeroAction`, `toggleTheme`, `importLibraryConcept`) down to three (`selectTile`, `runHeroAction`, `toggleTheme`) — `importLibraryConcept` was dropped because the new tests 4–6 now provide partial guest-session coverage of `openLibraryConcept`-adjacent behavior. Line 37 and line 134 of the same doc now disagree on the count. Update the &#39;Extending later&#39; prose to &#39;three&#39; (or rephrase to match line 37&#39;s narrowed framing — e.g., &#39;the still-uncovered critical flows&#39;) so the doc is internally consistent.

**Round 9** (auto-fix) - found 1 warning
- ⚠️ `tests/e2e/test_smoke.py:1` - The module docstring at the top of `tests/e2e/test_smoke.py` is now internally inconsistent with the file&#39;s own contents and contradicts every other doc that was just updated in this branch. Three concrete drifts: (a) Lines 5–9 &#39;What this catches&#39; list only the original 5 catches — health, critical DOM, no console errors, no failed asset requests, theme-preloader resilience — and miss both the existing `test_guest_session_is_labeled_as_guest` and the three new behavioral tests added in this same change (`test_drawer_toggle_remains_visible_in_concept_view`, `test_saved_library_concept_reopens_map_view`, `test_active_concept_delete_confirms_then_returns_to_desk`). The companion `tests/e2e/README.md` was updated in round 1 to enumerate all 9 tests; this docstring was not. (b) Lines 13–16 &#39;What this deliberately does NOT cover&#39; still list &#39;Authenticated flows (will live in test_authenticated_flows.py later, using an authenticated_page fixture …)&#39; and &#39;The 4 critical flows: selectTile, runHeroAction, toggleTheme, importLibraryConcept&#39;. The new tests 4–6 use the guest Supabase session helper `_enter_app_shell_as_guest` (so they are partially authenticated flows in this file, not a future sibling file), and `importLibraryConcept` no longer belongs in the still-uncovered list — its sibling `openLibraryConcept` is now exercised. `tests/e2e/README.md` line 37 was already narrowed to &#39;Full critical-flow exercise (`selectTile`, `runHeroAction`, `toggleTheme`)&#39; and CLAUDE.md line 91 to the matching three; this docstring still says four. (c) Line 22 still instructs &#39;local (uvicorn main:app --reload running)&#39; as the local-run command, but README.md, AGENTS.md, docs/project/mvp-happy-path.md, and `tests/e2e/README.md` were all updated to recommend `bash scripts/dev.sh` (which runs the new local-auth preflight that catches `.env` vs `.env.local` Supabase/session misconfiguration — exactly the kind of misconfig that would make tests 3–6 fail). Refresh the docstring to enumerate all 9 tests, narrow the out-of-scope list to match the README, and update the local-run instruction to `bash scripts/dev.sh`.

**Round 10** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
