### PR TITLE
feat(pipette): macro gate — F15 heuristic + F14 lite mode (Chunk G, reopened)

### DIFF
--- a/.claude/commands/pipette-lite.md
+++ b/.claude/commands/pipette-lite.md
@@ -1,0 +1,55 @@
+---
+description: Heavy-planning pipeline (lite). Skips Step 3 hard gate unconditionally — for low-stakes runs.
+---
+
+# pipette-lite
+
+Run the pipette pipeline without the Step 3 hard gate.
+
+**When to use:** bug fixes, single-file features, dev-tooling — anything that
+doesn't touch prod customer surface. F15's heuristic auto-pass already
+short-circuits well-tested low-risk runs in default `/pipette`; reach for
+`/pipette-lite` only when you've consciously decided the topic doesn't need
+multi-reviewer review even if F15 wouldn't auto-pass.
+
+**Cost:** ~60–100k tokens for a small task vs. ~500k for full pipette.
+
+**What's preserved:** Steps 0, 1, 2, 4, 5, 6, 7. Single-subagent only — no
+best-of-N. Lockfile, trace.jsonl, and audit trail behave identically to
+default `/pipette`.
+
+**What's skipped:** Step 3 hard gate (no reviewers, no verifier, no gemini
+critique). The orchestrator records `step3_skipped reason=lite_mode` on the
+trace so the audit log captures the override.
+
+## Procedure
+
+Invoke the same pipette orchestrator with `--lite` (or equivalent flag)
+that calls `lite_pipeline_steps()` and `should_run_step3(..., lite_mode=True)`.
+The orchestrator markdown for `/pipette` is the source of truth for the
+step-by-step procedure; this command differs only in the Step 3 gate.
+
+Before any reviewer dispatch, the markdown must record the lite-mode skip
+on the trace:
+
+```bash
+pipette trace-append --folder "$PIPETTE_FOLDER" --step 3 --event step3_skipped
+# Then pass --data 'reason=lite_mode' once Chunk B's trace-append --data flag lands
+```
+
+This emits `step3_skipped reason=lite_mode` to trace.jsonl so the audit log
+captures the override. Do not silently skip — the trace event is the paper trail.
+
+## Step subset
+
+```bash
+pipette lite-pipeline-steps
+# stdout: [0, 1, 2, 4, 5, 6, 7]
+```
+
+## Gate query (for use in conditional markdown)
+
+```bash
+pipette should-run-step3 --folder "$PIPETTE_FOLDER" --lite
+# stdout: false  (always — lite mode is an absolute override)
+```

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .claude/commands/*
 !.claude/commands/pipette.md
 !.claude/commands/pipette-weekly.md
+!.claude/commands/pipette-lite.md
 .kiro/
 .playwright-cli/
 .firecrawl/

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Reinstall git hooks for this repo.
+# Run after fresh clone or if .git/hooks is wiped.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+hooks_dir="$repo_root/.git/hooks"
+mkdir -p "$hooks_dir"
+
+cat > "$hooks_dir/pre-commit" <<'HOOK'
+#!/bin/sh
+# Block commits containing git conflict markers (stash-pop / merge / rebase residue).
+# Reinstall via scripts/install-hooks.sh if .git is recreated.
+
+files=$(git diff --cached --name-only --diff-filter=AM)
+if [ -n "$files" ]; then
+    hits=""
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        nums=$(git diff --cached --numstat -- "$f" 2>/dev/null | awk '{print $1, $2}')
+        case "$nums" in
+            "- "*|*" -") continue ;;
+        esac
+        match=$(git show ":$f" 2>/dev/null | grep -nE '^(<{7}|>{7}|={7})( |$)' || true)
+        if [ -n "$match" ]; then
+            hits="$hits
+--- $f ---
+$match"
+        fi
+    done <<EOF
+$files
+EOF
+
+    if [ -n "$hits" ]; then
+        echo "Commit blocked: git conflict markers found in staged content."
+        printf '%s\n' "$hits"
+        echo ""
+        echo "Resolve markers before committing."
+        echo "To bypass (NOT recommended), use: git commit --no-verify"
+        exit 1
+    fi
+fi
+
+if command -v code-review-graph >/dev/null 2>&1; then
+    code-review-graph detect-changes --brief || true
+fi
+HOOK
+
+chmod +x "$hooks_dir/pre-commit"
+echo "Installed: $hooks_dir/pre-commit"

--- a/tests/pipette/test_cli.py
+++ b/tests/pipette/test_cli.py
@@ -245,3 +245,22 @@ def test_build_coverage_map_warns_on_malformed_dump(tmp_path: Path, capsys: pyte
     err = capsys.readouterr().err
     assert "warning" in err.lower()
     assert "malformed" in err.lower() or "no test→source edges" in err.lower()
+
+
+def test_step3_heuristic_check_cli_returns_json_decision(tmp_path: Path):
+    """F15 CLI: step3-heuristic-check prints a JSON decision and exits 0."""
+    import json
+    folder = tmp_path / "feature-x"
+    folder.mkdir()
+    # Write coverage_map.json and 01-grill.md so all thresholds pass.
+    (folder / "coverage_map.json").write_text(
+        json.dumps({"_method": "graph_approx_v1", "files": {"src/foo.py": 0.95}})
+    )
+    (folder / "01-grill.md").write_text(
+        "# Grill\n\n<!-- pipette-meta total_changed_lines=10 max_risk_score=0.10 -->\n"
+    )
+    r = _run("step3-heuristic-check", "--folder", str(folder))
+    assert r.returncode == 0, r.stderr
+    decision = json.loads(r.stdout.strip())
+    assert decision["auto_pass"] is True
+    assert decision["reason"] == "heuristic_auto_pass"

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -1,0 +1,99 @@
+"""Tests for orchestrator dispatch decisions — Chunk G (F15, F14) and Chunk F (F11–F13)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# F15 thresholds (hardcoded constants per spec scope cuts)
+COVERAGE_FLOOR = 0.80
+RISK_CEILING = 0.30
+LINES_CEILING = 50
+
+
+@pytest.fixture
+def folder_with_artifacts(tmp_path: Path):
+    """A pipeline folder with the artifacts F15 inspects."""
+    folder = tmp_path / "feature-x"
+    folder.mkdir()
+    return folder
+
+
+def _write_coverage_map(folder: Path, files_map: dict[str, float]):
+    (folder / "coverage_map.json").write_text(
+        json.dumps({"_method": "graph_approx_v1", "files": files_map})
+    )
+
+
+def _write_grill_summary(folder: Path, total_changed_lines: int, max_risk_score: float):
+    (folder / "01-grill.md").write_text(
+        f"# Grill summary\n\n"
+        f"<!-- pipette-meta total_changed_lines={total_changed_lines} max_risk_score={max_risk_score} -->\n"
+        f"...\n"
+    )
+
+
+def test_f15_auto_pass_when_all_thresholds_met(folder_with_artifacts: Path):
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    _write_coverage_map(folder_with_artifacts, {"src/foo.py": 0.95, "src/bar.py": 0.88})
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=20, max_risk_score=0.10)
+    decision = step3_heuristic_decision(folder=folder_with_artifacts)
+    assert decision.auto_pass is True
+    assert decision.reason == "heuristic_auto_pass"
+
+
+def test_f15_falls_through_on_low_coverage(folder_with_artifacts: Path):
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    _write_coverage_map(folder_with_artifacts, {"src/foo.py": 0.50})
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=10, max_risk_score=0.10)
+    decision = step3_heuristic_decision(folder=folder_with_artifacts)
+    assert decision.auto_pass is False
+    assert decision.reason == "coverage_below_80"
+
+
+def test_f15_falls_through_on_high_risk(folder_with_artifacts: Path):
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    _write_coverage_map(folder_with_artifacts, {"src/foo.py": 0.95})
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=10, max_risk_score=0.50)
+    decision = step3_heuristic_decision(folder=folder_with_artifacts)
+    assert decision.auto_pass is False
+    assert decision.reason == "risk_above_30"
+
+
+def test_f15_falls_through_on_large_diff(folder_with_artifacts: Path):
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    _write_coverage_map(folder_with_artifacts, {"src/foo.py": 0.95})
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=200, max_risk_score=0.10)
+    decision = step3_heuristic_decision(folder=folder_with_artifacts)
+    assert decision.auto_pass is False
+    assert decision.reason == "lines_above_50"
+
+
+def test_f15_falls_through_on_malformed_coverage(folder_with_artifacts: Path):
+    """F15 + F3 dependency: malformed coverage data → fall through with logged reason."""
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    (folder_with_artifacts / "coverage_map.json").write_text("{not json}")
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=10, max_risk_score=0.10)
+    decision = step3_heuristic_decision(folder=folder_with_artifacts)
+    assert decision.auto_pass is False
+    assert decision.reason == "coverage_malformed"
+
+
+def test_f15_emits_autopass_rejected_trace_event(folder_with_artifacts: Path):
+    """Per spec enhancement: each fall-through writes a structured event."""
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    _write_coverage_map(folder_with_artifacts, {"src/foo.py": 0.40})
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=10, max_risk_score=0.10)
+    step3_heuristic_decision(folder=folder_with_artifacts, write_trace=True)
+    line = (folder_with_artifacts / "trace.jsonl").read_text().strip().splitlines()[-1]
+    rec = json.loads(line)
+    assert rec["event"] == "autopass_rejected"
+    assert rec["reason"] == "coverage_below_80"

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -97,3 +97,25 @@ def test_f15_emits_autopass_rejected_trace_event(folder_with_artifacts: Path):
     rec = json.loads(line)
     assert rec["event"] == "autopass_rejected"
     assert rec["reason"] == "coverage_below_80"
+
+
+def test_f14_lite_mode_overrides_f15_unconditionally(folder_with_artifacts: Path):
+    """Spec enhancement: lite mode is an absolute manual override.
+    Even synthetic high-risk-score input that would fail F15 must still
+    bypass Step 3 in lite mode."""
+    from tools.pipette.orchestrator import should_run_step3
+
+    _write_coverage_map(folder_with_artifacts, {"src/foo.py": 0.40})
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=999, max_risk_score=0.99)
+    # Lite mode: never run Step 3, regardless of heuristic.
+    assert should_run_step3(folder=folder_with_artifacts, lite_mode=True) is False
+    # Default: F15 fall-through → run Step 3.
+    assert should_run_step3(folder=folder_with_artifacts, lite_mode=False) is True
+
+
+def test_lite_mode_runs_correct_step_subset(folder_with_artifacts: Path, monkeypatch: pytest.MonkeyPatch):
+    """Lite path runs Steps 0, 1, 2, 4, 5, 6, 7 — never Step 3."""
+    from tools.pipette.orchestrator import lite_pipeline_steps
+    steps = lite_pipeline_steps()
+    assert 3 not in steps
+    assert {0, 1, 2, 4, 5, 6, 7}.issubset(set(steps))

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -76,7 +76,8 @@ def test_f15_falls_through_on_large_diff(folder_with_artifacts: Path):
 
 
 def test_f15_falls_through_on_malformed_coverage(folder_with_artifacts: Path):
-    """F15 + F3 dependency: malformed coverage data → fall through with logged reason."""
+    """F15 + F3 dependency: malformed coverage data → fall through with
+    reason='coverage_malformed'."""
     from tools.pipette.orchestrator import step3_heuristic_decision
 
     (folder_with_artifacts / "coverage_map.json").write_text("{not json}")
@@ -84,6 +85,20 @@ def test_f15_falls_through_on_malformed_coverage(folder_with_artifacts: Path):
     decision = step3_heuristic_decision(folder=folder_with_artifacts)
     assert decision.auto_pass is False
     assert decision.reason == "coverage_malformed"
+
+
+def test_f15_falls_through_on_missing_coverage(folder_with_artifacts: Path):
+    """F15 distinguishes 'Step 2 didn't produce coverage_map.json'
+    (coverage_missing) from 'the file is corrupt' (coverage_malformed).
+    Both block auto-pass but imply different fixes; the audit trail's
+    `autopass_rejected reason=...` keeps them distinct."""
+    from tools.pipette.orchestrator import step3_heuristic_decision
+
+    # No coverage_map.json written.
+    _write_grill_summary(folder_with_artifacts, total_changed_lines=10, max_risk_score=0.10)
+    decision = step3_heuristic_decision(folder=folder_with_artifacts)
+    assert decision.auto_pass is False
+    assert decision.reason == "coverage_missing"
 
 
 def test_f15_emits_autopass_rejected_trace_event(folder_with_artifacts: Path):

--- a/tools/pipette/cli.py
+++ b/tools/pipette/cli.py
@@ -113,6 +113,21 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="list of affected source files to compute coverage for")
     cm.add_argument("--output", required=True, help="write coverage_map.json here")
 
+    sh = sub.add_parser("step3-heuristic-check",
+                        help="F15: run Step 3 heuristic gate; prints JSON decision to stdout (exit 0 always)")
+    sh.add_argument("--folder", required=True,
+                    help="per-feature pipeline folder (contains coverage_map.json and 01-grill.md)")
+
+    lps = sub.add_parser("lite-pipeline-steps",
+                         help="F14: print the step list that pipette-lite runs as JSON")
+
+    srs = sub.add_parser("should-run-step3",
+                         help="F14/F15: combined gate; prints 'true' or 'false' to stdout (exit 0 always)")
+    srs.add_argument("--folder", required=True,
+                     help="per-feature pipeline folder")
+    srs.add_argument("--lite", action="store_true", default=False,
+                     help="if set, lite mode is active (Step 3 is unconditionally skipped)")
+
     return p
 
 
@@ -279,6 +294,22 @@ def main(argv: list[str] | None = None) -> int:
         files_map = {f: (0.85 if f in tested_files else 0.30) for f in args.affected_files}
         out = {"_method": "graph_approx_v1", "files": files_map}
         Path(args.output).write_text(_json.dumps(out, indent=2))
+        return 0
+    if args.cmd == "step3-heuristic-check":
+        import json as _json
+        from tools.pipette.orchestrator import step3_heuristic_decision
+        decision = step3_heuristic_decision(folder=Path(args.folder), write_trace=True)
+        print(_json.dumps({"auto_pass": decision.auto_pass, "reason": decision.reason}))
+        return 0  # always 0: decision is informational; slash-command markdown branches on JSON
+    if args.cmd == "lite-pipeline-steps":
+        import json as _json
+        from tools.pipette.orchestrator import lite_pipeline_steps
+        print(_json.dumps(lite_pipeline_steps()))
+        return 0
+    if args.cmd == "should-run-step3":
+        from tools.pipette.orchestrator import should_run_step3
+        result = should_run_step3(folder=Path(args.folder), lite_mode=args.lite)
+        print("true" if result else "false")
         return 0
     parser.print_help()
     return 0

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -125,6 +125,87 @@ def recover_run(*, topic: str, root: Path) -> int:
     return 0
 
 
+from dataclasses import dataclass
+
+
+# F15 thresholds — hardcoded constants per spec scope cuts.
+# Tuning requires editing this file (deliberate; no scoring module).
+F15_COVERAGE_FLOOR = 0.80
+F15_RISK_CEILING = 0.30
+F15_LINES_CEILING = 50
+
+
+@dataclass
+class Step3HeuristicDecision:
+    auto_pass: bool
+    reason: str  # "heuristic_auto_pass" | "coverage_below_80" | "risk_above_30" | "lines_above_50" | "coverage_malformed" | "grill_meta_missing"
+
+
+def _read_grill_meta(folder: Path) -> tuple[int | None, float | None]:
+    """Parse the `<!-- pipette-meta total_changed_lines=N max_risk_score=F -->`
+    annotation that the grill writes into 01-grill.md. The grill prompt
+    instructs it to emit this block; if missing, both values are None and
+    F15 falls through (no auto-pass without a grounded count)."""
+    import re
+    p = folder / "01-grill.md"
+    if not p.exists():
+        return None, None
+    text = p.read_text()
+    m = re.search(r"pipette-meta\s+total_changed_lines=(\d+)\s+max_risk_score=([\d.]+)", text)
+    if not m:
+        return None, None
+    return int(m.group(1)), float(m.group(2))
+
+
+def _read_coverage_min(folder: Path) -> tuple[float | None, str | None]:
+    """Returns (min_coverage_across_affected, error_reason). On malformed
+    JSON or missing file, returns (None, 'coverage_malformed')."""
+    import json as _json
+    p = folder / "coverage_map.json"
+    if not p.exists():
+        return None, "coverage_malformed"
+    try:
+        data = _json.loads(p.read_text())
+    except _json.JSONDecodeError:
+        return None, "coverage_malformed"
+    files = data.get("files") if isinstance(data, dict) else None
+    if not isinstance(files, dict) or not files:
+        return None, "coverage_malformed"
+    return min(float(v) for v in files.values()), None
+
+
+def step3_heuristic_decision(*, folder: Path, write_trace: bool = False) -> "Step3HeuristicDecision":
+    """F15: gate at Step 3 entry. Auto-pass IFF all thresholds met.
+
+    On fall-through, optionally emits an `autopass_rejected` trace event
+    naming the failed threshold — needed for future threshold tuning.
+    """
+    cov_min, cov_err = _read_coverage_min(folder)
+    if cov_err:
+        decision = Step3HeuristicDecision(auto_pass=False, reason=cov_err)
+    elif cov_min < F15_COVERAGE_FLOOR:
+        decision = Step3HeuristicDecision(auto_pass=False, reason="coverage_below_80")
+    else:
+        lines, risk = _read_grill_meta(folder)
+        if lines is None or risk is None:
+            decision = Step3HeuristicDecision(auto_pass=False, reason="grill_meta_missing")
+        elif risk >= F15_RISK_CEILING:
+            decision = Step3HeuristicDecision(auto_pass=False, reason="risk_above_30")
+        elif lines >= F15_LINES_CEILING:
+            decision = Step3HeuristicDecision(auto_pass=False, reason="lines_above_50")
+        else:
+            decision = Step3HeuristicDecision(auto_pass=True, reason="heuristic_auto_pass")
+
+    if write_trace and not decision.auto_pass:
+        try:
+            append_event(folder / "trace.jsonl",
+                         Event(step=3, event="autopass_rejected",
+                               extra={"reason": decision.reason}))
+        except OSError:
+            pass
+    return decision
+
+
 def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     """§5.3: archive artifacts from step jump_back_to..highest into _attempts/N-<ts>/.
 

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -1,6 +1,9 @@
 # tools/pipette/orchestrator.py
 from __future__ import annotations
+import json
+import re
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
@@ -125,9 +128,6 @@ def recover_run(*, topic: str, root: Path) -> int:
     return 0
 
 
-from dataclasses import dataclass
-
-
 # F15 thresholds — hardcoded constants per spec scope cuts.
 # Tuning requires editing this file (deliberate; no scoring module).
 F15_COVERAGE_FLOOR = 0.80
@@ -137,16 +137,33 @@ F15_LINES_CEILING = 50
 
 @dataclass
 class Step3HeuristicDecision:
+    """Result of the F15 heuristic gate at Step 3 entry.
+
+    `reason` is one of:
+      "heuristic_auto_pass" — all thresholds met, skip Step 3 ceremony
+      "coverage_missing"    — coverage_map.json absent (Step 2 didn't produce it)
+      "coverage_malformed"  — coverage_map.json parse error or unexpected shape
+      "coverage_below_80"   — min coverage across affected files < F15_COVERAGE_FLOOR
+      "risk_above_30"       — max_risk_score >= F15_RISK_CEILING
+      "lines_above_50"      — total_changed_lines >= F15_LINES_CEILING
+      "grill_meta_missing"  — 01-grill.md present but lacks the pipette-meta comment
+    """
     auto_pass: bool
-    reason: str  # "heuristic_auto_pass" | "coverage_below_80" | "risk_above_30" | "lines_above_50" | "coverage_malformed" | "grill_meta_missing"
+    reason: str
 
 
 def _read_grill_meta(folder: Path) -> tuple[int | None, float | None]:
     """Parse the `<!-- pipette-meta total_changed_lines=N max_risk_score=F -->`
     annotation that the grill writes into 01-grill.md. The grill prompt
     instructs it to emit this block; if missing, both values are None and
-    F15 falls through (no auto-pass without a grounded count)."""
-    import re
+    F15 falls through (no auto-pass without a grounded count).
+
+    NOTE: until Chunk E lands the grill-prompt change that emits this
+    comment, every real grill output will lack the meta and F15 will
+    always fall through with reason='grill_meta_missing'. This is the
+    correct conservative behavior — auto-passing on missing meta would
+    be more permissive than spec'd.
+    """
     p = folder / "01-grill.md"
     if not p.exists():
         return None, None
@@ -158,15 +175,24 @@ def _read_grill_meta(folder: Path) -> tuple[int | None, float | None]:
 
 
 def _read_coverage_min(folder: Path) -> tuple[float | None, str | None]:
-    """Returns (min_coverage_across_affected, error_reason). On malformed
-    JSON or missing file, returns (None, 'coverage_malformed')."""
-    import json as _json
+    """Returns (min_coverage_across_affected, error_reason).
+
+    error_reason is one of:
+      "coverage_missing"   — coverage_map.json does not exist
+      "coverage_malformed" — JSON parse error or unexpected shape (e.g., no
+                             `files` dict, empty `files` dict)
+
+    Caller (step3_heuristic_decision) maps these distinct reasons through
+    to the final decision so the audit trail (`autopass_rejected reason=...`)
+    distinguishes "Step 2 didn't produce coverage_map.json" from "the file
+    is corrupt." Both are non-OK for F15, but they imply different fixes.
+    """
     p = folder / "coverage_map.json"
     if not p.exists():
-        return None, "coverage_malformed"
+        return None, "coverage_missing"
     try:
-        data = _json.loads(p.read_text())
-    except _json.JSONDecodeError:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError:
         return None, "coverage_malformed"
     files = data.get("files") if isinstance(data, dict) else None
     if not isinstance(files, dict) or not files:
@@ -181,8 +207,10 @@ def step3_heuristic_decision(*, folder: Path, write_trace: bool = False) -> "Ste
     naming the failed threshold — needed for future threshold tuning.
     """
     cov_min, cov_err = _read_coverage_min(folder)
-    if cov_err:
+    if cov_err is not None:
         decision = Step3HeuristicDecision(auto_pass=False, reason=cov_err)
+    elif cov_min is None:  # defensive: cov_err None + cov_min None should be impossible
+        decision = Step3HeuristicDecision(auto_pass=False, reason="coverage_malformed")
     elif cov_min < F15_COVERAGE_FLOOR:
         decision = Step3HeuristicDecision(auto_pass=False, reason="coverage_below_80")
     else:

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -206,6 +206,22 @@ def step3_heuristic_decision(*, folder: Path, write_trace: bool = False) -> "Ste
     return decision
 
 
+def should_run_step3(*, folder: Path, lite_mode: bool) -> bool:
+    """Combined gate. Lite mode is an absolute manual override (P-spec
+    enhancement #5): even if F15 demands a full review, lite skips Step 3.
+    Default path: respect F15 — auto-pass means skip, fall-through means run."""
+    if lite_mode:
+        return False
+    return not step3_heuristic_decision(folder=folder, write_trace=False).auto_pass
+
+
+def lite_pipeline_steps() -> list[float]:
+    """Steps that pipette-lite runs. Step 3 is unconditionally skipped;
+    best-of-N is disabled (single-subagent only) — the integration layer
+    is responsible for honoring the latter."""
+    return [0, 1, 2, 4, 5, 6, 7]
+
+
 def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     """§5.3: archive artifacts from step jump_back_to..highest into _attempts/N-<ts>/.
 


### PR DESCRIPTION
## Summary

Reopens the work from PR #63 (closed when dev-fresh archived). Now targets \`main\`. Clean rebase.

Implements Chunk G: F15 heuristic auto-pass at Step 3 entry with hardcoded thresholds (coverage ≥ 0.80, risk < 0.30, lines < 50); \`autopass_rejected\` trace events with distinct \`coverage_missing\` vs \`coverage_malformed\` reasons. F14 \`pipette-lite\` slash command bypasses Step 3 unconditionally as absolute manual override. 3 new CLI subcommands so the markdown can wire into Step 3 entry.

## Test plan

- [x] \`pytest tests/pipette/\` — all green
- [x] Spec + code-quality review subagents both ✅ (with defensive guards + split coverage reasons applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)