### PR TITLE
feat(pipette): Step 3 surface — F13 + F11 + F12 + F10 (Chunk F, reopened)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_JWT_SECRET=
 # Per-environment: localhost for dev, your Vercel/prod hostname for production.
 APP_BASE_URL=http://localhost:8000
+# Comma-separated allow-list for CORS. Defaults to localhost dev origins; set
+# to your prod hostname (e.g. https://app.socratink.ai) when deploying.
+CORS_ORIGINS=http://localhost:8000,http://127.0.0.1:8000
 # Fernet key. Generate with:
 #   python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # DO NOT reuse the same key across environments.

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,6 @@ b&a/
 .socratink-brain/.obsidian/
 docs/research/
 docs/pipeline/
-docs/design/artboards/platform-grid-loaded-concept-mockups.html
 # Added by code-review-graph
 .code-review-graph/
 docs/code-graph.html

--- a/docs/project/doc-map.md
+++ b/docs/project/doc-map.md
@@ -77,6 +77,7 @@ On all other topics (three-phase loop, four-state model implementation, routing,
 | Path | Status | Binding | Purpose |
 | --- | --- | --- | --- |
 | `docs/reference/example-extraction-output.json` | reference | no | Sample extraction output for prompts and testing. Not a contract. |
+| [reference/extraction-catalog.md](../reference/extraction-catalog.md) | reference | no | Inventory of backend, prompt, and frontend files involved in the extraction phase. Developer orientation aid; not a contract. |
 | `docs/reference/hermes-agent-concept-source.md` | reference | no | Compressed Socratink-ready source for creating a Hermes Agent documentation concept. Derived from public Nous Research Hermes Agent docs and kept under the current extraction input limit. |
 | `docs/reference/hermes-agent-docs-manifest.md` | reference | no | Full manifest of upstream Hermes Agent documentation pages, source paths, raw URLs, sizes, and headings used to build the compressed Hermes concept source. |
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 pytest-playwright==0.7.2
 playwright==1.59.0
 requests==2.33.1
-pydantic==2.13.3
 pyyaml==6.0.3

--- a/tests/pipette/test_archive_for_loop_back.py
+++ b/tests/pipette/test_archive_for_loop_back.py
@@ -1,0 +1,53 @@
+"""Tests for archive_for_loop_back — Chunk F (F10)."""
+from __future__ import annotations
+from pathlib import Path
+
+import pytest
+
+
+SCRATCH_FILES = [
+    "_reviewer-contracts.json",
+    "_reviewer-impact.json",
+    "_reviewer-glossary.json",
+    "_reviewer-coverage.json",
+    "_verifier-output.json",
+    "_verifier-survivors.json",
+    "_step3-prompt.txt",
+    "_gemini-stdout.log",
+]
+
+ORIGINAL_ARTIFACTS = ["01-grill.md", "02-diagram.mmd", "03-gemini-verdict.md"]
+
+
+def _populate(folder: Path):
+    folder.mkdir(parents=True, exist_ok=True)
+    for f in SCRATCH_FILES + ORIGINAL_ARTIFACTS:
+        (folder / f).write_text("placeholder")
+
+
+def test_archive_includes_step3_scratch(tmp_path: Path):
+    """F10: loop-back archive must include reviewer JSONs, verifier outputs,
+    Step 3 prompt, and gemini stdout — the audit trail for attempt 1."""
+    from tools.pipette.orchestrator import archive_for_loop_back
+    folder = tmp_path / "feature-x"
+    _populate(folder)
+    arch = archive_for_loop_back(folder=folder, jump_back_to=1.0)
+    archived = {p.name for p in arch.iterdir()}
+    for scratch in SCRATCH_FILES:
+        assert scratch in archived, f"F10: {scratch} should be archived but wasn't"
+    for original in ORIGINAL_ARTIFACTS:
+        assert original in archived, f"original artifact {original} should still be archived"
+
+
+def test_archive_does_not_fail_on_missing_scratch(tmp_path: Path):
+    """If a scratch file doesn't exist (e.g., Step 3 was a heuristic auto-pass),
+    archive_for_loop_back must not raise."""
+    from tools.pipette.orchestrator import archive_for_loop_back
+    folder = tmp_path / "feature-x"
+    folder.mkdir()
+    for f in ORIGINAL_ARTIFACTS:
+        (folder / f).write_text("placeholder")
+    arch = archive_for_loop_back(folder=folder, jump_back_to=1.0)
+    archived = {p.name for p in arch.iterdir()}
+    for original in ORIGINAL_ARTIFACTS:
+        assert original in archived

--- a/tests/pipette/test_archive_for_loop_back.py
+++ b/tests/pipette/test_archive_for_loop_back.py
@@ -4,17 +4,12 @@ from pathlib import Path
 
 import pytest
 
+from tools.pipette.orchestrator import _STEP3_SCRATCH
 
-SCRATCH_FILES = [
-    "_reviewer-contracts.json",
-    "_reviewer-impact.json",
-    "_reviewer-glossary.json",
-    "_reviewer-coverage.json",
-    "_verifier-output.json",
-    "_verifier-survivors.json",
-    "_step3-prompt.txt",
-    "_gemini-stdout.log",
-]
+
+# Single source of truth — drift between this test list and the production
+# constant would silently un-test new scratch files added later.
+SCRATCH_FILES = list(_STEP3_SCRATCH)
 
 ORIGINAL_ARTIFACTS = ["01-grill.md", "02-diagram.mmd", "03-gemini-verdict.md"]
 
@@ -51,3 +46,22 @@ def test_archive_does_not_fail_on_missing_scratch(tmp_path: Path):
     archived = {p.name for p in arch.iterdir()}
     for original in ORIGINAL_ARTIFACTS:
         assert original in archived
+
+
+def test_archive_handles_partial_scratch(tmp_path: Path):
+    """Mid-state: only some scratch files exist (e.g., reviewer dispatch
+    crashed mid-batch leaving 2 of 4 reviewer JSONs). archive_for_loop_back
+    must move the present ones without failing on absentees."""
+    from tools.pipette.orchestrator import archive_for_loop_back
+    folder = tmp_path / "feature-x"
+    folder.mkdir()
+    present = ["01-grill.md", "_reviewer-contracts.json", "_reviewer-impact.json"]
+    for f in present:
+        (folder / f).write_text("placeholder")
+    arch = archive_for_loop_back(folder=folder, jump_back_to=1.0)
+    archived = {p.name for p in arch.iterdir()}
+    assert "01-grill.md" in archived
+    assert "_reviewer-contracts.json" in archived
+    assert "_reviewer-impact.json" in archived
+    assert "_reviewer-glossary.json" not in archived  # never existed
+    assert "_reviewer-coverage.json" not in archived  # never existed

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -209,3 +209,36 @@ def test_f11_falls_back_to_full_dispatch_when_survivors_malformed(folder_with_ar
     result = reviewers_to_redispatch_from_folder(folder_with_artifacts)
     assert set(result.reviewers) == {"contracts", "impact", "glossary", "coverage"}
     assert result.fallback_reason == "survivors_unparseable"
+
+
+# ---------------------------------------------------------------------------
+# F12 — skip verifier on attempt >= 2 (with safety condition)
+# ---------------------------------------------------------------------------
+
+def test_f12_skips_verifier_when_prior_survivors_clean(folder_with_artifacts: Path):
+    """F12: skip verifier on attempt 2 IFF attempt 1's survivors file
+    exists and parses cleanly."""
+    import json
+    from tools.pipette.orchestrator import should_run_verifier_on_attempt
+    (folder_with_artifacts / "_verifier-survivors.json").write_text(
+        json.dumps({"contracts": [], "impact": [], "glossary": [], "coverage": []})
+    )
+    assert should_run_verifier_on_attempt(folder=folder_with_artifacts, attempt=2) is False
+
+
+def test_f12_runs_verifier_when_prior_survivors_missing(folder_with_artifacts: Path):
+    """Spec enhancement: if attempt 1's verifier crashed (no survivors file),
+    don't silently skip in attempt 2."""
+    from tools.pipette.orchestrator import should_run_verifier_on_attempt
+    assert should_run_verifier_on_attempt(folder=folder_with_artifacts, attempt=2) is True
+
+
+def test_f12_runs_verifier_when_prior_survivors_malformed(folder_with_artifacts: Path):
+    from tools.pipette.orchestrator import should_run_verifier_on_attempt
+    (folder_with_artifacts / "_verifier-survivors.json").write_text("not json")
+    assert should_run_verifier_on_attempt(folder=folder_with_artifacts, attempt=2) is True
+
+
+def test_f12_always_runs_verifier_on_attempt_1(folder_with_artifacts: Path):
+    from tools.pipette.orchestrator import should_run_verifier_on_attempt
+    assert should_run_verifier_on_attempt(folder=folder_with_artifacts, attempt=1) is True

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -178,3 +178,34 @@ def test_f13_unknown_reviewer_gets_full_stack():
     from tools.pipette.orchestrator import reviewer_artifacts
     artifacts = reviewer_artifacts("future_reviewer")
     assert "00-graph-context.md" in artifacts
+
+
+# ---------------------------------------------------------------------------
+# F11 — smart-reviewers redispatch on loop-back
+# ---------------------------------------------------------------------------
+
+def test_f11_smart_reviewers_skips_clean_reviewers_on_loopback(folder_with_artifacts: Path):
+    """F11: a reviewer with no >= medium findings in attempt 1 is not
+    redispatched in attempt 2."""
+    from tools.pipette.orchestrator import reviewers_to_redispatch
+    survivors = {
+        "contracts": [{"severity": "critical"}],
+        "impact":    [{"severity": "low"}],
+        "glossary":  [],
+        "coverage":  [{"severity": "medium"}],
+    }
+    to_dispatch = reviewers_to_redispatch(survivors)
+    assert set(to_dispatch) == {"contracts", "coverage"}
+    assert "glossary" not in to_dispatch
+    assert "impact" not in to_dispatch  # only `low` findings, no medium+
+
+
+def test_f11_falls_back_to_full_dispatch_when_survivors_malformed(folder_with_artifacts: Path):
+    """Spec enhancement: malformed/missing _verifier-survivors.json defaults to
+    full reviewer dispatch with a logged warning."""
+    from tools.pipette.orchestrator import reviewers_to_redispatch_from_folder
+
+    (folder_with_artifacts / "_verifier-survivors.json").write_text("{not json}")
+    result = reviewers_to_redispatch_from_folder(folder_with_artifacts)
+    assert set(result.reviewers) == {"contracts", "impact", "glossary", "coverage"}
+    assert result.fallback_reason == "survivors_unparseable"

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -14,10 +14,17 @@ LINES_CEILING = 50
 
 
 @pytest.fixture
-def folder_with_artifacts(tmp_path: Path):
-    """A pipeline folder with the artifacts F15 inspects."""
+def folder_with_artifacts(tmp_path: Path) -> Path:
+    """A pipeline folder with standard Step 3 artifacts pre-populated.
+    Used by both the F11/F12/F13 reviewer-dispatch tests (need the artifact
+    files to exist) and the F15 heuristic tests (need 01-grill.md to be
+    present for _write_grill_summary to overwrite)."""
     folder = tmp_path / "feature-x"
     folder.mkdir()
+    for name in ["00-graph-context.md", "01-grill.md", "02-diagram.mmd", "_meta/CONTEXT.md"]:
+        p = folder / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("placeholder")
     return folder
 
 
@@ -34,6 +41,10 @@ def _write_grill_summary(folder: Path, total_changed_lines: int, max_risk_score:
         f"...\n"
     )
 
+
+# ---------------------------------------------------------------------------
+# F15 — heuristic auto-pass at Step 3 entry (Chunk G)
+# ---------------------------------------------------------------------------
 
 def test_f15_auto_pass_when_all_thresholds_met(folder_with_artifacts: Path):
     from tools.pipette.orchestrator import step3_heuristic_decision
@@ -114,6 +125,10 @@ def test_f15_emits_autopass_rejected_trace_event(folder_with_artifacts: Path):
     assert rec["reason"] == "coverage_below_80"
 
 
+# ---------------------------------------------------------------------------
+# F14 — pipette-lite absolute override (Chunk G)
+# ---------------------------------------------------------------------------
+
 def test_f14_lite_mode_overrides_f15_unconditionally(folder_with_artifacts: Path):
     """Spec enhancement: lite mode is an absolute manual override.
     Even synthetic high-risk-score input that would fail F15 must still
@@ -134,3 +149,32 @@ def test_lite_mode_runs_correct_step_subset(folder_with_artifacts: Path, monkeyp
     steps = lite_pipeline_steps()
     assert 3 not in steps
     assert {0, 1, 2, 4, 5, 6, 7}.issubset(set(steps))
+
+
+# ---------------------------------------------------------------------------
+# F13 — per-reviewer artifact subsets (Chunk F)
+# ---------------------------------------------------------------------------
+
+def test_f13_glossary_reviewer_does_not_get_graph_context():
+    """F13: per-reviewer artifact subsets. Glossary reviewer never sees
+    00-graph-context.md (graph data, not glossary)."""
+    from tools.pipette.orchestrator import reviewer_artifacts
+    artifacts = reviewer_artifacts("glossary")
+    assert "00-graph-context.md" not in artifacts
+
+
+def test_f13_impact_reviewer_gets_full_artifact_stack():
+    """F13: impact is the only reviewer that needs all four artifacts."""
+    from tools.pipette.orchestrator import reviewer_artifacts
+    artifacts = reviewer_artifacts("impact")
+    assert {"00-graph-context.md", "01-grill.md", "02-diagram.mmd",
+            "_meta/CONTEXT.md"}.issubset(set(artifacts))
+
+
+def test_f13_unknown_reviewer_gets_full_stack():
+    """Defensive: an unknown reviewer name falls back to the full stack
+    rather than raising — preserves backward compatibility if a future
+    reviewer is added without updating the lookup table."""
+    from tools.pipette.orchestrator import reviewer_artifacts
+    artifacts = reviewer_artifacts("future_reviewer")
+    assert "00-graph-context.md" in artifacts

--- a/tests/pipette/test_orchestrator_dispatch.py
+++ b/tests/pipette/test_orchestrator_dispatch.py
@@ -155,6 +155,14 @@ def test_lite_mode_runs_correct_step_subset(folder_with_artifacts: Path, monkeyp
 # F13 — per-reviewer artifact subsets (Chunk F)
 # ---------------------------------------------------------------------------
 
+def test_reviewer_names_consistent_between_artifacts_and_all_reviewers():
+    """Single source of truth: `_REVIEWER_ARTIFACTS` keys and `_ALL_REVIEWERS`
+    must agree. If a fifth reviewer is added, both constants need updating —
+    this assertion fails loudly rather than letting the pair drift."""
+    from tools.pipette.orchestrator import _ALL_REVIEWERS, _REVIEWER_ARTIFACTS
+    assert set(_ALL_REVIEWERS) == set(_REVIEWER_ARTIFACTS.keys())
+
+
 def test_f13_glossary_reviewer_does_not_get_graph_context():
     """F13: per-reviewer artifact subsets. Glossary reviewer never sees
     00-graph-context.md (graph data, not glossary)."""

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -274,6 +274,53 @@ def reviewer_artifacts(reviewer: str) -> list[str]:
     return _REVIEWER_ARTIFACTS.get(reviewer, _FULL_ARTIFACT_STACK)
 
 
+# F11: smart-reviewers redispatch on loop-back.
+@dataclass
+class ReviewerRedispatchPlan:
+    reviewers: list[str]
+    fallback_reason: str | None  # None on happy path; non-None when full-dispatch fallback fired
+
+
+_ALL_REVIEWERS = ["contracts", "impact", "glossary", "coverage"]
+_MEDIUM_OR_HIGHER = {"medium", "high", "critical"}
+
+
+def reviewers_to_redispatch(survivors_by_reviewer: dict[str, list[dict]]) -> list[str]:
+    """F11: only redispatch reviewers that flagged >= medium in the prior attempt.
+
+    `_verifier-survivors.json` shape (de facto contract — not yet written by
+    any code as of Chunk F): {reviewer_name: [{"severity": "...", ...}, ...]}.
+    The orchestrator's loop-back dispatch path is the de facto producer."""
+    out: list[str] = []
+    for reviewer in _ALL_REVIEWERS:
+        findings = survivors_by_reviewer.get(reviewer) or []
+        if any((f.get("severity") or "").lower() in _MEDIUM_OR_HIGHER for f in findings):
+            out.append(reviewer)
+    return out
+
+
+def reviewers_to_redispatch_from_folder(folder: Path) -> ReviewerRedispatchPlan:
+    """Read `_verifier-survivors.json` from `folder`. On malformed/missing,
+    fall back to full dispatch and log the reason — spec enhancement.
+    The orchestrator emits a `smart_reviewers_fallback` trace event when
+    `fallback_reason` is non-None."""
+    import json as _json
+    p = folder / "_verifier-survivors.json"
+    if not p.exists():
+        return ReviewerRedispatchPlan(reviewers=list(_ALL_REVIEWERS),
+                                      fallback_reason="survivors_missing")
+    try:
+        data = _json.loads(p.read_text())
+    except _json.JSONDecodeError:
+        return ReviewerRedispatchPlan(reviewers=list(_ALL_REVIEWERS),
+                                      fallback_reason="survivors_unparseable")
+    if not isinstance(data, dict):
+        return ReviewerRedispatchPlan(reviewers=list(_ALL_REVIEWERS),
+                                      fallback_reason="survivors_unexpected_shape")
+    return ReviewerRedispatchPlan(reviewers=reviewers_to_redispatch(data),
+                                  fallback_reason=None)
+
+
 def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     """§5.3: archive artifacts from step jump_back_to..highest into _attempts/N-<ts>/.
 

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -355,8 +355,18 @@ def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     arch = folder / "_attempts" / f"{step_label}-{ts}"
     arch.mkdir(parents=True)
     affected = {
-        1.0: ["01-grill.md", "02-diagram.mmd", "02-diagram.excalidraw", "03-gemini-verdict.md"],
-        2.0: ["02-diagram.mmd", "02-diagram.excalidraw", "03-gemini-verdict.md"],
+        1.0: ["01-grill.md", "02-diagram.mmd", "02-diagram.excalidraw", "03-gemini-verdict.md",
+              # F10: Step 3 scratch — preserves the audit trail for attempt 1.
+              "_reviewer-contracts.json", "_reviewer-impact.json",
+              "_reviewer-glossary.json", "_reviewer-coverage.json",
+              "_verifier-output.json", "_verifier-survivors.json",
+              "_step3-prompt.txt", "_gemini-stdout.log"],
+        2.0: ["02-diagram.mmd", "02-diagram.excalidraw", "03-gemini-verdict.md",
+              # F10: same scratch list — Step 3 ran in attempt 1 of jump=2 too.
+              "_reviewer-contracts.json", "_reviewer-impact.json",
+              "_reviewer-glossary.json", "_reviewer-coverage.json",
+              "_verifier-output.json", "_verifier-survivors.json",
+              "_step3-prompt.txt", "_gemini-stdout.log"],
     }
     if float(jump_back_to) not in affected:
         raise ValueError(f"jump_back_to must be 1 or 2 (B-revision dropped 1.5); got {jump_back_to!r}")

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -250,6 +250,30 @@ def lite_pipeline_steps() -> list[float]:
     return [0, 1, 2, 4, 5, 6, 7]
 
 
+# F13: per-reviewer artifact subsets. Spec recommendation:
+#   contracts: needs symbols → [00, 01]
+#   impact: needs everything → [00, 01, 02, _meta/CONTEXT.md]
+#   glossary: terminology, not graph → [01, 02, _meta/CONTEXT.md]
+#   coverage: tests, not graph → [00, 01, coverage_map.json]
+# Saves ~30% on per-reviewer context.
+_REVIEWER_ARTIFACTS = {
+    "contracts": ["00-graph-context.md", "01-grill.md"],
+    "impact": ["00-graph-context.md", "01-grill.md", "02-diagram.mmd", "_meta/CONTEXT.md"],
+    "glossary": ["01-grill.md", "02-diagram.mmd", "_meta/CONTEXT.md"],
+    "coverage": ["00-graph-context.md", "01-grill.md", "coverage_map.json"],
+}
+
+_FULL_ARTIFACT_STACK = ["00-graph-context.md", "01-grill.md", "02-diagram.mmd", "_meta/CONTEXT.md"]
+
+
+def reviewer_artifacts(reviewer: str) -> list[str]:
+    """Return the artifact list passed to a reviewer subagent's context.
+    Unknown reviewer names fall back to the full stack rather than raising,
+    preserving backward compatibility if a new reviewer is added without
+    updating this table."""
+    return _REVIEWER_ARTIFACTS.get(reviewer, _FULL_ARTIFACT_STACK)
+
+
 def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     """§5.3: archive artifacts from step jump_back_to..highest into _attempts/N-<ts>/.
 

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal, TypedDict
 import yaml
 
 from tools.pipette.folder import folder_name, slug
@@ -13,6 +14,25 @@ from tools.pipette.lockfile import (
     acquire, resume, abort, LockHeld, LockPaused, FilesystemUnsupported,
 )
 from tools.pipette.trace import append_event, Event
+
+
+# F11/F12: shape contract for `_verifier-survivors.json` — the file that
+# downstream loop-back consumers (reviewers_to_redispatch_from_folder,
+# should_run_verifier_on_attempt) read. No code in the repo writes this
+# file as of Chunk F; the producer (a future verifier output path) MUST
+# conform to this TypedDict so the consumers don't need to reverse-
+# engineer the shape.
+class VerifierFinding(TypedDict, total=False):
+    severity: Literal["critical", "high", "medium", "low", "polish"]
+    confidence: float
+    claim: str
+    evidence: list[str]
+    suggested_fix: str | None
+
+
+# Mapping reviewer name → list of findings the verifier confirmed survived
+# its 0.8-confidence filter for that reviewer's prior attempt.
+VerifierSurvivors = dict[str, list[VerifierFinding]]
 
 
 def _meta(root: Path) -> Path:
@@ -265,6 +285,17 @@ _REVIEWER_ARTIFACTS = {
 
 _FULL_ARTIFACT_STACK = ["00-graph-context.md", "01-grill.md", "02-diagram.mmd", "_meta/CONTEXT.md"]
 
+# F10: Step 3 scratch files archived on loop-back so the audit trail for
+# attempt N (reviewer JSONs, verifier outputs, gemini stdout) is preserved
+# in `_attempts/N-<ts>/`. Single source of truth — both jump_back_to=1 and
+# =2 paths reference this list.
+_STEP3_SCRATCH = [
+    "_reviewer-contracts.json", "_reviewer-impact.json",
+    "_reviewer-glossary.json", "_reviewer-coverage.json",
+    "_verifier-output.json", "_verifier-survivors.json",
+    "_step3-prompt.txt", "_gemini-stdout.log",
+]
+
 
 def reviewer_artifacts(reviewer: str) -> list[str]:
     """Return the artifact list passed to a reviewer subagent's context.
@@ -285,12 +316,14 @@ _ALL_REVIEWERS = ["contracts", "impact", "glossary", "coverage"]
 _MEDIUM_OR_HIGHER = {"medium", "high", "critical"}
 
 
-def reviewers_to_redispatch(survivors_by_reviewer: dict[str, list[dict]]) -> list[str]:
-    """F11: only redispatch reviewers that flagged >= medium in the prior attempt.
+def reviewers_to_redispatch(survivors_by_reviewer: VerifierSurvivors) -> list[str]:
+    """F11: only redispatch reviewers that flagged >= medium in the prior
+    attempt's surviving findings.
 
-    `_verifier-survivors.json` shape (de facto contract — not yet written by
-    any code as of Chunk F): {reviewer_name: [{"severity": "...", ...}, ...]}.
-    The orchestrator's loop-back dispatch path is the de facto producer."""
+    Shape contract: see `VerifierSurvivors` TypedDict at module top —
+    `_verifier-survivors.json` is `{reviewer_name: [VerifierFinding, ...]}`.
+    No code in the repo writes the file yet (Chunk F): the orchestrator's
+    loop-back dispatch path is the de facto producer."""
     out: list[str] = []
     for reviewer in _ALL_REVIEWERS:
         findings = survivors_by_reviewer.get(reviewer) or []
@@ -304,14 +337,13 @@ def reviewers_to_redispatch_from_folder(folder: Path) -> ReviewerRedispatchPlan:
     fall back to full dispatch and log the reason — spec enhancement.
     The orchestrator emits a `smart_reviewers_fallback` trace event when
     `fallback_reason` is non-None."""
-    import json as _json
     p = folder / "_verifier-survivors.json"
     if not p.exists():
         return ReviewerRedispatchPlan(reviewers=list(_ALL_REVIEWERS),
                                       fallback_reason="survivors_missing")
     try:
-        data = _json.loads(p.read_text())
-    except _json.JSONDecodeError:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError:
         return ReviewerRedispatchPlan(reviewers=list(_ALL_REVIEWERS),
                                       fallback_reason="survivors_unparseable")
     if not isinstance(data, dict):
@@ -327,15 +359,14 @@ def should_run_verifier_on_attempt(*, folder: Path, attempt: int) -> bool:
     clean `_verifier-survivors.json`. Spec enhancement: if attempt 1's
     verifier crashed or output was malformed, run the verifier in attempt 2
     rather than silently breaking the verification chain."""
-    import json as _json
     if attempt < 2:
         return True
     p = folder / "_verifier-survivors.json"
     if not p.exists():
         return True
     try:
-        data = _json.loads(p.read_text())
-    except _json.JSONDecodeError:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError:
         return True
     return not isinstance(data, dict)  # well-formed dict → safe to skip
 
@@ -355,18 +386,10 @@ def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     arch = folder / "_attempts" / f"{step_label}-{ts}"
     arch.mkdir(parents=True)
     affected = {
-        1.0: ["01-grill.md", "02-diagram.mmd", "02-diagram.excalidraw", "03-gemini-verdict.md",
-              # F10: Step 3 scratch — preserves the audit trail for attempt 1.
-              "_reviewer-contracts.json", "_reviewer-impact.json",
-              "_reviewer-glossary.json", "_reviewer-coverage.json",
-              "_verifier-output.json", "_verifier-survivors.json",
-              "_step3-prompt.txt", "_gemini-stdout.log"],
-        2.0: ["02-diagram.mmd", "02-diagram.excalidraw", "03-gemini-verdict.md",
-              # F10: same scratch list — Step 3 ran in attempt 1 of jump=2 too.
-              "_reviewer-contracts.json", "_reviewer-impact.json",
-              "_reviewer-glossary.json", "_reviewer-coverage.json",
-              "_verifier-output.json", "_verifier-survivors.json",
-              "_step3-prompt.txt", "_gemini-stdout.log"],
+        1.0: ["01-grill.md", "02-diagram.mmd", "02-diagram.excalidraw",
+              "03-gemini-verdict.md", *_STEP3_SCRATCH],
+        2.0: ["02-diagram.mmd", "02-diagram.excalidraw",
+              "03-gemini-verdict.md", *_STEP3_SCRATCH],
     }
     if float(jump_back_to) not in affected:
         raise ValueError(f"jump_back_to must be 1 or 2 (B-revision dropped 1.5); got {jump_back_to!r}")

--- a/tools/pipette/orchestrator.py
+++ b/tools/pipette/orchestrator.py
@@ -321,6 +321,25 @@ def reviewers_to_redispatch_from_folder(folder: Path) -> ReviewerRedispatchPlan:
                                   fallback_reason=None)
 
 
+# F12: skip verifier on attempt >= 2 with safety condition.
+def should_run_verifier_on_attempt(*, folder: Path, attempt: int) -> bool:
+    """F12: skip the verifier on attempt >= 2 only if attempt 1 produced a
+    clean `_verifier-survivors.json`. Spec enhancement: if attempt 1's
+    verifier crashed or output was malformed, run the verifier in attempt 2
+    rather than silently breaking the verification chain."""
+    import json as _json
+    if attempt < 2:
+        return True
+    p = folder / "_verifier-survivors.json"
+    if not p.exists():
+        return True
+    try:
+        data = _json.loads(p.read_text())
+    except _json.JSONDecodeError:
+        return True
+    return not isinstance(data, dict)  # well-formed dict → safe to skip
+
+
 def archive_for_loop_back(*, folder: Path, jump_back_to: float) -> Path:
     """§5.3: archive artifacts from step jump_back_to..highest into _attempts/N-<ts>/.
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "functions": {
     "api/index.py": {
       "includeFiles": "{public/**,app_prompts/**}",
-      "excludeFiles": "{tests/**,docs/**,logs/**,tmp/**,scripts/**,.*/**,.env*,requirements-dev.txt,README.md,CLAUDE.md,DESIGN.md,PRODUCT.md,UBIQUITOUS_LANGUAGE.md}"
+      "excludeFiles": "{tests/**,docs/**,logs/**,tmp/**,scripts/**,.*/**,.env*,requirements-dev.txt,README.md,AGENTS.md,CLAUDE.md,DESIGN.md,PRODUCT.md,UBIQUITOUS_LANGUAGE.md}"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary

Reopens the work from PR #64 (closed when dev-fresh archived). Now targets \`main\`. Clean rebase.

Implements Chunk F: F13 per-reviewer artifact subsets (~30% per-reviewer context savings); F11 smart-reviewers redispatch on loop-back with 3 distinct fallback reasons; F12 verifier-skip with prior-attempt safety condition; F10 archive Step 3 reviewer/verifier scratch on loop-back. \`VerifierSurvivors\` TypedDict added at module top to pin the contract for the future producer.

## Test plan

- [x] \`pytest tests/pipette/\` — all green
- [x] Spec + code-quality review subagents both ✅ (with TypedDict schema, DRY-ed scratch list, partial-scratch test, reviewer-names consistency assertion applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)