### PR TITLE
feat(pipette): signal honesty — F1 + F3 + F5 + F8 (Chunk C, reopened)

### DIFF
--- a/tests/pipette/test_cli.py
+++ b/tests/pipette/test_cli.py
@@ -186,6 +186,39 @@ def test_build_coverage_map_ignores_non_test_edges(tmp_path: Path):
     assert cov["files"]["src/foo.py"] == 0.30
 
 
+def test_build_coverage_map_warns_on_partially_malformed_dump(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """F3 (extended per code-quality review): when the dump has >= 5
+    edges but < 50% have `tests/`-prefixed source_files, warn that the
+    dump is partially malformed. Catches mid-refactor dump-producer
+    bugs that the original all-or-nothing check missed."""
+    import json
+    from tools.pipette.cli import main
+
+    bad_dump = tmp_path / "partial.json"
+    # 6 edges total: 1 tests/-prefixed, 5 absolute paths → ratio 1/6 ≈ 17%.
+    edges = [
+        {"from": {"source_file": "tests/test_foo.py"},
+         "to": {"source_file": "src/foo.py"}},
+    ]
+    edges.extend(
+        {"from": {"source_file": f"/abs/path/file_{i}.py"},
+         "to": {"source_file": f"/abs/path/dst_{i}.py"}}
+        for i in range(5)
+    )
+    bad_dump.write_text(json.dumps({"edges": edges}))
+    out_path = tmp_path / "coverage_map.json"
+    rc = main([
+        "build-coverage-map",
+        "--dump-file", str(bad_dump),
+        "--affected-files", "src/foo.py",
+        "--output", str(out_path),
+    ])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "warning" in err.lower()
+    assert "partially malformed" in err.lower() or "1/6" in err
+
+
 def test_build_coverage_map_warns_on_malformed_dump(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     """F3: when the dump's edges have NO `from.source_file` starting with
     'tests/', every affected file gets the uncovered default. That's a

--- a/tests/pipette/test_cli.py
+++ b/tests/pipette/test_cli.py
@@ -1,4 +1,4 @@
-"""CLI tests for tools.pipette.cli — added/extended in Chunk B (F4)."""
+"""CLI tests for tools.pipette.cli — added/extended in Chunks B (F4) and C (F3)."""
 from __future__ import annotations
 import json
 import subprocess
@@ -184,3 +184,31 @@ def test_build_coverage_map_ignores_non_test_edges(tmp_path: Path):
     assert r.returncode == 0
     cov = json.loads(out.read_text())
     assert cov["files"]["src/foo.py"] == 0.30
+
+
+def test_build_coverage_map_warns_on_malformed_dump(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """F3: when the dump's edges have NO `from.source_file` starting with
+    'tests/', every affected file gets the uncovered default. That's a
+    silent failure mode that triggered TDD enforcement spuriously in the
+    2026-04-28 run. Emit a stderr warning when the shape looks wrong."""
+    from tools.pipette.cli import main
+
+    bad_dump = tmp_path / "bad.json"
+    # Absolute paths, no 'tests/' prefix — the symptom from F3.
+    bad_dump.write_text(json.dumps({
+        "edges": [
+            {"from": {"source_file": "/abs/path/foo.py"},
+             "to": {"source_file": "/abs/path/bar.py"}}
+        ]
+    }))
+    out_path = tmp_path / "coverage_map.json"
+    rc = main([
+        "build-coverage-map",
+        "--dump-file", str(bad_dump),
+        "--affected-files", "src/foo.py",
+        "--output", str(out_path),
+    ])
+    assert rc == 0  # warning, not error
+    err = capsys.readouterr().err
+    assert "warning" in err.lower()
+    assert "malformed" in err.lower() or "no test→source edges" in err.lower()

--- a/tests/pipette/test_doctor.py
+++ b/tests/pipette/test_doctor.py
@@ -27,23 +27,66 @@ def test_doctor_aggregate_returns_one_on_any_fail():
     assert _aggregate_rc([CheckResult(name="a", ok=True), CheckResult(name="b", ok=False, message="x", fix="y")]) == 1
 
 
-def test_mcp_probe_warns_when_tools_absent_in_session(monkeypatch):
-    """F1: when MCP is configured but the running session doesn't expose
-    the mcp__code-review-graph__* tools, doctor must return WARN, not OK."""
+def test_mcp_probe_warns_when_server_not_configured(monkeypatch):
+    """F1: when `claude mcp get code-review-graph` exits nonzero (server
+    not configured), doctor must return WARN, not OK."""
     from tools.pipette import doctor
 
-    # Simulate: MCP configured per settings.local.json (the CLI+settings part
-    # of the existing check passes), but no in-session tools exposed.
-    monkeypatch.setattr(doctor, "_session_exposes_mcp_tools",
-                        lambda prefix: False, raising=False)
+    monkeypatch.setattr(doctor, "_probe_mcp_via_claude_cli",
+                        lambda name: (False, f"{name} MCP not configured"),
+                        raising=False)
     ok, msg = doctor._verify_code_review_graph_session_probe()
     assert ok is False
-    assert "tools not exposed" in msg
+    assert "not configured" in msg
 
 
-def test_mcp_probe_ok_when_tools_present_in_session(monkeypatch):
+def test_mcp_probe_warns_when_server_disconnected(monkeypatch):
+    """F1: when the server is configured but the probe doesn't see
+    `Connected`, doctor must WARN."""
     from tools.pipette import doctor
-    monkeypatch.setattr(doctor, "_session_exposes_mcp_tools",
-                        lambda prefix: True, raising=False)
+
+    monkeypatch.setattr(doctor, "_probe_mcp_via_claude_cli",
+                        lambda name: (False, f"{name} MCP configured but not connected"),
+                        raising=False)
+    ok, msg = doctor._verify_code_review_graph_session_probe()
+    assert ok is False
+    assert "not connected" in msg
+
+
+def test_mcp_probe_ok_when_server_connected(monkeypatch):
+    """F1: when `claude mcp get code-review-graph` returns rc=0 with
+    `Status: ✓ Connected`, doctor must return OK."""
+    from tools.pipette import doctor
+
+    monkeypatch.setattr(doctor, "_probe_mcp_via_claude_cli",
+                        lambda name: (True, f"{name} MCP connected"),
+                        raising=False)
     ok, msg = doctor._verify_code_review_graph_session_probe()
     assert ok is True
+    assert "connected" in msg.lower()
+
+
+def test_mcp_probe_handles_missing_claude_cli(monkeypatch):
+    """F1: if the `claude` CLI is not on PATH (rare, but possible in CI),
+    the probe must WARN with a clear message rather than crash."""
+    import tools.pipette.doctor as doctor_mod
+    # shutil.which is the gate; force it to return None.
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    ok, msg = doctor_mod._probe_mcp_via_claude_cli("code-review-graph")
+    assert ok is False
+    assert "claude CLI not on PATH" in msg
+
+
+def test_mcp_probe_treats_subprocess_failure_as_warn(monkeypatch):
+    """F1: timeout/FileNotFoundError from subprocess.run must surface as
+    WARN, not propagate."""
+    import tools.pipette.doctor as doctor_mod
+    import subprocess as _sp
+
+    def boom(*args, **kwargs):
+        raise _sp.TimeoutExpired(cmd=args[0], timeout=15)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/claude")
+    monkeypatch.setattr("subprocess.run", boom)
+    ok, msg = doctor_mod._probe_mcp_via_claude_cli("code-review-graph")
+    assert ok is False
+    assert "TimeoutExpired" in msg or "claude mcp probe failed" in msg

--- a/tests/pipette/test_doctor.py
+++ b/tests/pipette/test_doctor.py
@@ -1,5 +1,11 @@
 # tests/pipette/test_doctor.py
+"""Unit tests for tools.pipette.doctor — added in Chunk C (F1)."""
+from __future__ import annotations
+
+import pytest
+
 from tools.pipette.doctor import Check, run_checks
+
 
 def test_check_passes_when_command_succeeds():
     c = Check(name="x", verify=lambda: (True, ""), fix="run x")
@@ -19,3 +25,25 @@ def test_doctor_aggregate_returns_zero_on_all_pass():
 def test_doctor_aggregate_returns_one_on_any_fail():
     from tools.pipette.doctor import CheckResult, _aggregate_rc
     assert _aggregate_rc([CheckResult(name="a", ok=True), CheckResult(name="b", ok=False, message="x", fix="y")]) == 1
+
+
+def test_mcp_probe_warns_when_tools_absent_in_session(monkeypatch):
+    """F1: when MCP is configured but the running session doesn't expose
+    the mcp__code-review-graph__* tools, doctor must return WARN, not OK."""
+    from tools.pipette import doctor
+
+    # Simulate: MCP configured per settings.local.json (the CLI+settings part
+    # of the existing check passes), but no in-session tools exposed.
+    monkeypatch.setattr(doctor, "_session_exposes_mcp_tools",
+                        lambda prefix: False, raising=False)
+    ok, msg = doctor._verify_code_review_graph_session_probe()
+    assert ok is False
+    assert "tools not exposed" in msg
+
+
+def test_mcp_probe_ok_when_tools_present_in_session(monkeypatch):
+    from tools.pipette import doctor
+    monkeypatch.setattr(doctor, "_session_exposes_mcp_tools",
+                        lambda prefix: True, raising=False)
+    ok, msg = doctor._verify_code_review_graph_session_probe()
+    assert ok is True

--- a/tests/pipette/test_lockfile.py
+++ b/tests/pipette/test_lockfile.py
@@ -14,6 +14,7 @@ from tools.pipette.lockfile import (
     resume,
     abort,
     detect_filesystem_supports_o_excl,
+    set_current_step,
 )
 
 def _read_lock(p: Path) -> dict:
@@ -138,3 +139,31 @@ def test_abort_renames_folder_and_removes_lock(tmp_pipeline_root: Path):
 
 def test_filesystem_detection_passes_on_local_fs(tmp_pipeline_root: Path):
     assert detect_filesystem_supports_o_excl(tmp_pipeline_root / "_meta") is True
+
+
+def test_set_current_step_writes_step_to_lockfile(tmp_pipeline_root: Path):
+    """F8: `set_current_step` is the orchestrator's hook into the
+    SubagentStop hook's step-tagging path. The helper must write the
+    step into the lockfile yaml so the hook (`subagent_stop._read_current_step_from_lockfile`)
+    can pick it up. Caller for this helper is intentionally absent in
+    Chunk C (orchestrator wiring is markdown-driven and lands in a later
+    chunk); this direct test guards the helper's contract regardless."""
+    lock = tmp_pipeline_root / "_meta" / ".lock"
+    folder = tmp_pipeline_root / "2026-04-28-143211-x"
+    folder.mkdir()
+    acquire(lock, topic="x", folder=folder)
+    set_current_step(lock, 3)
+    cur = _read_lock(lock)
+    assert cur["current_step"] == 3
+
+
+def test_set_current_step_updates_existing_step(tmp_pipeline_root: Path):
+    """Successive calls overwrite — orchestrator transitions advance step."""
+    lock = tmp_pipeline_root / "_meta" / ".lock"
+    folder = tmp_pipeline_root / "2026-04-28-143211-x"
+    folder.mkdir()
+    acquire(lock, topic="x", folder=folder)
+    set_current_step(lock, 1)
+    set_current_step(lock, 3)
+    cur = _read_lock(lock)
+    assert cur["current_step"] == 3

--- a/tests/pipette/test_subagent_stop_f8.py
+++ b/tests/pipette/test_subagent_stop_f8.py
@@ -1,0 +1,40 @@
+"""Unit tests for tools.pipette.subagent_stop — added in Chunk C (F8)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def lockfile_at_step_3(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Build a fixture lockfile + folder representing 'pipeline paused at step 3'."""
+    folder = tmp_path / "feature-x"
+    folder.mkdir()
+    lock = tmp_path / ".lock"
+    lock.write_text(yaml.safe_dump({
+        "topic": "feature-x",
+        "folder": str(folder),
+        "state": "running",
+        "current_step": 3,  # the new field the hook should read
+        "acquired_at": "2026-04-30T00:00:00Z",
+        "lock_written_at": "2026-04-30T00:00:00Z",
+    }))
+    monkeypatch.setenv("PIPETTE_LOCK_PATH", str(lock))
+    return folder
+
+
+def test_emit_uses_step_from_lockfile_not_hardcoded_5(lockfile_at_step_3: Path):
+    """F8: the trace event the hook writes must carry the actual step
+    (3 in this fixture), not a hardcoded 5."""
+    from tools.pipette.subagent_stop import _emit
+    from tools.pipette.trace import Event  # noqa: F401 — used via _emit's append_event call
+
+    rc = _emit("allow", "test", folder=lockfile_at_step_3, task_id="t.1")
+    assert rc == 0
+    trace_line = (lockfile_at_step_3 / "trace.jsonl").read_text().strip().splitlines()[-1]
+    rec = json.loads(trace_line)
+    assert rec["event"] == "subagent_stop_hook"
+    assert rec["step"] == 3, f"expected step=3 from lockfile, got step={rec['step']}"

--- a/tests/pipette/test_subagent_stop_f8.py
+++ b/tests/pipette/test_subagent_stop_f8.py
@@ -26,9 +26,18 @@ def lockfile_at_step_3(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return folder
 
 
-def test_emit_uses_step_from_lockfile_not_hardcoded_5(lockfile_at_step_3: Path):
-    """F8: the trace event the hook writes must carry the actual step
-    (3 in this fixture), not a hardcoded 5."""
+def test_emit_uses_step_from_lockfile_when_set(lockfile_at_step_3: Path):
+    """F8 — read path: when the lockfile carries `current_step: N`, the
+    SubagentStop hook tags its trace event with that step rather than
+    the legacy hardcoded `step=5`.
+
+    NOTE: this test exercises the READ path only — the fixture writes
+    `current_step: 3` directly into the lockfile yaml. In production
+    today, the orchestrator's step-transition sites do not yet call
+    `lockfile.set_current_step` (that wiring is markdown-driven and
+    lands in a later chunk), so the hook falls back to `default=5` for
+    real runs. Direct test coverage for `set_current_step` itself lives
+    in `tests/pipette/test_lockfile.py`."""
     from tools.pipette.subagent_stop import _emit
     from tools.pipette.trace import Event  # noqa: F401 — used via _emit's append_event call
 

--- a/tools/pipette/cli.py
+++ b/tools/pipette/cli.py
@@ -241,12 +241,26 @@ def main(argv: list[str] | None = None) -> int:
         # OR a flat list of nodes with a `tested_files` field. Support both.
         edges = dump.get("edges") if isinstance(dump, dict) else dump
         tested_files: set[str] = set()
+        edges_with_tests_prefix = 0
         if isinstance(edges, list):
             for e in edges:
                 src = (e.get("from") or {}).get("source_file") if isinstance(e, dict) else None
                 dst = (e.get("to") or {}).get("source_file") if isinstance(e, dict) else None
                 if src and dst and src.startswith("tests/"):
                     tested_files.add(dst)
+                    edges_with_tests_prefix += 1
+        # F3: shape validation. If the dump claims edges but none have a
+        # tests/-prefixed source_file, the dump shape is malformed and the
+        # coverage map will be all-uncovered — silently triggering TDD
+        # enforcement spuriously. Warn loudly to stderr.
+        if isinstance(edges, list) and len(edges) > 0 and edges_with_tests_prefix == 0:
+            print(
+                "pipette: warning — coverage dump appears malformed "
+                "(no test→source edges with `from.source_file` starting with 'tests/'); "
+                "coverage map will be all-uncovered. "
+                "Verify dump shape: {edges:[{from:{source_file:'tests/...'}, to:{source_file:'...'}}]}",
+                file=sys.stderr,
+            )
         files_map = {f: (0.85 if f in tested_files else 0.30) for f in args.affected_files}
         out = {"_method": "graph_approx_v1", "files": files_map}
         Path(args.output).write_text(_json.dumps(out, indent=2))

--- a/tools/pipette/cli.py
+++ b/tools/pipette/cli.py
@@ -249,18 +249,33 @@ def main(argv: list[str] | None = None) -> int:
                 if src and dst and src.startswith("tests/"):
                     tested_files.add(dst)
                     edges_with_tests_prefix += 1
-        # F3: shape validation. If the dump claims edges but none have a
-        # tests/-prefixed source_file, the dump shape is malformed and the
-        # coverage map will be all-uncovered — silently triggering TDD
-        # enforcement spuriously. Warn loudly to stderr.
-        if isinstance(edges, list) and len(edges) > 0 and edges_with_tests_prefix == 0:
-            print(
-                "pipette: warning — coverage dump appears malformed "
-                "(no test→source edges with `from.source_file` starting with 'tests/'); "
-                "coverage map will be all-uncovered. "
-                "Verify dump shape: {edges:[{from:{source_file:'tests/...'}, to:{source_file:'...'}}]}",
-                file=sys.stderr,
-            )
+        # F3: shape validation. The coverage map is silently wrong when
+        # the dump's edges lack `tests/`-prefixed source_files. Two warning
+        # tiers:
+        #   (1) all-or-nothing — len > 0 and zero tests-prefixed → almost
+        #       certainly malformed (the 2026-04-28 silent-failure shape).
+        #   (2) majority-non-test — len >= 5 and ratio < 50% → likely
+        #       partial corruption (e.g., dump producer mid-refactor).
+        # Both warn loudly to stderr; rc unchanged (warning, not error).
+        if isinstance(edges, list) and len(edges) > 0:
+            ratio = edges_with_tests_prefix / len(edges)
+            if edges_with_tests_prefix == 0:
+                print(
+                    "pipette: warning — coverage dump appears malformed "
+                    "(no test→source edges with `from.source_file` starting with 'tests/'); "
+                    "coverage map will be all-uncovered. "
+                    "Verify dump shape: {edges:[{from:{source_file:'tests/...'}, to:{source_file:'...'}}]}",
+                    file=sys.stderr,
+                )
+            elif len(edges) >= 5 and ratio < 0.5:
+                print(
+                    f"pipette: warning — coverage dump appears partially malformed "
+                    f"(only {edges_with_tests_prefix}/{len(edges)} edges = "
+                    f"{ratio:.0%} have `from.source_file` starting with 'tests/'); "
+                    f"the coverage map for non-tests/-prefixed source files will be all-uncovered. "
+                    f"Verify dump shape: {{edges:[{{from:{{source_file:'tests/...'}}, to:{{source_file:'...'}}}}]}}",
+                    file=sys.stderr,
+                )
         files_map = {f: (0.85 if f in tested_files else 0.30) for f in args.affected_files}
         out = {"_method": "graph_approx_v1", "files": files_map}
         Path(args.output).write_text(_json.dumps(out, indent=2))

--- a/tools/pipette/doctor.py
+++ b/tools/pipette/doctor.py
@@ -20,6 +20,7 @@ class CheckResult:
     ok: bool
     message: str = ""
     fix: str = ""
+    severity: str = "fail"  # 'fail' (❌) or 'warn' (⚠) when ok is False
 
 
 def _verify_no_mistakes() -> tuple[bool, str]:
@@ -48,6 +49,33 @@ def _verify_code_review_graph_cli_and_mcp() -> tuple[bool, str]:
     if "code-review-graph" not in enabled:
         return False, f"`code-review-graph` not in enabledMcpjsonServers: {enabled}"
     return True, "CLI status OK + MCP enabled in settings.local.json"
+
+def _session_exposes_mcp_tools(prefix: str) -> bool:
+    """Probe whether the running Claude Code session has tools matching
+    `prefix` exposed (e.g., 'mcp__code-review-graph__'). Implementation
+    detail: Claude Code writes the deferred-tool list to an env var or a
+    well-known path on session start. If we can't read it, return False
+    (which downstream `_verify_code_review_graph_session_probe` interprets
+    as 'not exposed' → WARN). This is patchable in tests."""
+    import os
+    # Claude Code exposes the available tool prefixes via this env var when
+    # the session starts. Best-effort: if it's missing, treat as "tools not
+    # exposed" (the conservative answer for F1).
+    raw = os.environ.get("CLAUDE_CODE_AVAILABLE_TOOL_PREFIXES", "")
+    return prefix in {p.strip() for p in raw.split(",") if p.strip()}
+
+
+def _verify_code_review_graph_session_probe() -> tuple[bool, str]:
+    """F1: in-session probe — confirms the mcp__code-review-graph__ tools
+    are actually exposed in the running session, not just configured.
+    Returns (False, msg) when configured-but-not-exposed; the caller's
+    Check should classify this as WARN, not FAIL — fallback paths (SQLite,
+    Grep) still let the pipeline run."""
+    if _session_exposes_mcp_tools("mcp__code-review-graph__"):
+        return True, "mcp__code-review-graph__ tools exposed in session"
+    return False, ("MCP server configured but tools not exposed in session — "
+                   "restart Claude Code or check `claude --mcp-debug`")
+
 
 def _verify_post_commit_hook() -> tuple[bool, str]:
     p = Path(".git/hooks/post-commit")
@@ -141,7 +169,16 @@ CHECKS: list[Check] = [
           "Ensure `tools/pipette/validate_pipeline_graph.py` exists and is importable. (Replaces the spec's Agentproof reference; see plan §1.)"),
     Check("filesystem supports O_EXCL", _verify_filesystem,
           "pipette refuses to run on filesystems without reliable O_EXCL semantics (e.g., NFS, FUSE). Run pipette on a local APFS/ext4/btrfs volume."),
+    Check("code-review-graph MCP tools exposed in session (F1)", _verify_code_review_graph_session_probe,
+          "MCP tools not visible in this session — restart Claude Code or run `claude --mcp-debug` to diagnose. "
+          "Fallback paths (SQLite, Grep) are documented in tools/pipette/sanity/reviewers/_shared/mcp-fallback.md."),
 ]
+
+
+# Override severity for warn-only checks (F1 session probe is WARN, not FAIL)
+_CHECK_SEVERITY: dict[str, str] = {
+    "code-review-graph MCP tools exposed in session (F1)": "warn",
+}
 
 
 def run_checks(checks: list[Check]) -> list[CheckResult]:
@@ -151,19 +188,27 @@ def run_checks(checks: list[Check]) -> list[CheckResult]:
             ok, detail = c.verify()
         except Exception as e:
             ok, detail = False, f"{type(e).__name__}: {e}"
-        results.append(CheckResult(name=c.name, ok=ok, message=detail, fix=c.fix if not ok else ""))
+        severity = _CHECK_SEVERITY.get(c.name, "fail")
+        results.append(CheckResult(name=c.name, ok=ok, message=detail,
+                                   fix=c.fix if not ok else "", severity=severity))
     return results
 
 
 def _aggregate_rc(results: list[CheckResult]) -> int:
-    return 0 if all(r.ok for r in results) else 1
+    # WARN-severity failures are non-blocking (fallback paths exist); only FAIL-severity drives rc=1.
+    return 0 if all(r.ok or r.severity == "warn" for r in results) else 1
 
 
 def run_doctor() -> int:
     results = run_checks(CHECKS)
     for r in results:
-        mark = "✅" if r.ok else "❌"
-        print(f"{mark} {r.name}: {r.message}")
+        if r.ok:
+            glyph = "✅"
+        elif r.severity == "warn":
+            glyph = "⚠"
+        else:
+            glyph = "❌"
+        print(f"{glyph} {r.name}: {r.message}")
         if not r.ok:
             print(f"   FIX: {r.fix}")
     rc = _aggregate_rc(results)

--- a/tools/pipette/doctor.py
+++ b/tools/pipette/doctor.py
@@ -50,31 +50,47 @@ def _verify_code_review_graph_cli_and_mcp() -> tuple[bool, str]:
         return False, f"`code-review-graph` not in enabledMcpjsonServers: {enabled}"
     return True, "CLI status OK + MCP enabled in settings.local.json"
 
-def _session_exposes_mcp_tools(prefix: str) -> bool:
-    """Probe whether the running Claude Code session has tools matching
-    `prefix` exposed (e.g., 'mcp__code-review-graph__'). Implementation
-    detail: Claude Code writes the deferred-tool list to an env var or a
-    well-known path on session start. If we can't read it, return False
-    (which downstream `_verify_code_review_graph_session_probe` interprets
-    as 'not exposed' → WARN). This is patchable in tests."""
-    import os
-    # Claude Code exposes the available tool prefixes via this env var when
-    # the session starts. Best-effort: if it's missing, treat as "tools not
-    # exposed" (the conservative answer for F1).
-    raw = os.environ.get("CLAUDE_CODE_AVAILABLE_TOOL_PREFIXES", "")
-    return prefix in {p.strip() for p in raw.split(",") if p.strip()}
+def _probe_mcp_via_claude_cli(server_name: str) -> tuple[bool, str]:
+    """F1: probe MCP runtime status via `claude mcp get <server>`.
+
+    Returns (False, msg) when the server is missing or not connected;
+    (True, msg) when `Status: ✓ Connected` appears in the output. This
+    answers a different question than the legacy in-session env probe
+    (which Claude Code does not actually export): "is the MCP server
+    configured and currently reachable from this CLI?" — a stronger
+    proxy for "are its tools usable" than reading settings.local.json
+    alone.
+
+    Patchable in tests via `monkeypatch.setattr(doctor, "_probe_mcp_via_claude_cli", ...)`.
+    """
+    if shutil.which("claude") is None:
+        return False, "claude CLI not on PATH; cannot verify MCP runtime status"
+    try:
+        r = subprocess.run(
+            ["claude", "mcp", "get", server_name],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        return False, f"claude mcp probe failed: {type(e).__name__}: {e}"
+    if r.returncode != 0:
+        # `claude mcp get` exits nonzero with "No MCP server found with name: <x>".
+        return False, (f"{server_name} MCP not configured in this Claude Code installation — "
+                       f"`claude mcp add {server_name} ...` (or restart Claude Code if recently added)")
+    if "Connected" not in r.stdout:
+        return False, (f"{server_name} MCP configured but not connected — "
+                       f"check `claude --debug` or restart Claude Code")
+    return True, f"{server_name} MCP connected"
 
 
 def _verify_code_review_graph_session_probe() -> tuple[bool, str]:
-    """F1: in-session probe — confirms the mcp__code-review-graph__ tools
-    are actually exposed in the running session, not just configured.
-    Returns (False, msg) when configured-but-not-exposed; the caller's
-    Check should classify this as WARN, not FAIL — fallback paths (SQLite,
-    Grep) still let the pipeline run."""
-    if _session_exposes_mcp_tools("mcp__code-review-graph__"):
-        return True, "mcp__code-review-graph__ tools exposed in session"
-    return False, ("MCP server configured but tools not exposed in session — "
-                   "restart Claude Code or check `claude --mcp-debug`")
+    """F1: confirms the code-review-graph MCP server is reachable.
+
+    Wraps `_probe_mcp_via_claude_cli` so the surface is named after the
+    pipette concern rather than the implementation. Returns (False, msg)
+    when missing/disconnected; the caller's Check classifies this as WARN
+    (not FAIL) since fallback paths (SQLite, Grep) still let the pipeline
+    run — see tools/pipette/sanity/reviewers/_shared/mcp-fallback.md."""
+    return _probe_mcp_via_claude_cli("code-review-graph")
 
 
 def _verify_post_commit_hook() -> tuple[bool, str]:
@@ -169,15 +185,17 @@ CHECKS: list[Check] = [
           "Ensure `tools/pipette/validate_pipeline_graph.py` exists and is importable. (Replaces the spec's Agentproof reference; see plan §1.)"),
     Check("filesystem supports O_EXCL", _verify_filesystem,
           "pipette refuses to run on filesystems without reliable O_EXCL semantics (e.g., NFS, FUSE). Run pipette on a local APFS/ext4/btrfs volume."),
-    Check("code-review-graph MCP tools exposed in session (F1)", _verify_code_review_graph_session_probe,
-          "MCP tools not visible in this session — restart Claude Code or run `claude --mcp-debug` to diagnose. "
+    Check("code-review-graph MCP runtime probe (F1)", _verify_code_review_graph_session_probe,
+          "code-review-graph MCP not configured or not connected. Try: "
+          "`claude mcp get code-review-graph` for status; reinstall via "
+          "`code-review-graph install --platform claude-code`; or restart Claude Code if recently added. "
           "Fallback paths (SQLite, Grep) are documented in tools/pipette/sanity/reviewers/_shared/mcp-fallback.md."),
 ]
 
 
 # Override severity for warn-only checks (F1 session probe is WARN, not FAIL)
 _CHECK_SEVERITY: dict[str, str] = {
-    "code-review-graph MCP tools exposed in session (F1)": "warn",
+    "code-review-graph MCP runtime probe (F1)": "warn",
 }
 
 

--- a/tools/pipette/lockfile.py
+++ b/tools/pipette/lockfile.py
@@ -175,6 +175,12 @@ def pause(lock_path: Path, *, paused_at_step: float | int, pause_reason: str) ->
     update_state(lock_path, state="paused", paused_at_step=paused_at_step, pause_reason=pause_reason)
 
 
+def set_current_step(lock_path: Path, step: float) -> None:
+    """F8 helper: orchestrator calls this on each step transition so the
+    SubagentStop hook can tag trace events with the right step."""
+    update_state(lock_path, current_step=step)
+
+
 def resume(lock_path: Path, *, topic: str) -> None:
     """Transition paused → running. Refuses any other state."""
     if not lock_path.exists():

--- a/tools/pipette/sanity/reviewers/_shared/mcp-fallback.md
+++ b/tools/pipette/sanity/reviewers/_shared/mcp-fallback.md
@@ -1,0 +1,36 @@
+# MCP fallback for `code-review-graph`
+
+If `mcp__code-review-graph__*` tools are not exposed in the running session
+(the doctor's F1 in-session probe will WARN about this), use one of these
+fallbacks instead of waiting on tool turns to rediscover them:
+
+## SQLite fallback
+
+The graph database lives at `.code-review-graph/graph.db` (relative to repo
+root). Open with:
+
+```bash
+sqlite3 .code-review-graph/graph.db
+```
+
+Useful schemas:
+- `nodes(id, kind, qualified_name, source_file, line_start, line_end)`
+- `edges(id, kind, src_id, dst_id)` where `kind` includes `calls`, `imports`, `tests`
+
+Example query (test→source coverage):
+
+```sql
+SELECT n_src.source_file AS test_file, n_dst.source_file AS source_file
+FROM edges e
+JOIN nodes n_src ON e.src_id = n_src.id
+JOIN nodes n_dst ON e.dst_id = n_dst.id
+WHERE e.kind = 'tests';
+```
+
+## Grep fallback
+
+For a quick "where is this symbol used?" the Grep tool with a fully
+qualified name (`MyClass.my_method` or `module.function`) is fast and cheap.
+Trade-off: misses dynamic dispatch and indirect call sites — Grep is a
+floor, not a ceiling. (See user memory: "Graph counts are a floor, not a
+ceiling.")

--- a/tools/pipette/sanity/reviewers/contracts.md
+++ b/tools/pipette/sanity/reviewers/contracts.md
@@ -26,3 +26,7 @@ For each finding, emit:
 ```
 
 No prose outside the JSON. No code fences. The orchestrator parses your stdout as JSON and rejects anything else.
+
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.

--- a/tools/pipette/sanity/reviewers/contracts.md
+++ b/tools/pipette/sanity/reviewers/contracts.md
@@ -5,6 +5,10 @@ You will receive: `00-graph-context.md`, `01-grill.md`, `02-diagram.{mmd|excalid
 
 Your job: flag invented APIs, missing dependencies, and type mismatches in the grill summary, glossary, and diagram against the **real symbols** present in `00-graph-context.md`.
 
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.
+
 For each finding, emit:
 - reviewer: "contracts"
 - severity: critical | high | medium | low | polish
@@ -26,7 +30,3 @@ For each finding, emit:
 ```
 
 No prose outside the JSON. No code fences. The orchestrator parses your stdout as JSON and rejects anything else.
-
-If the MCP tools are not exposed in this session, use the fallbacks
-documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
-(SQLite + Grep) rather than burning tool turns rediscovering them.

--- a/tools/pipette/sanity/reviewers/coverage.md
+++ b/tools/pipette/sanity/reviewers/coverage.md
@@ -5,6 +5,10 @@ You will receive: `00-graph-context.md`, `01-grill.md`, `02-diagram.{mmd|excalid
 
 Your job: read the coverage map embedded in `00-graph-context.md` and flag any proposed changes that touch currently untested code, as well as grill summaries that lack a concrete test plan for new or modified behaviour.
 
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.
+
 For each finding, emit:
 - reviewer: "coverage"
 - severity: critical | high | medium | low | polish
@@ -26,7 +30,3 @@ For each finding, emit:
 ```
 
 No prose outside the JSON. No code fences. The orchestrator parses your stdout as JSON and rejects anything else.
-
-If the MCP tools are not exposed in this session, use the fallbacks
-documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
-(SQLite + Grep) rather than burning tool turns rediscovering them.

--- a/tools/pipette/sanity/reviewers/coverage.md
+++ b/tools/pipette/sanity/reviewers/coverage.md
@@ -26,3 +26,7 @@ For each finding, emit:
 ```
 
 No prose outside the JSON. No code fences. The orchestrator parses your stdout as JSON and rejects anything else.
+
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.

--- a/tools/pipette/sanity/reviewers/glossary.md
+++ b/tools/pipette/sanity/reviewers/glossary.md
@@ -26,3 +26,7 @@ For each finding, emit:
 ```
 
 No prose outside the JSON. No code fences. The orchestrator parses your stdout as JSON and rejects anything else.
+
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.

--- a/tools/pipette/sanity/reviewers/glossary.md
+++ b/tools/pipette/sanity/reviewers/glossary.md
@@ -5,6 +5,10 @@ You will receive: `00-graph-context.md`, `01-grill.md`, `02-diagram.{mmd|excalid
 
 Your job: check every domain term introduced or used in the grill summary and diagram against the canonical definitions in `_meta/CONTEXT.md` (the project's ubiquitous-language glossary, updated inline by `grill-with-docs` during Step 1). Flag synonyms (two terms used for the same concept) and undefined terms (terms used but not defined in CONTEXT.md).
 
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.
+
 For each finding, emit:
 - reviewer: "glossary"
 - severity: critical | high | medium | low | polish
@@ -26,7 +30,3 @@ For each finding, emit:
 ```
 
 No prose outside the JSON. No code fences. The orchestrator parses your stdout as JSON and rejects anything else.
-
-If the MCP tools are not exposed in this session, use the fallbacks
-documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
-(SQLite + Grep) rather than burning tool turns rediscovering them.

--- a/tools/pipette/sanity/reviewers/impact.md
+++ b/tools/pipette/sanity/reviewers/impact.md
@@ -5,6 +5,10 @@ You will receive: `00-graph-context.md`, `01-grill.md`, `02-diagram.{mmd|excalid
 
 Your job: flag missed callers and untested affected paths by re-running `mcp__code-review-graph__get_affected_flows` against the proposal and comparing the results to what is acknowledged in the grill summary and diagram.
 
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.
+
 For each finding, emit:
 - reviewer: "impact"
 - severity: critical | high | medium | low | polish

--- a/tools/pipette/sanity/reviewers/verifier.md
+++ b/tools/pipette/sanity/reviewers/verifier.md
@@ -4,6 +4,10 @@ You are the **verifier** for /pipette Step 3. Four reviewers have produced findi
 For each finding from the 4 reviewers below:
 1. Read the cited evidence (file paths, symbol names from `00-graph-context.md`).
 2. Use the `code-review-graph` MCP (`mcp__code-review-graph__query_graph`, `mcp__code-review-graph__get_review_context`) to verify the claim against current code.
+
+If the MCP tools are not exposed in this session, use the fallbacks
+documented in `tools/pipette/sanity/reviewers/_shared/mcp-fallback.md`
+(SQLite + Grep) rather than burning tool turns rediscovering them.
 3. Re-score `confidence` (0.0–1.0) based on what you found. If the original reviewer was hallucinating a non-existent symbol, score 0.0. If the reviewer's claim is verified by inspection, score 0.9+. If ambiguous, score 0.4–0.7.
 4. Drop findings where you cannot locate the cited evidence at all.
 

--- a/tools/pipette/subagent_stop.py
+++ b/tools/pipette/subagent_stop.py
@@ -77,14 +77,35 @@ LLM_RETRY_LIMIT = 3
 LLM_TIMEOUT_S = 120
 
 
+def _read_current_step_from_lockfile(default: float = 5) -> float:
+    """F8: hook tags trace events with the actual pipeline step rather than
+    a hardcoded 5. The lockfile carries `current_step` (set by the orchestrator
+    on each step transition); read it here. Returns `default` if the lockfile
+    is missing or doesn't carry the field — preserves prior behavior on
+    unrecognized state rather than failing the hook."""
+    try:
+        cur = yaml.safe_load(_lock_path().read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return default
+    val = cur.get("current_step")
+    if isinstance(val, (int, float)):
+        return float(val)
+    # Fallback to paused_at_step if running-state field is missing
+    paused = cur.get("paused_at_step")
+    if isinstance(paused, (int, float)):
+        return float(paused)
+    return default
+
+
 def _emit(decision: str, reason: str, *, folder: Path | None = None, task_id: str | None = None) -> int:
     out = {"permissionDecision": decision, "reason": reason}
     json.dump(out, sys.stdout)
     if folder is not None:
         try:
+            step = _read_current_step_from_lockfile(default=5)
             append_event(
                 folder / "trace.jsonl",
-                Event(step=5, event="subagent_stop_hook", decision=decision,
+                Event(step=step, event="subagent_stop_hook", decision=decision,
                       extra={"task_id": task_id, "reason": reason}),
             )
         except OSError:


### PR DESCRIPTION
## Summary

Reopens the work from PR #62 (closed when dev-fresh archived). Now targets \`main\`. Clean rebase against main.

Implements Chunk C: F1 doctor MCP probe via \`claude mcp get\`; F3 build-coverage-map malformed-dump warning (binary + ratio thresholds); F5 shared MCP-fallback reference at consistent line 9 of all 5 reviewer prompts; F8 SubagentStop hook reads step from lockfile (read path tested; production wiring deferred to future markdown change).

## Test plan

- [x] \`pytest tests/pipette/\` — all green
- [x] Spec + code-quality review subagents both ✅ (with code-review fixes applied: \`claude mcp get\`-based probe, ratio threshold for F3, prompt placement consistency, F8 test renamed for honesty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)