### PR TITLE
feat: LLM seam foundation — extract_knowledge_map returns a typed ProvisionalMap

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -31,7 +31,6 @@ DRILL_PROMPT_VERSION = "drill-system-v1"
 REPAIR_REPS_PROMPT_VERSION = "repair-reps-system-v1"
 DRILL_SYSTEM_BASE = DRILL_PROMPT_PATH.read_text()
 REPAIR_REPS_SYSTEM_BASE = REPAIR_REPS_PROMPT_PATH.read_text()
-EXTRACT_FAILURE_LOG_PATH = Path(__file__).parent / "logs/extract-invalid-json.log"
 MAX_RETRIES = 3
 BACKOFF_BASE = 2
 RETRYABLE_CODES = {429, 503, 500}

--- a/ai_service.py
+++ b/ai_service.py
@@ -11,6 +11,13 @@ from google.genai.errors import APIError
 from google.genai import types
 from pydantic import BaseModel, ConfigDict, Field
 
+from llm import (
+    LLMClient,
+    StructuredLLMRequest,
+    build_llm_client,
+)
+from models import ProvisionalMap
+
 MODEL = "gemini-2.5-flash"
 EXTRACT_TEMPERATURE = 0.2
 DRILL_TEMPERATURE = 0.2
@@ -200,39 +207,6 @@ def _get_client(api_key: str | None = None):
             "No Gemini API key configured. Add one in Settings or set GEMINI_API_KEY in .env."
         )
     return genai.Client(api_key=key)
-
-
-def _clean_response(text: str | None, context: str = "Gemini") -> str:
-    """Strip code fences. Used ONLY for extract_knowledge_map."""
-    result = (text or "").strip()
-    if not result:
-        raise ValueError(f"{context} returned an empty response.")
-
-    if result.startswith("```"):
-        result = result.split("\n", 1)[1].rsplit("```", 1)[0].strip()
-
-    return result
-
-
-def _log_extract_failure(
-    *, reason: str, raw_response: str | None, cleaned_response: str | None = None
-) -> None:
-    try:
-        EXTRACT_FAILURE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with EXTRACT_FAILURE_LOG_PATH.open("a", encoding="utf-8") as log_file:
-            log_file.write("=" * 80 + "\n")
-            log_file.write(f"timestamp: {datetime.now(timezone.utc).isoformat()}\n")
-            log_file.write(f"reason: {reason}\n")
-            log_file.write("raw_response:\n")
-            log_file.write((raw_response or "").strip() or "<empty>")
-            log_file.write("\n")
-            if cleaned_response is not None and cleaned_response != raw_response:
-                log_file.write("cleaned_response:\n")
-                log_file.write(cleaned_response.strip() or "<empty>")
-                log_file.write("\n")
-    except Exception:
-        # Logging must never break extraction error handling.
-        pass
 
 
 def _parse_iso_timestamp(iso_string: str) -> datetime:
@@ -678,51 +652,31 @@ def _normalize_drill_evaluation(
 
 def extract_knowledge_map(
     raw_text: str,
+    *,
+    llm: LLMClient | None = None,
     api_key: str | None = None,
     telemetry_context: dict | None = None,
-) -> dict:
-    client = _get_client(api_key)
+) -> ProvisionalMap:
+    """Generate a Provisional map from learner-supplied text.
 
-    response = _call_gemini_with_retry(
-        client,
-        model=MODEL,
-        contents=USER_PROMPT.format(text=raw_text),
-        config=types.GenerateContentConfig(
-            system_instruction=EXTRACT_PROMPT_PATH.read_text(),
-            temperature=EXTRACT_TEMPERATURE,
-        ),
+    The application sees a typed ProvisionalMap, never a dict and never
+    a Gemini-shaped response. All provider-specific behavior lives behind
+    the LLMClient seam (see llm/ package). The closure validators on
+    ProvisionalMap enforce the structural rules from extract-system-v1.txt.
+    """
+    client: LLMClient = llm if llm is not None else build_llm_client(api_key=api_key)
+    request = StructuredLLMRequest(
+        system_prompt=EXTRACT_PROMPT_PATH.read_text(),
+        user_prompt=USER_PROMPT.format(text=raw_text),
+        response_schema=ProvisionalMap,
+        temperature=EXTRACT_TEMPERATURE,
+        task_name="provisional_map_generation",
+        prompt_version=EXTRACT_PROMPT_VERSION,
     )
-
-    raw_response = response.text
-    try:
-        cleaned = _clean_response(raw_response)
-    except ValueError as err:
-        _log_extract_failure(reason=str(err), raw_response=raw_response)
-        raise
-
-    try:
-        knowledge_map = json.loads(cleaned)
-    except json.JSONDecodeError as err:
-        _log_extract_failure(
-            reason=f"Invalid JSON: {err.msg} at line {err.lineno} column {err.colno}",
-            raw_response=raw_response,
-            cleaned_response=cleaned,
-        )
-        raise ValueError(
-            f"Gemini returned invalid JSON for extraction: {err.msg}"
-        ) from err
-
-    try:
-        _validate_knowledge_map(knowledge_map)
-    except ValueError as err:
-        _log_extract_failure(
-            reason=f"Schema validation failed: {err}",
-            raw_response=raw_response,
-            cleaned_response=cleaned,
-        )
-        raise
-
-    return knowledge_map
+    result = client.generate_structured(request)
+    # Adapter guarantees parsed is a ProvisionalMap or it raised
+    # LLMValidationError. The cast is for type-checker clarity.
+    return result.parsed  # type: ignore[return-value]
 
 
 def _validate_repair_reps_result(

--- a/docs/adr/0001-provisional-map-typed-contract.md
+++ b/docs/adr/0001-provisional-map-typed-contract.md
@@ -1,0 +1,37 @@
+# ADR-0001 — `ProvisionalMap` as a typed cognitive artifact contract
+
+**Status:** Accepted (2026-05-01)
+**Driver:** [foundation design spec, §5.1](../superpowers/specs/2026-05-01-foundation-design.md), PR #76
+
+## Context
+
+The MVP path produces a **Provisional map** (per [UBIQUITOUS_LANGUAGE.md](../../UBIQUITOUS_LANGUAGE.md): "a map shaped by starting-map input but still carrying no graph-truth mutation"). Every downstream stage — Cold attempt, Targeted study, Repair Reps, Spaced re-drill — consumes the map as a graph of mechanisms, identifiers, and relationships. If the map's structural integrity is broken, the brittleness propagates invisibly and surfaces as bad UX much later (a Cold attempt on a node that doesn't exist; a Repair Rep referencing a missing cluster).
+
+Before this PR, `extract_knowledge_map` returned a `dict` and validated only that `metadata`/`backbone`/`clusters` were the right top-level types. There were no checks that subnodes lived in their declared cluster, that backbone references resolved, that learning-prerequisite edges formed a DAG, or that identifiers matched the grammar the prompt asked for. Pre-PR there were also zero unit tests for the function.
+
+## Decision
+
+The MVP map is a typed Pydantic model — `models.ProvisionalMap` — and that model is the contract between extraction and every downstream consumer. Its shape mirrors `app_prompts/extract-system-v1.txt` exactly. Application code holds `ProvisionalMap` instances; the wire shape (`dict`) is produced only at the route boundary via `.model_dump()`.
+
+The model enforces structural integrity at parse time:
+
+- Identifier grammar (`b<N>`, `c<N>`, `c<N>_s<M>`, `core-thesis`) via `models.identifiers.parse_id`.
+- Reference closure: every backbone `dependent_clusters` references an existing cluster; every cluster is covered by ≥ 1 backbone (BACKBONE COVERAGE RULE); every cluster has ≥ 1 subnode (MINIMUM DRILLABILITY RULE); every subnode lives in its declared cluster; relationship endpoints exist; framework `source_clusters` resolve.
+- Acyclicity: learning prerequisites form a DAG (no self-loops, no reciprocals, DFS cycle check).
+
+The route maps any `ValueError` raised by these validators to HTTP 422 — the structural shape is wrong, retrying won't help.
+
+`extra="forbid"` is intentionally **not** set. Pydantic emits `additionalProperties: false` in the JSON Schema when `extra="forbid"` is configured, and Gemini's `response_schema` parameter rejects schemas containing it. Field-level correctness is governed by the prompt + the closure validators above. See `_parse_repair_reps_response` in `ai_service.py` for the same precedent.
+
+## Alternatives
+
+- **Keep the `dict` shape and add a separate validator function.** Considered and rejected: validation would be a separate step downstream code could forget to invoke. Pydantic at the boundary is enforcement-by-construction.
+- **Strict `extra="forbid"` with a parallel "loose" schema for Gemini export.** Considered and rejected for v1 — adds a dual-class dance (the same one `_parse_repair_reps_response` already does for repair-reps). Worth revisiting if Gemini starts producing extra fields that we want loud rejection on.
+- **Quality-floor knobs** (≥ N nodes, ≥ M clusters per backbone) on the model. Considered and rejected: that is the prompt's job. If the prompt produces thin maps, fix the prompt; the schema is for *structural* integrity, not content quality.
+
+## Consequences
+
+- **Catches breakage at extraction time, not three steps later.** A malformed map fails at parse, surfacing as a 422 with a specific validator message instead of a Cold attempt UX bug.
+- **Downstream code that previously walked dicts must update.** `scripts/run_tasting_fixture.py` was updated to call `.model_dump()` after extraction; future internal callers must either consume `ProvisionalMap` directly (preferred) or do the same.
+- **Wire shape preserved.** Route handlers call `.model_dump()` so frontend consumers see the same JSON they always did.
+- **Schema is bound to one prompt version.** When `app_prompts/extract-system-v1.txt` changes shape, `ProvisionalMap` must change alongside it. Prompts and schemas version together; this ADR doesn't formalize the registry yet (deferred — see spec §5.4).

--- a/docs/adr/0002-llm-seam.md
+++ b/docs/adr/0002-llm-seam.md
@@ -1,0 +1,65 @@
+# ADR-0002 — LLM provider lives behind a seam; application asks for cognitive artifacts
+
+**Status:** Accepted (2026-05-01)
+**Driver:** [foundation design spec, §5.2 + §5.3](../superpowers/specs/2026-05-01-foundation-design.md), PR #76
+
+## Context
+
+Before this PR, `ai_service.py` was a 1035-line module that fused four concerns: Gemini SDK calls, retry policy, error normalization, and several distinct prompted Gemini stages (extraction, drill, repair reps). Tests reached for `ai_service._get_client` and `ai_service._call_gemini_with_retry` (private names) — a strong signal that the seam between application code and provider code did not exist where it needed to.
+
+The product itself does not care which LLM produced a Provisional map. The *application* says, "give me a `ProvisionalMap`"; the *infrastructure* — Gemini today, possibly Anthropic or OpenAI later — handles "how do we get one?" The two concerns lived in the same file.
+
+## Decision
+
+The LLM provider lives behind an `llm/` package. Application code imports only `LLMClient`, `StructuredLLMRequest`, `StructuredLLMResult`, `TokenUsage`, the normalized error hierarchy, and `build_llm_client`. Provider-specific code (currently `google-genai`) is confined to `llm/gemini_adapter.py`.
+
+The application asks for a validated cognitive artifact:
+
+```python
+result = client.generate_structured(StructuredLLMRequest(
+    system_prompt=...,
+    user_prompt=...,
+    response_schema=ProvisionalMap,   # ← the contract
+    task_name="provisional_map_generation",
+    prompt_version=EXTRACT_PROMPT_VERSION,
+))
+provisional_map = result.parsed   # ← already a Pydantic instance
+```
+
+The application **never** sees a Gemini `response`, a `dict`, a JSON string, or a provider-specific exception class.
+
+### Responsibility split
+
+| Concern | Lives in |
+|---|---|
+| SDK call (request/response) | `llm/gemini_adapter.py` |
+| Pydantic → JSON Schema translation | `llm/gemini_adapter.py` |
+| Provider exception → normalized error | `llm/gemini_adapter.py` |
+| Retry policy + exponential backoff | `llm/client.py` |
+| Structured telemetry log per call | `llm/client.py` |
+| Token-usage extraction (normalized shape) | `llm/gemini_adapter.py` (raw) → `llm/client.py` (consumed) |
+
+`LLMAdapter` is a `runtime_checkable` Protocol with a single primitive: `call_once(request) -> StructuredLLMResult` or raises a normalized error. `LLMClient` is the concrete wrapper that owns retry + telemetry. Adding a second provider is one new file (e.g., `llm/anthropic_adapter.py`) plus updating `llm/factory.py`.
+
+### The architectural invariant
+
+`tests/test_llm_seam_isolation.py` walks every `.py` file outside `.worktrees/`/`.venv/`/etc. and asserts that none of them import `google.genai` or `google.generativeai` except `llm/gemini_adapter.py`. `ai_service.py` is currently exempted because `drill_chat` and `generate_repair_reps` still use the legacy SDK; that exemption is documented and removed in the next migration sweep. **The foundation thesis holds iff this test passes.**
+
+A second test asserts `ai_service.py` references `from llm import` and `ProvisionalMap` for the extract path — a positive regression gate that the migration didn't quietly revert.
+
+### User-facing error policy
+
+Across the entire `LLMError` hierarchy, the route returns **stable copy** to the learner. Provider-internal strings (`"Gemini service error (HTTP 503): ..."`, model names, error codes) flow into operator logs but never into the response body. The learner is never told which AI provider we use. See [PR #76 commit `706bd5b`](https://github.com/jon-devlapaz/socratink-app/commit/706bd5b) for the parametrized leak test that locks this in.
+
+## Alternatives
+
+- **Wrap each Gemini call site in a small helper.** Rejected: doesn't solve the seam problem (provider details still in application files), doesn't centralize retry/telemetry, and tests would still patch private names.
+- **Build the seam but add multiple adapters now.** Rejected as cargo-culting. The seam is the architectural commitment; adding a second adapter is later focused work driven by an actual product or cost reason. The Gemini adapter exists today because we use Gemini today.
+- **Retry policy in the adapter (per-provider).** Rejected: duplicates the loop in every adapter and makes "what is retried?" a per-provider question. The current shape — adapter classifies errors into normalized categories, client owns retry — is the cleanest split (see also [ADR-0003](0003-retriable-error-marker.md)).
+
+## Consequences
+
+- **The product-quality test from the design spec — *"no socratink application code should import Gemini directly"* — is now an automated assertion**, not a hope. It enforces itself on every commit.
+- **Switching providers is a one-file addition.** Once a second adapter exists (e.g., Anthropic), `LLM_PROVIDER=anthropic` flips the entire stack — including the `/api/extract` route — without touching application code.
+- **One legacy exception remains** for `ai_service.py` until `drill_chat` and `generate_repair_reps` migrate. That exception is annotated in the test and removed in the next sweep. Until then, contributors writing new logic in `ai_service.py` should prefer the seam path over the legacy one (the test won't catch this — judgment matters).
+- **Tests no longer patch private names.** The migration test for `extract_knowledge_map` injects a fake `LLMClient` instead of monkeypatching `_get_client` and `_call_gemini_with_retry`. Future LLM-touching tests follow the same pattern.

--- a/docs/adr/0003-retriable-error-marker.md
+++ b/docs/adr/0003-retriable-error-marker.md
@@ -1,0 +1,60 @@
+# ADR-0003 — Retry contract is encoded in the type system via `RetriableLLMError`
+
+**Status:** Accepted (2026-05-01)
+**Driver:** Gemini sanity-check feedback during PR #76, [commit `56bde46`](https://github.com/jon-devlapaz/socratink-app/commit/56bde46)
+**Supersedes:** N/A. Implicit retry contract from earlier in PR #76.
+
+## Context
+
+The first cut of `LLMClient.generate_structured` retried via:
+
+```python
+except (LLMRateLimitError, LLMServiceError) as exc:
+    ...retry...
+```
+
+This was correct at the moment of writing but **fragile under future change**. The fragility is concrete:
+
+- The retry contract — "which errors should `LLMClient` retry?" — lived in the tuple inside the `except` clause. It was implicit, not type-encoded.
+- A live smoke test surfaced this exact failure mode: a 4xx error (expired API key) was first classified as `LLMServiceError`, which placed it in the retry set. The fix introduced `LLMClientError` as a sibling — but a future contributor adding another error class (e.g., `LLMQuotaExhaustedError`, `LLMSafetyFilteredError`) has no compiler signal telling them which category is correct. They have to remember to update both the class hierarchy AND the `except` tuple.
+- Independent post-implementation review (Gemini sanity check) flagged the same risk: "the retry contract is implicit in a tuple and prone to future developer error."
+
+## Decision
+
+The retry contract is a marker base class.
+
+```python
+class LLMError(Exception): ...
+
+class RetriableLLMError(LLMError):
+    """LLMClient retries any exception that subclasses this."""
+
+class LLMRateLimitError(RetriableLLMError): ...   # retried
+class LLMServiceError(RetriableLLMError): ...     # retried
+
+class LLMMissingKeyError(LLMError): ...           # NOT retried
+class LLMClientError(LLMError): ...               # NOT retried
+class LLMValidationError(LLMError): ...           # NOT retried
+```
+
+`LLMClient.generate_structured` reads:
+
+```python
+except RetriableLLMError as exc:
+    ...retry...
+```
+
+Adding a new error type is a one-decision act: subclass `RetriableLLMError` iff it should be retried. The class hierarchy *is* the contract — there is no separate tuple to forget to update. A test (`test_retriable_marker_governs_retry_set`) locks in the current membership so accidental drift is caught.
+
+## Alternatives
+
+- **Stable tuple in `LLMClient`** (the original shape). Rejected on the grounds above: prone to drift; new contributors need to know about a tuple they may not be looking at.
+- **`is_retriable: bool` attribute on each `LLMError`**. Rejected: behavior carried by an instance attribute is harder to introspect than behavior carried by the class hierarchy. `issubclass` is cheap, explicit, and discoverable.
+- **Decorator-based registration** (e.g., `@retriable` on the class). Rejected as over-engineered for a flat hierarchy. ABC inheritance is the standard Python idiom; we use it.
+
+## Consequences
+
+- **The retry policy is self-documenting.** A reader of `llm/errors.py` sees the contract by class structure alone. No cross-file lookup needed.
+- **Adding a new error class is type-safe** with respect to retry behavior. The compiler/type-checker (mypy) and the regression test both surface mistakes before runtime.
+- **The retry loop is unchanged in shape but stronger in guarantee.** `except RetriableLLMError` is a simpler and more specific catch than `except (A, B)` — no maintenance work as the hierarchy grows.
+- **Future categorization is open.** If a permanent-but-different category ever needs the same treatment (e.g., a `FatalLLMError` ABC for non-retried errors that get a special log path), it slots into the existing pattern.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,35 @@
+# Architecture Decision Records
+
+This directory holds the binding architectural decisions for socratink-app. Each ADR records: a decision that was made, the context that forced it, the alternatives we considered, and the consequences we have to live with.
+
+## When to write a new ADR
+
+Write one when:
+
+- A decision shapes how new code in some area MUST be written, and that "must" can't be inferred from reading the code itself.
+- A decision is non-obvious enough that a contributor (or a future agent) might re-litigate it without context.
+- A decision rules out an alternative for a load-bearing reason that would otherwise be invisible.
+
+Don't write one for:
+
+- Vocabulary — that lives in [UBIQUITOUS_LANGUAGE.md](../../UBIQUITOUS_LANGUAGE.md).
+- Style preferences without an architectural blast radius.
+- Working notes — those go in `docs/superpowers/specs/`.
+
+## Format
+
+Each ADR is a markdown file numbered sequentially: `NNNN-short-slug.md`. Format:
+
+- **Status**: Accepted / Superseded by ADR-XXXX / Proposed
+- **Context**: What forced the decision. Cite code locations, prior incidents, or product constraints.
+- **Decision**: What we are doing. Use the present tense — "we use X" not "we will use X."
+- **Alternatives**: Other options we considered, and why they lost.
+- **Consequences**: What this decision now costs or constrains. Both positive and negative.
+
+Keep them short. Link to the spec / plan / commits that drove the decision rather than re-explaining context.
+
+## Index
+
+- [ADR-0001 — `ProvisionalMap` as a typed cognitive artifact contract](0001-provisional-map-typed-contract.md)
+- [ADR-0002 — LLM provider lives behind a seam; application asks for cognitive artifacts](0002-llm-seam.md)
+- [ADR-0003 — Retry contract is encoded in the type system via `RetriableLLMError`](0003-retriable-error-marker.md)

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -8,6 +8,7 @@ that the Gemini SDK is only imported in ``llm/gemini_adapter.py``.
 """
 from .client import LLMClient
 from .errors import (
+    LLMClientError,
     LLMError,
     LLMMissingKeyError,
     LLMRateLimitError,
@@ -23,6 +24,7 @@ __all__ = [
     "StructuredLLMResult",
     "TokenUsage",
     "LLMError",
+    "LLMClientError",
     "LLMMissingKeyError",
     "LLMRateLimitError",
     "LLMServiceError",

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,31 @@
+"""Public API for the LLM seam.
+
+Application code imports everything it needs from ``llm`` directly.
+Submodules (``types``, ``errors``, ``adapter``, ``client``, ``gemini_adapter``,
+``factory``) are implementation detail; importing from them outside of
+``llm/`` itself is discouraged. The architectural isolation test enforces
+that the Gemini SDK is only imported in ``llm/gemini_adapter.py``.
+"""
+from .client import LLMClient
+from .errors import (
+    LLMError,
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
+from .factory import build_llm_client
+from .types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
+
+__all__ = [
+    "LLMClient",
+    "StructuredLLMRequest",
+    "StructuredLLMResult",
+    "TokenUsage",
+    "LLMError",
+    "LLMMissingKeyError",
+    "LLMRateLimitError",
+    "LLMServiceError",
+    "LLMValidationError",
+    "build_llm_client",
+]

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -14,6 +14,7 @@ from .errors import (
     LLMRateLimitError,
     LLMServiceError,
     LLMValidationError,
+    RetriableLLMError,
 )
 from .factory import build_llm_client
 from .types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
@@ -29,5 +30,6 @@ __all__ = [
     "LLMRateLimitError",
     "LLMServiceError",
     "LLMValidationError",
+    "RetriableLLMError",
     "build_llm_client",
 ]

--- a/llm/adapter.py
+++ b/llm/adapter.py
@@ -1,0 +1,38 @@
+"""The LLMAdapter Protocol.
+
+An adapter is the single place provider-specific code lives. It must:
+  - translate a StructuredLLMRequest into a provider SDK call
+  - extract a StructuredLLMResult from the provider's response
+  - classify provider exceptions into normalized LLMError subclasses
+  - validate the parsed content matches the requested schema, or raise
+    LLMValidationError
+
+It does NOT:
+  - retry (LLMClient owns retry policy)
+  - log (LLMClient owns telemetry)
+  - cache (out of scope for MVP)
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .types import StructuredLLMRequest, StructuredLLMResult
+
+
+@runtime_checkable
+class LLMAdapter(Protocol):
+    """Provider adapter. Implements one primitive: ``call_once``.
+
+    Adapters MUST raise normalized errors from ``llm.errors``:
+      - LLMMissingKeyError when no API key is configured
+      - LLMRateLimitError on 429 / equivalent
+      - LLMServiceError on 5xx / transport / unknown failure
+      - LLMValidationError when response cannot be parsed as
+        ``request.response_schema``
+
+    Adapters MUST populate ``StructuredLLMResult.parsed`` with an instance of
+    ``request.response_schema``, never a dict.
+    """
+
+    def call_once(self, request: StructuredLLMRequest) -> StructuredLLMResult:
+        ...

--- a/llm/client.py
+++ b/llm/client.py
@@ -1,0 +1,25 @@
+"""LLMClient — wraps an adapter with retry, telemetry, and timing.
+
+This is the public surface application code uses. The application calls
+``client.generate_structured(request)`` and gets a ``StructuredLLMResult``
+or one of the normalized exceptions from ``llm.errors``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .adapter import LLMAdapter
+from .types import StructuredLLMRequest, StructuredLLMResult
+
+
+@dataclass
+class LLMClient:
+    """Application-facing client. Owns retry policy and telemetry.
+
+    Construct via ``llm.build_llm_client(...)`` for the configured provider.
+    """
+
+    adapter: LLMAdapter
+
+    def generate_structured(self, request: StructuredLLMRequest) -> StructuredLLMResult:
+        return self.adapter.call_once(request)

--- a/llm/client.py
+++ b/llm/client.py
@@ -7,16 +7,20 @@ or one of the normalized exceptions from ``llm.errors``.
 The adapter does one thing: translate request -> SDK call -> result, or
 raise a normalized error. The client does policy: retry on transient
 provider failures (rate-limit, service errors), but never retry on
-schema-validation or missing-key failures.
+schema-validation or missing-key failures. It also emits a structured
+log line per call (success or failure) for telemetry.
 """
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass, replace
 
 from .adapter import LLMAdapter
 from .errors import LLMRateLimitError, LLMServiceError
 from .types import StructuredLLMRequest, StructuredLLMResult
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -32,17 +36,23 @@ class LLMClient:
             try:
                 result = self.adapter.call_once(request)
             except (LLMRateLimitError, LLMServiceError) as exc:
+                latency_ms = (time.perf_counter() - start) * 1000.0
+                self._log_failure(request, exc, attempt=attempt, latency_ms=latency_ms)
                 last_exc = exc
                 if attempt < request.max_retries:
                     self._sleep_backoff(attempt)
                     continue
                 raise
-            # Adapter populates latency; we override with our wall-clock
-            # measurement so retries do not inflate the figure.
-            latency_ms = (time.perf_counter() - start) * 1000.0
-            return replace(result, latency_ms=latency_ms)
-        # Defensive — only reachable if max_retries < 0, which the dataclass
-        # default does not allow.
+            except Exception as exc:
+                latency_ms = (time.perf_counter() - start) * 1000.0
+                self._log_failure(request, exc, attempt=attempt, latency_ms=latency_ms)
+                raise
+            else:
+                latency_ms = (time.perf_counter() - start) * 1000.0
+                final_result = replace(result, latency_ms=latency_ms)
+                self._log_success(request, final_result, attempt=attempt)
+                return final_result
+        # Defensive — only reachable if max_retries < 0.
         if last_exc is not None:
             raise last_exc
         raise RuntimeError("LLMClient exhausted retries without raising")  # pragma: no cover
@@ -50,3 +60,44 @@ class LLMClient:
     @staticmethod
     def _sleep_backoff(attempt: int) -> None:
         time.sleep(2 ** attempt)
+
+    @staticmethod
+    def _log_success(
+        request: StructuredLLMRequest,
+        result: StructuredLLMResult,
+        *,
+        attempt: int,
+    ) -> None:
+        logger.info(
+            "llm.call_succeeded",
+            extra={
+                "task_name": request.task_name,
+                "prompt_version": request.prompt_version,
+                "provider": result.provider,
+                "model": result.model,
+                "input_tokens": result.usage.input_tokens,
+                "output_tokens": result.usage.output_tokens,
+                "latency_ms": result.latency_ms,
+                "attempt": attempt,
+            },
+        )
+
+    @staticmethod
+    def _log_failure(
+        request: StructuredLLMRequest,
+        exc: Exception,
+        *,
+        attempt: int,
+        latency_ms: float,
+    ) -> None:
+        logger.warning(
+            "llm.call_failed",
+            extra={
+                "task_name": request.task_name,
+                "prompt_version": request.prompt_version,
+                "error_class": type(exc).__name__,
+                "error_message": str(exc),
+                "attempt": attempt,
+                "latency_ms": latency_ms,
+            },
+        )

--- a/llm/client.py
+++ b/llm/client.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import dataclass, replace
 
 from .adapter import LLMAdapter
-from .errors import LLMRateLimitError, LLMServiceError
+from .errors import RetriableLLMError
 from .types import StructuredLLMRequest, StructuredLLMResult
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class LLMClient:
             start = time.perf_counter()
             try:
                 result = self.adapter.call_once(request)
-            except (LLMRateLimitError, LLMServiceError) as exc:
+            except RetriableLLMError as exc:
                 latency_ms = (time.perf_counter() - start) * 1000.0
                 self._log_failure(request, exc, attempt=attempt, latency_ms=latency_ms)
                 last_exc = exc

--- a/llm/client.py
+++ b/llm/client.py
@@ -3,23 +3,50 @@
 This is the public surface application code uses. The application calls
 ``client.generate_structured(request)`` and gets a ``StructuredLLMResult``
 or one of the normalized exceptions from ``llm.errors``.
+
+The adapter does one thing: translate request -> SDK call -> result, or
+raise a normalized error. The client does policy: retry on transient
+provider failures (rate-limit, service errors), but never retry on
+schema-validation or missing-key failures.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, replace
 
 from .adapter import LLMAdapter
+from .errors import LLMRateLimitError, LLMServiceError
 from .types import StructuredLLMRequest, StructuredLLMResult
 
 
 @dataclass
 class LLMClient:
-    """Application-facing client. Owns retry policy and telemetry.
-
-    Construct via ``llm.build_llm_client(...)`` for the configured provider.
-    """
+    """Application-facing client. Owns retry policy and telemetry."""
 
     adapter: LLMAdapter
 
     def generate_structured(self, request: StructuredLLMRequest) -> StructuredLLMResult:
-        return self.adapter.call_once(request)
+        last_exc: Exception | None = None
+        for attempt in range(request.max_retries + 1):
+            start = time.perf_counter()
+            try:
+                result = self.adapter.call_once(request)
+            except (LLMRateLimitError, LLMServiceError) as exc:
+                last_exc = exc
+                if attempt < request.max_retries:
+                    self._sleep_backoff(attempt)
+                    continue
+                raise
+            # Adapter populates latency; we override with our wall-clock
+            # measurement so retries do not inflate the figure.
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            return replace(result, latency_ms=latency_ms)
+        # Defensive — only reachable if max_retries < 0, which the dataclass
+        # default does not allow.
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("LLMClient exhausted retries without raising")  # pragma: no cover
+
+    @staticmethod
+    def _sleep_backoff(attempt: int) -> None:
+        time.sleep(2 ** attempt)

--- a/llm/errors.py
+++ b/llm/errors.py
@@ -1,0 +1,39 @@
+"""Normalized exception hierarchy for the LLM seam.
+
+Application code catches these. Adapter code raises these. The mapping
+from provider-specific exceptions to these lives inside each adapter.
+"""
+from __future__ import annotations
+
+
+class LLMError(Exception):
+    """Base for all errors raised through the LLM seam."""
+
+
+class LLMMissingKeyError(LLMError):
+    """The configured provider has no API key."""
+
+
+class LLMRateLimitError(LLMError):
+    """The provider rate-limited the request (e.g., Gemini 429)."""
+
+
+class LLMServiceError(LLMError):
+    """The provider returned a transport-level or upstream failure
+    (Gemini 5xx, network timeouts, malformed transport response).
+
+    Distinct from ``LLMValidationError`` — the model produced no usable content.
+    """
+
+
+class LLMValidationError(LLMError):
+    """The provider returned content but it failed schema validation.
+
+    Distinct from ``LLMServiceError`` — content arrived; it just was not
+    shaped like the requested Pydantic model. Carries ``raw_text`` so callers
+    can log, record, or refresh fixtures.
+    """
+
+    def __init__(self, message: str, *, raw_text: str | None = None):
+        super().__init__(message)
+        self.raw_text = raw_text

--- a/llm/errors.py
+++ b/llm/errors.py
@@ -19,10 +19,24 @@ class LLMRateLimitError(LLMError):
 
 
 class LLMServiceError(LLMError):
-    """The provider returned a transport-level or upstream failure
+    """The provider returned a transient transport / upstream failure
     (Gemini 5xx, network timeouts, malformed transport response).
 
-    Distinct from ``LLMValidationError`` — the model produced no usable content.
+    These ARE retried by ``LLMClient``. Distinct from ``LLMClientError``,
+    which is permanent (no retry), and ``LLMValidationError``, which means
+    the provider returned content but it failed schema validation.
+    """
+
+
+class LLMClientError(LLMError):
+    """A permanent client-side failure: Gemini rejected the request
+    (HTTP 4xx other than 429). Causes include expired/invalid API key,
+    unknown model name, malformed request, quota exhausted (non-rate-limit).
+
+    NOT retried by ``LLMClient`` — retrying a 4xx wastes quota and time.
+    The route layer should map this to a 503 to the learner (the cause is
+    operator-misconfiguration, not a learner action) and surface the
+    underlying message to the operator's logs.
     """
 
 

--- a/llm/errors.py
+++ b/llm/errors.py
@@ -2,6 +2,12 @@
 
 Application code catches these. Adapter code raises these. The mapping
 from provider-specific exceptions to these lives inside each adapter.
+
+Retry contract is encoded in the type system via ``RetriableLLMError``:
+``LLMClient`` retries any exception that subclasses ``RetriableLLMError``.
+Permanent failures (missing key, validation, client-side rejections) do
+not subclass it, so adding a new permanent error type cannot accidentally
+re-enable retries.
 """
 from __future__ import annotations
 
@@ -10,21 +16,34 @@ class LLMError(Exception):
     """Base for all errors raised through the LLM seam."""
 
 
+class RetriableLLMError(LLMError):
+    """Marker base class: ``LLMClient`` retries these with exponential backoff.
+
+    Concrete subclasses represent transient failures where retrying makes
+    sense (rate limits clear, upstream services recover). New retriable
+    error types should subclass this directly.
+
+    Permanent failures must NOT subclass ``RetriableLLMError``. The retry
+    loop catches ``except RetriableLLMError`` exactly, so this is the
+    single source of truth for "should LLMClient retry?"
+    """
+
+
 class LLMMissingKeyError(LLMError):
-    """The configured provider has no API key."""
+    """The configured provider has no API key. Permanent (not retried)."""
 
 
-class LLMRateLimitError(LLMError):
-    """The provider rate-limited the request (e.g., Gemini 429)."""
+class LLMRateLimitError(RetriableLLMError):
+    """The provider rate-limited the request (e.g., Gemini 429). Retried."""
 
 
-class LLMServiceError(LLMError):
+class LLMServiceError(RetriableLLMError):
     """The provider returned a transient transport / upstream failure
-    (Gemini 5xx, network timeouts, malformed transport response).
+    (Gemini 5xx, network timeouts, malformed transport response). Retried.
 
-    These ARE retried by ``LLMClient``. Distinct from ``LLMClientError``,
-    which is permanent (no retry), and ``LLMValidationError``, which means
-    the provider returned content but it failed schema validation.
+    Distinct from ``LLMClientError`` (permanent 4xx) and
+    ``LLMValidationError`` (provider returned content but it failed
+    schema validation).
     """
 
 
@@ -33,10 +52,10 @@ class LLMClientError(LLMError):
     (HTTP 4xx other than 429). Causes include expired/invalid API key,
     unknown model name, malformed request, quota exhausted (non-rate-limit).
 
-    NOT retried by ``LLMClient`` — retrying a 4xx wastes quota and time.
-    The route layer should map this to a 503 to the learner (the cause is
-    operator-misconfiguration, not a learner action) and surface the
-    underlying message to the operator's logs.
+    NOT retried — retrying a 4xx wastes quota and time. The route layer
+    maps this to a 503 to the learner (the cause is
+    operator-misconfiguration, not a learner action) and surfaces the
+    underlying message to the operator's logs only.
     """
 
 

--- a/llm/factory.py
+++ b/llm/factory.py
@@ -1,0 +1,38 @@
+"""Factory for building the configured LLMClient.
+
+Reads:
+  - ``LLM_PROVIDER`` (default: ``"gemini"``)
+  - ``LLM_MODEL`` (default per provider — currently ``"gemini-2.5-flash"``)
+
+Optional ``api_key`` argument lets callers (e.g., the /api/extract route)
+override the env-resolved key with a per-request key. The adapter still
+falls back to the env var if neither is provided.
+"""
+from __future__ import annotations
+
+import os
+
+from .client import LLMClient
+from .gemini_adapter import GeminiAdapter
+
+_DEFAULT_PROVIDER = "gemini"
+_DEFAULT_MODELS = {"gemini": "gemini-2.5-flash"}
+
+
+def build_llm_client(*, api_key: str | None = None) -> LLMClient:
+    """Construct the configured LLMClient.
+
+    Provider selection is via ``LLM_PROVIDER`` (default ``"gemini"``).
+    Per-stage override env vars (``LLM_PROVIDER_<STAGE>``) are not yet
+    implemented; the factory currently uses one global default.
+    """
+    provider = os.environ.get("LLM_PROVIDER", _DEFAULT_PROVIDER).strip().lower()
+    if provider != "gemini":
+        raise NotImplementedError(
+            f"LLM provider {provider!r} not implemented. Currently supported: 'gemini'."
+        )
+    model = os.environ.get("LLM_MODEL", _DEFAULT_MODELS[provider]).strip()
+    if not model:
+        raise ValueError(f"LLM_MODEL must be non-empty for provider {provider!r}.")
+    adapter = GeminiAdapter(api_key=api_key, model=model)
+    return LLMClient(adapter=adapter)

--- a/llm/gemini_adapter.py
+++ b/llm/gemini_adapter.py
@@ -1,0 +1,116 @@
+"""Gemini provider adapter.
+
+This is the only file in the repo that imports the google-genai SDK.
+Enforced by ``tests/test_llm_seam_isolation.py``. All Gemini-specific
+quirks live here: SDK call shape, error code classification,
+``response.parsed`` extraction, token usage extraction.
+
+Application code never imports this module directly; it constructs an
+``LLMClient`` via ``llm.build_llm_client(...)`` instead.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from google import genai
+from google.genai import types as genai_types
+from google.genai.errors import APIError
+
+from .errors import (
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
+from .types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
+
+_PROVIDER = "gemini"
+_RATE_LIMIT_CODE = 429
+_RETRYABLE_SERVICE_CODES = {500, 503}
+
+
+class GeminiAdapter:
+    """Translates StructuredLLMRequest into a google-genai SDK call.
+
+    Constructed by ``llm.build_llm_client`` with an explicit model name.
+    Resolves the API key from constructor argument first, then falls back
+    to the ``GEMINI_API_KEY`` environment variable.
+    """
+
+    def __init__(self, *, api_key: str | None = None, model: str):
+        self._explicit_key = api_key
+        self._model = model
+
+    def _resolve_key(self) -> str:
+        key = self._explicit_key or os.environ.get("GEMINI_API_KEY")
+        if not key:
+            raise LLMMissingKeyError(
+                "No Gemini API key configured. "
+                "Set GEMINI_API_KEY or pass api_key=... to build_llm_client()."
+            )
+        return key
+
+    def call_once(self, request: StructuredLLMRequest) -> StructuredLLMResult:
+        key = self._resolve_key()
+        client = genai.Client(api_key=key)
+        config = genai_types.GenerateContentConfig(
+            system_instruction=request.system_prompt,
+            temperature=request.temperature,
+            response_schema=request.response_schema,
+            response_mime_type="application/json",
+        )
+
+        start = time.perf_counter()
+        try:
+            response = client.models.generate_content(
+                model=self._model,
+                contents=request.user_prompt,
+                config=config,
+            )
+        except APIError as err:
+            self._raise_normalized(err)
+        latency_ms = (time.perf_counter() - start) * 1000.0
+
+        parsed = getattr(response, "parsed", None)
+        if not isinstance(parsed, request.response_schema):
+            raw_text = getattr(response, "text", None) or ""
+            if not raw_text:
+                raise LLMServiceError("Gemini returned an empty response.")
+            raise LLMValidationError(
+                f"Gemini response did not match {request.response_schema.__name__}.",
+                raw_text=raw_text,
+            )
+
+        usage = self._extract_usage(response)
+        raw_text = getattr(response, "text", "") or ""
+
+        return StructuredLLMResult(
+            parsed=parsed,
+            raw_text=raw_text,
+            usage=usage,
+            model=self._model,
+            provider=_PROVIDER,
+            latency_ms=latency_ms,
+        )
+
+    @staticmethod
+    def _raise_normalized(err: APIError) -> None:
+        code = getattr(err, "code", None)
+        message = getattr(err, "message", None) or str(err)
+        if code == _RATE_LIMIT_CODE:
+            raise LLMRateLimitError(f"Gemini rate-limited: {message}") from err
+        if code in _RETRYABLE_SERVICE_CODES:
+            raise LLMServiceError(f"Gemini service error (HTTP {code}): {message}") from err
+        raise LLMServiceError(f"Gemini API error (HTTP {code}): {message}") from err
+
+    @staticmethod
+    def _extract_usage(response: Any) -> TokenUsage:
+        meta = getattr(response, "usage_metadata", None)
+        if meta is None:
+            return TokenUsage(input_tokens=0, output_tokens=0)
+        return TokenUsage(
+            input_tokens=getattr(meta, "prompt_token_count", 0) or 0,
+            output_tokens=getattr(meta, "candidates_token_count", 0) or 0,
+        )

--- a/llm/gemini_adapter.py
+++ b/llm/gemini_adapter.py
@@ -19,6 +19,7 @@ from google.genai import types as genai_types
 from google.genai.errors import APIError
 
 from .errors import (
+    LLMClientError,
     LLMMissingKeyError,
     LLMRateLimitError,
     LLMServiceError,
@@ -28,7 +29,8 @@ from .types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
 
 _PROVIDER = "gemini"
 _RATE_LIMIT_CODE = 429
-_RETRYABLE_SERVICE_CODES = {500, 503}
+# 5xx are transient upstream failures that LLMClient retries.
+_RETRYABLE_SERVICE_CODES = {500, 502, 503, 504}
 
 
 class GeminiAdapter:
@@ -103,6 +105,11 @@ class GeminiAdapter:
             raise LLMRateLimitError(f"Gemini rate-limited: {message}") from err
         if code in _RETRYABLE_SERVICE_CODES:
             raise LLMServiceError(f"Gemini service error (HTTP {code}): {message}") from err
+        if isinstance(code, int) and 400 <= code < 500:
+            # Permanent client-side failure (expired key, invalid model,
+            # malformed request, quota exhausted). NOT retried.
+            raise LLMClientError(f"Gemini API error (HTTP {code}): {message}") from err
+        # Unknown / non-HTTP error — treat as transient service to be safe.
         raise LLMServiceError(f"Gemini API error (HTTP {code}): {message}") from err
 
     @staticmethod

--- a/llm/types.py
+++ b/llm/types.py
@@ -1,0 +1,56 @@
+"""Request / result / usage types for the LLM seam.
+
+These are the contract between application code and any LLM provider.
+The application sees only these shapes, never provider-native objects.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+
+@dataclass(frozen=True)
+class StructuredLLMRequest:
+    """A request for a validated cognitive artifact.
+
+    The application asks for a Pydantic model; the adapter returns one
+    or raises a normalized error. The application never sees raw text
+    unless it explicitly inspects ``StructuredLLMResult.raw_text``.
+    """
+
+    system_prompt: str
+    user_prompt: str
+    response_schema: type[BaseModel]
+    temperature: float = 0.0
+    max_retries: int = 2
+    task_name: str | None = None
+    prompt_version: str | None = None
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Provider-agnostic token usage."""
+
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass(frozen=True)
+class StructuredLLMResult:
+    """A validated cognitive artifact, plus the metadata to debug it.
+
+    ``parsed`` is already a Pydantic instance of the requested schema.
+    ``raw_text`` is preserved for logging and golden-fixture refresh.
+    ``raw_provider_metadata`` is an escape hatch — provider-specific data
+    that would otherwise pollute the normalized shape.
+    """
+
+    parsed: BaseModel
+    raw_text: str
+    usage: TokenUsage
+    model: str
+    provider: str
+    latency_ms: float
+    raw_provider_metadata: dict[str, Any] | None = None

--- a/main.py
+++ b/main.py
@@ -334,37 +334,50 @@ def extract(req: ExtractRequest):
         provisional_map = extract_knowledge_map(src.text, api_key=req.api_key)
         # Wire-shape preserved: frontend consumes a dict at "knowledge_map".
         return {"knowledge_map": provisional_map.model_dump()}
+    # All LLM-error branches: stable user-facing copy ONLY. Provider details
+    # (model name, error code, original message) flow into operator logs but
+    # never into the response body. This is consistent across the whole LLM
+    # error hierarchy — the user is never told which provider we use.
     except LLMMissingKeyError as err:
-        raise HTTPException(status_code=401, detail=str(err))
-    except LLMRateLimitError as err:
-        raise HTTPException(status_code=429, detail=str(err))
-    except LLMValidationError:
-        # Provider returned content but it did not match ProvisionalMap.
-        # Stable user-facing copy; raw_text is preserved internally for
-        # logging / fixture refresh but never surfaced to the user.
-        logger.warning(
-            "extract_knowledge_map: LLMValidationError on /api/extract"
+        logger.warning("extract: LLMMissingKeyError: %s", err)
+        raise HTTPException(
+            status_code=401,
+            detail="No API key configured. Add one in Settings to continue.",
         )
+    except LLMRateLimitError as err:
+        logger.warning("extract: LLMRateLimitError: %s", err)
+        raise HTTPException(
+            status_code=429,
+            detail="The AI service is rate-limiting requests. Try again in a minute.",
+        )
+    except LLMValidationError as err:
+        # raw_text preserved internally on the exception object for fixture
+        # refresh / debugging; never serialized to the response.
+        logger.warning("extract: LLMValidationError: %s", err)
         raise HTTPException(
             status_code=502,
             detail="Extraction returned malformed structure. Please retry.",
         )
     except LLMServiceError as err:
-        raise HTTPException(status_code=503, detail=str(err))
-    except LLMClientError as err:
-        # Operator-misconfiguration (expired key, unknown model, etc.).
-        # Surface as 503 to the learner — same UX as a transient outage —
-        # but log the underlying message so the operator can fix the root
-        # cause. Stable user-facing copy; do NOT leak the API error string.
-        logger.warning(
-            "extract_knowledge_map: LLMClientError on /api/extract: %s", err
-        )
+        logger.warning("extract: LLMServiceError: %s", err)
         raise HTTPException(
             status_code=503,
-            detail="Extraction service is temporarily unavailable. Please try again shortly.",
+            detail="The AI service is temporarily unavailable. Please try again shortly.",
+        )
+    except LLMClientError as err:
+        # Operator-misconfiguration (expired key, unknown model, etc.).
+        # Same UX as a transient outage from the learner's perspective.
+        logger.warning("extract: LLMClientError: %s", err)
+        raise HTTPException(
+            status_code=503,
+            detail="The AI service is temporarily unavailable. Please try again shortly.",
         )
     except ValueError as err:
-        # Pydantic structural-validation errors raised by ProvisionalMap.
+        # Pydantic structural-validation errors raised by ProvisionalMap
+        # (closure rules, identifier grammar). The message here is OUR
+        # internal validator output, not provider-debug, so it is safe
+        # AND informative to surface.
+        logger.warning("extract: structural validation failed: %s", err)
         raise HTTPException(status_code=422, detail=str(err))
     except Exception as err:
         logger.exception("Unexpected failure in /api/extract")

--- a/main.py
+++ b/main.py
@@ -25,6 +25,12 @@ from ai_service import (
     generate_repair_reps,
     get_drill_session_time_limit_seconds,
 )
+from llm.errors import (
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
 import source_intake
 from source_intake import (
     BlockedSource,
@@ -324,16 +330,29 @@ def extract(req: ExtractRequest):
             detail="Couldn't find enough readable text in what you pasted.",
         )
     try:
-        knowledge_map = extract_knowledge_map(src.text, api_key=req.api_key)
-        return {"knowledge_map": knowledge_map}
-    except MissingAPIKeyError as err:
+        provisional_map = extract_knowledge_map(src.text, api_key=req.api_key)
+        # Wire-shape preserved: frontend consumes a dict at "knowledge_map".
+        return {"knowledge_map": provisional_map.model_dump()}
+    except LLMMissingKeyError as err:
         raise HTTPException(status_code=401, detail=str(err))
-    except GeminiRateLimitError as err:
+    except LLMRateLimitError as err:
         raise HTTPException(status_code=429, detail=str(err))
-    except GeminiServiceError as err:
+    except LLMValidationError:
+        # Provider returned content but it did not match ProvisionalMap.
+        # Stable user-facing copy; raw_text is preserved internally for
+        # logging / fixture refresh but never surfaced to the user.
+        logger.warning(
+            "extract_knowledge_map: LLMValidationError on /api/extract"
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Extraction returned malformed structure. Please retry.",
+        )
+    except LLMServiceError as err:
         raise HTTPException(status_code=503, detail=str(err))
     except ValueError as err:
-        raise HTTPException(status_code=400, detail=str(err))
+        # Pydantic structural-validation errors raised by ProvisionalMap.
+        raise HTTPException(status_code=422, detail=str(err))
     except Exception as err:
         logger.exception("Unexpected failure in /api/extract")
         raise HTTPException(

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from ai_service import (
     get_drill_session_time_limit_seconds,
 )
 from llm.errors import (
+    LLMClientError,
     LLMMissingKeyError,
     LLMRateLimitError,
     LLMServiceError,
@@ -350,6 +351,18 @@ def extract(req: ExtractRequest):
         )
     except LLMServiceError as err:
         raise HTTPException(status_code=503, detail=str(err))
+    except LLMClientError as err:
+        # Operator-misconfiguration (expired key, unknown model, etc.).
+        # Surface as 503 to the learner — same UX as a transient outage —
+        # but log the underlying message so the operator can fix the root
+        # cause. Stable user-facing copy; do NOT leak the API error string.
+        logger.warning(
+            "extract_knowledge_map: LLMClientError on /api/extract: %s", err
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Extraction service is temporarily unavailable. Please try again shortly.",
+        )
     except ValueError as err:
         # Pydantic structural-validation errors raised by ProvisionalMap.
         raise HTTPException(status_code=422, detail=str(err))

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,17 @@
+from .identifiers import (
+    BackboneId,
+    ClusterId,
+    IdKind,
+    SubnodeId,
+    parse_id,
+    CORE_THESIS,
+)
+
+__all__ = [
+    "BackboneId",
+    "ClusterId",
+    "IdKind",
+    "SubnodeId",
+    "parse_id",
+    "CORE_THESIS",
+]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,6 +6,17 @@ from .identifiers import (
     parse_id,
     CORE_THESIS,
 )
+from .provisional_map import (
+    BackboneItem,
+    Cluster,
+    DomainMechanic,
+    Framework,
+    LearningPrereq,
+    Metadata,
+    ProvisionalMap,
+    Relationships,
+    Subnode,
+)
 
 __all__ = [
     "BackboneId",
@@ -14,4 +25,13 @@ __all__ = [
     "SubnodeId",
     "parse_id",
     "CORE_THESIS",
+    "BackboneItem",
+    "Cluster",
+    "DomainMechanic",
+    "Framework",
+    "LearningPrereq",
+    "Metadata",
+    "ProvisionalMap",
+    "Relationships",
+    "Subnode",
 ]

--- a/models/identifiers.py
+++ b/models/identifiers.py
@@ -1,0 +1,74 @@
+"""Identifier grammar for ProvisionalMap nodes.
+
+Grammar:
+  - ``"core-thesis"`` — the single root concept of a map
+  - ``"b<N>"`` — backbone node, N in 1..99
+  - ``"c<N>"`` — cluster node, N in 1..99
+  - ``"c<N>_s<M>"`` — subnode of cluster c<N>, M in 1..99
+
+Parsing rejects everything else. This is the contract enforced at the
+ProvisionalMap boundary.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Tuple, Union
+
+CORE_THESIS = "core-thesis"
+
+_BACKBONE_RE = re.compile(r"^b(\d{1,2})$")
+_CLUSTER_RE = re.compile(r"^c(\d{1,2})$")
+_SUBNODE_RE = re.compile(r"^(c\d{1,2})_s(\d{1,2})$")
+
+
+class IdKind(Enum):
+    CORE_THESIS = "core-thesis"
+    BACKBONE = "backbone"
+    CLUSTER = "cluster"
+    SUBNODE = "subnode"
+
+
+@dataclass(frozen=True)
+class BackboneId:
+    raw: str
+
+    def __str__(self) -> str:
+        return self.raw
+
+
+@dataclass(frozen=True)
+class ClusterId:
+    raw: str
+
+    def __str__(self) -> str:
+        return self.raw
+
+
+@dataclass(frozen=True)
+class SubnodeId:
+    raw: str
+    cluster_id: str
+
+    def __str__(self) -> str:
+        return self.raw
+
+
+ParsedId = Union[str, BackboneId, ClusterId, SubnodeId]
+
+
+def parse_id(value: str) -> Tuple[IdKind, ParsedId]:
+    """Return ``(kind, parsed)``. Raises ``ValueError`` on malformed input."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"id must be a non-empty string, got {value!r}")
+    if value == CORE_THESIS:
+        return IdKind.CORE_THESIS, value
+    if _BACKBONE_RE.match(value):
+        return IdKind.BACKBONE, BackboneId(raw=value)
+    if _CLUSTER_RE.match(value):
+        return IdKind.CLUSTER, ClusterId(raw=value)
+    m = _SUBNODE_RE.match(value)
+    if m:
+        return IdKind.SUBNODE, SubnodeId(raw=value, cluster_id=m.group(1))
+    raise ValueError(f"unrecognized id grammar: {value!r}")

--- a/models/provisional_map.py
+++ b/models/provisional_map.py
@@ -1,0 +1,260 @@
+"""ProvisionalMap — the typed cognitive artifact contract.
+
+Mirrors the JSON schema described in ``app_prompts/extract-system-v1.txt``.
+Application code that consumes extraction output sees this type, never a
+dict. Structural integrity is enforced at parse time:
+
+  - Every id (backbone, cluster, subnode) matches the identifier grammar
+  - Every subnode lives in its declared cluster (c1_s2 must be inside c1)
+  - Every cluster id referenced by backbone, relationships, or frameworks exists
+  - Every cluster is covered by at least one backbone's dependent_clusters
+  - Every cluster has at least one subnode (MINIMUM DRILLABILITY RULE)
+  - Learning-prerequisite edges form a DAG (no self-loops, no cycles, no reciprocals)
+
+What is NOT enforced here:
+  - Quality minimums (>=N nodes total): governed by the prompt
+  - Framework quality gates: governed by the prompt
+
+Models do NOT use ``extra="forbid"`` because Gemini's response_schema
+parameter rejects the resulting JSON Schema (additionalProperties: false).
+See ``ai_service.py:_parse_repair_reps_response`` for the same precedent.
+"""
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .identifiers import IdKind, parse_id
+
+
+# --- Leaf shapes -------------------------------------------------------------
+
+
+class Metadata(BaseModel):
+    source_title: str
+    core_thesis: str
+    architecture_type: Literal[
+        "causal_chain", "problem_solution", "comparison", "system_description"
+    ]
+    difficulty: Literal["easy", "medium", "hard"]
+    governing_assumptions: List[str] = Field(default_factory=list)
+    low_density: bool = False
+
+
+class Subnode(BaseModel):
+    id: str
+    label: str
+    mechanism: str
+    drill_status: Optional[str] = None
+    gap_type: Optional[str] = None
+    gap_description: Optional[str] = None
+    last_drilled: Optional[str] = None
+
+    @field_validator("id")
+    @classmethod
+    def _subnode_only(cls, v: str) -> str:
+        kind, _ = parse_id(v)
+        if kind is not IdKind.SUBNODE:
+            raise ValueError(f"subnode id must match c<N>_s<M>, got {v!r}")
+        return v
+
+
+class Cluster(BaseModel):
+    id: str
+    label: str
+    description: str
+    subnodes: List[Subnode] = Field(default_factory=list)
+
+    @field_validator("id")
+    @classmethod
+    def _cluster_only(cls, v: str) -> str:
+        kind, _ = parse_id(v)
+        if kind is not IdKind.CLUSTER:
+            raise ValueError(f"cluster id must match c<N>, got {v!r}")
+        return v
+
+    @model_validator(mode="after")
+    def _subnodes_belong_to_this_cluster(self) -> "Cluster":
+        for sn in self.subnodes:
+            kind, parsed = parse_id(sn.id)
+            assert kind is IdKind.SUBNODE
+            if parsed.cluster_id != self.id:  # type: ignore[union-attr]
+                raise ValueError(
+                    f"subnode {sn.id!r} does not belong to cluster {self.id!r}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _at_least_one_subnode(self) -> "Cluster":
+        # Per extract prompt MINIMUM DRILLABILITY RULE.
+        if not self.subnodes:
+            raise ValueError(
+                f"cluster {self.id!r} must contain at least one subnode (drillability rule)"
+            )
+        return self
+
+
+class BackboneItem(BaseModel):
+    id: str
+    principle: str
+    dependent_clusters: List[str] = Field(default_factory=list)
+
+    @field_validator("id")
+    @classmethod
+    def _backbone_only(cls, v: str) -> str:
+        kind, _ = parse_id(v)
+        if kind is not IdKind.BACKBONE:
+            raise ValueError(f"backbone id must match b<N>, got {v!r}")
+        return v
+
+
+class DomainMechanic(BaseModel):
+    # populate_by_name lets construction via from_=... work even though the
+    # JSON key is "from" (a Python keyword). Validation accepts either.
+    model_config = ConfigDict(populate_by_name=True)
+
+    from_: str = Field(alias="from")
+    to: str
+    type: Literal["causal", "bidirectional", "amplifies", "suppresses", "tension"]
+    mechanism: str
+
+
+class LearningPrereq(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    from_: str = Field(alias="from")
+    to: str
+    rationale: str
+
+
+class Relationships(BaseModel):
+    domain_mechanics: List[DomainMechanic] = Field(default_factory=list)
+    learning_prerequisites: List[LearningPrereq] = Field(default_factory=list)
+
+
+class Framework(BaseModel):
+    id: str
+    name: str
+    statement: str
+    source_clusters: List[str] = Field(default_factory=list)
+    external_application: str
+
+
+# --- Top-level shape ---------------------------------------------------------
+
+
+class ProvisionalMap(BaseModel):
+    """A typed knowledge map. Consumed by drill, repair-reps, traversal."""
+
+    metadata: Metadata
+    backbone: List[BackboneItem]
+    clusters: List[Cluster]
+    relationships: Relationships
+    frameworks: List[Framework] = Field(default_factory=list)
+
+    # --- Closure validators ---
+
+    @model_validator(mode="after")
+    def _every_id_unique(self) -> "ProvisionalMap":
+        ids = [c.id for c in self.clusters]
+        if len(ids) != len(set(ids)):
+            raise ValueError("duplicate cluster ids")
+        bb_ids = [b.id for b in self.backbone]
+        if len(bb_ids) != len(set(bb_ids)):
+            raise ValueError("duplicate backbone ids")
+        return self
+
+    @model_validator(mode="after")
+    def _backbone_dependent_clusters_exist(self) -> "ProvisionalMap":
+        cluster_ids = {c.id for c in self.clusters}
+        for bb in self.backbone:
+            for ref in bb.dependent_clusters:
+                if ref not in cluster_ids:
+                    raise ValueError(
+                        f"backbone {bb.id!r} lists unknown dependent_cluster {ref!r}"
+                    )
+        return self
+
+    @model_validator(mode="after")
+    def _every_cluster_covered_by_some_backbone(self) -> "ProvisionalMap":
+        # Per BACKBONE COVERAGE RULE in extract-system-v1.txt.
+        covered: set[str] = set()
+        for bb in self.backbone:
+            covered.update(bb.dependent_clusters)
+        cluster_ids = {c.id for c in self.clusters}
+        orphans = cluster_ids - covered
+        if orphans:
+            raise ValueError(
+                f"clusters not covered by any backbone: {sorted(orphans)}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _relationship_endpoints_exist(self) -> "ProvisionalMap":
+        cluster_ids = {c.id for c in self.clusters}
+        for dm in self.relationships.domain_mechanics:
+            for ref in (dm.from_, dm.to):
+                if ref not in cluster_ids:
+                    raise ValueError(
+                        f"domain_mechanics edge references unknown cluster {ref!r}"
+                    )
+        for lp in self.relationships.learning_prerequisites:
+            for ref in (lp.from_, lp.to):
+                if ref not in cluster_ids:
+                    raise ValueError(
+                        f"learning_prerequisites edge references unknown cluster {ref!r}"
+                    )
+            if lp.from_ == lp.to:
+                raise ValueError(f"learning_prerequisite self-loop on {lp.from_!r}")
+        return self
+
+    @model_validator(mode="after")
+    def _learning_prerequisites_acyclic(self) -> "ProvisionalMap":
+        # Per GRAPH-SAFETY RULES FOR PREREQUISITES.
+        edges: dict[str, list[str]] = {}
+        prereqs = list(self.relationships.learning_prerequisites)
+
+        # Reciprocal pair check (O(n^2) is fine for small n).
+        seen_pairs: set[tuple[str, str]] = set()
+        for lp in prereqs:
+            pair = (lp.from_, lp.to)
+            reverse = (lp.to, lp.from_)
+            if reverse in seen_pairs:
+                raise ValueError(
+                    f"reciprocal learning prerequisite: {lp.from_!r}<->{lp.to!r}"
+                )
+            seen_pairs.add(pair)
+            edges.setdefault(lp.from_, []).append(lp.to)
+
+        # DFS cycle detection.
+        WHITE, GRAY, BLACK = 0, 1, 2
+        colors: dict[str, int] = {}
+
+        def visit(node: str) -> None:
+            colors[node] = GRAY
+            for nb in edges.get(node, []):
+                state = colors.get(nb, WHITE)
+                if state == GRAY:
+                    raise ValueError(
+                        f"learning prerequisite cycle through {node!r}->{nb!r}"
+                    )
+                if state == WHITE:
+                    visit(nb)
+            colors[node] = BLACK
+
+        for node in list(edges.keys()):
+            if colors.get(node, WHITE) == WHITE:
+                visit(node)
+        return self
+
+    @model_validator(mode="after")
+    def _framework_source_clusters_exist(self) -> "ProvisionalMap":
+        cluster_ids = {c.id for c in self.clusters}
+        for fw in self.frameworks:
+            for ref in fw.source_clusters:
+                if ref not in cluster_ids:
+                    raise ValueError(
+                        f"framework {fw.id!r} references unknown cluster {ref!r}"
+                    )
+        return self

--- a/scripts/run_tasting_fixture.py
+++ b/scripts/run_tasting_fixture.py
@@ -233,11 +233,16 @@ def run_fixture(args: argparse.Namespace) -> int:
     }
 
     print(f"Running fixture: {fixture_title}")
-    knowledge_map = extract_knowledge_map(
+    # extract_knowledge_map now returns a ProvisionalMap (Pydantic).
+    # drill_chat and the dict-walking helpers in this script still expect a
+    # dict, so dump it. When drill_chat migrates through the seam too,
+    # update both call sites at once.
+    provisional_map = extract_knowledge_map(
         fixture["source_text"],
         api_key=args.api_key,
         telemetry_context=base_telemetry,
     )
+    knowledge_map = provisional_map.model_dump()
     print_map_summary(knowledge_map)
 
     node = resolve_node(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep_in_llm_client(monkeypatch):
+    """Replace LLMClient backoff sleep with a no-op so retry tests stay fast.
+
+    Only affects the LLMClient retry path; tests that need real timing
+    measure latency_ms via time.perf_counter.
+    """
+    try:
+        import llm.client as _client_mod  # type: ignore
+    except ImportError:
+        return  # llm package not yet built; nothing to patch
+    if hasattr(_client_mod.LLMClient, "_sleep_backoff"):
+        monkeypatch.setattr(
+            _client_mod.LLMClient,
+            "_sleep_backoff",
+            staticmethod(lambda attempt: None),
+        )

--- a/tests/test_extract_knowledge_map_migration.py
+++ b/tests/test_extract_knowledge_map_migration.py
@@ -1,0 +1,115 @@
+"""Task 9 — extract_knowledge_map now returns a ProvisionalMap via LLMClient."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from llm.errors import (
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMValidationError,
+)
+from llm.types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
+from models import ProvisionalMap
+
+
+VALID_MAP_DICT = {
+    "metadata": {
+        "source_title": "Test source",
+        "core_thesis": "Test thesis.",
+        "architecture_type": "system_description",
+        "difficulty": "easy",
+        "governing_assumptions": [],
+        "low_density": False,
+    },
+    "backbone": [
+        {"id": "b1", "principle": "test principle", "dependent_clusters": ["c1"]}
+    ],
+    "clusters": [
+        {
+            "id": "c1",
+            "label": "x",
+            "description": "x",
+            "subnodes": [
+                {
+                    "id": "c1_s1",
+                    "label": "x",
+                    "mechanism": "x",
+                    "drill_status": None,
+                    "gap_type": None,
+                    "gap_description": None,
+                    "last_drilled": None,
+                }
+            ],
+        }
+    ],
+    "relationships": {"domain_mechanics": [], "learning_prerequisites": []},
+    "frameworks": [],
+}
+
+
+@dataclass
+class _FakeClient:
+    """Captures calls; returns a pre-built StructuredLLMResult."""
+    response: StructuredLLMResult | None = None
+    raises: Exception | None = None
+    last_request: StructuredLLMRequest | None = None
+
+    def generate_structured(self, request: StructuredLLMRequest) -> StructuredLLMResult:
+        self.last_request = request
+        if self.raises is not None:
+            raise self.raises
+        return self.response  # type: ignore[return-value]
+
+
+def _ok_result() -> StructuredLLMResult:
+    return StructuredLLMResult(
+        parsed=ProvisionalMap.model_validate(VALID_MAP_DICT),
+        raw_text="{}",
+        usage=TokenUsage(input_tokens=10, output_tokens=20),
+        model="gemini-2.5-flash",
+        provider="gemini",
+        latency_ms=12.0,
+    )
+
+
+def test_extract_returns_provisional_map():
+    from ai_service import extract_knowledge_map
+
+    fake = _FakeClient(response=_ok_result())
+    result = extract_knowledge_map(
+        "raw text input here for extraction",
+        llm=fake,
+    )
+    assert isinstance(result, ProvisionalMap)
+    assert result.metadata.core_thesis == "Test thesis."
+
+
+def test_extract_request_uses_provisional_map_schema():
+    from ai_service import extract_knowledge_map
+
+    fake = _FakeClient(response=_ok_result())
+    extract_knowledge_map("some raw text", llm=fake)
+
+    assert fake.last_request is not None
+    assert fake.last_request.response_schema is ProvisionalMap
+    assert fake.last_request.task_name == "provisional_map_generation"
+    assert "some raw text" in fake.last_request.user_prompt
+
+
+def test_extract_propagates_validation_error():
+    from ai_service import extract_knowledge_map
+
+    fake = _FakeClient(raises=LLMValidationError("bad shape", raw_text="{...}"))
+    with pytest.raises(LLMValidationError):
+        extract_knowledge_map("text", llm=fake)
+
+
+def test_extract_propagates_rate_limit_and_missing_key():
+    from ai_service import extract_knowledge_map
+
+    for exc in (LLMRateLimitError("r"), LLMMissingKeyError("k")):
+        fake = _FakeClient(raises=exc)
+        with pytest.raises(type(exc)):
+            extract_knowledge_map("text", llm=fake)

--- a/tests/test_extract_route_error_mapping.py
+++ b/tests/test_extract_route_error_mapping.py
@@ -95,6 +95,41 @@ def test_route_client_error_does_not_leak_provider_message(client):
     assert "Gemini" not in detail
 
 
+# Provider-debug strings that MUST NEVER appear in the user-facing detail
+# regardless of which LLM error type is raised.
+_LEAKY_PROVIDER_TOKENS = ("Gemini", "HTTP 400", "HTTP 429", "HTTP 503", "gemini-2.5-flash")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        LLMMissingKeyError("No Gemini API key configured. Set GEMINI_API_KEY."),
+        LLMRateLimitError("Gemini rate-limited: too many requests"),
+        LLMServiceError("Gemini service error (HTTP 503): upstream"),
+        LLMClientError("Gemini API error (HTTP 400): expired key"),
+        LLMValidationError(
+            "Gemini response did not match ProvisionalMap.",
+            raw_text='{"oops":"data"}',
+        ),
+    ],
+    ids=["missing_key", "rate_limit", "service", "client", "validation"],
+)
+def test_no_llm_error_leaks_provider_details_to_user(client, exc):
+    """Across the entire LLM error hierarchy, the user-facing detail must
+    contain stable copy and no provider-internal strings. Surfaced by the
+    Gemini sanity check: previously LLMMissingKeyError, LLMRateLimitError,
+    and LLMServiceError used `str(err)` which leaked the provider name and
+    HTTP code into the wire response.
+    """
+    with patch("main.extract_knowledge_map", side_effect=exc):
+        resp = _post(client)
+    detail = resp.json().get("detail", "")
+    for token in _LEAKY_PROVIDER_TOKENS:
+        assert token not in detail, (
+            f"{type(exc).__name__} response leaked {token!r} via detail: {detail!r}"
+        )
+
+
 def test_route_validation_error_does_not_leak_raw_text(client):
     """LLMValidationError carries raw_text for fixture refresh, but the
     user-facing message must be stable copy, not the raw response.

--- a/tests/test_extract_route_error_mapping.py
+++ b/tests/test_extract_route_error_mapping.py
@@ -1,0 +1,93 @@
+"""Task 10 — /api/extract maps normalized LLM errors to HTTP statuses.
+
+These are wiring tests for the route's new exception mapping. Source-intake
+behavior is unchanged (covered by tests/test_extract_route.py); these
+tests cover the post-intake LLM seam errors.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+from auth.service import AuthSessionState
+from llm.errors import (
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
+
+
+class _FakeAuthService:
+    def __init__(self):
+        self.enabled = True
+        self.cookie_name = "wos_session"
+        self.cookie_samesite = "lax"
+        self.cookie_max_age = 120
+        self.oauth_state_cookie_name = "wos_oauth_state"
+        self.oauth_state_ttl_seconds = 600
+        self.current_state = AuthSessionState(
+            auth_enabled=True, authenticated=True, guest_mode=True
+        )
+
+    def load_session(self, sealed_session):
+        return self.current_state
+
+    def resolve_cookie_secure(self, base_url: str) -> bool:
+        return base_url.startswith("https://")
+
+
+@pytest.fixture
+def client():
+    original = main.app.state.auth_service
+    service = _FakeAuthService()
+    main.app.state.auth_service = service
+    test_client = TestClient(main.app)
+    test_client.cookies.set(service.cookie_name, "sealed-anon-blob")
+    try:
+        yield test_client
+    finally:
+        main.app.state.auth_service = original
+
+
+def _post(client):
+    # ParseEmpty floor for from_text is 1 char in default; a non-empty
+    # short string is enough to reach extract_knowledge_map.
+    return client.post("/api/extract", json={"text": "x" * 250})
+
+
+@pytest.mark.parametrize(
+    "exc_cls, expected_status",
+    [
+        (LLMMissingKeyError, 401),
+        (LLMRateLimitError, 429),
+        (LLMServiceError, 503),
+        (LLMValidationError, 502),
+    ],
+)
+def test_route_maps_normalized_errors_to_http(client, exc_cls, expected_status):
+    if exc_cls is LLMValidationError:
+        exc_instance: Exception = exc_cls("boom", raw_text="{}")
+    else:
+        exc_instance = exc_cls("boom")
+    with patch("main.extract_knowledge_map", side_effect=exc_instance):
+        resp = _post(client)
+    assert resp.status_code == expected_status, resp.json()
+
+
+def test_route_validation_error_does_not_leak_raw_text(client):
+    """LLMValidationError carries raw_text for fixture refresh, but the
+    user-facing message must be stable copy, not the raw response.
+    """
+    leaky_raw = '{"this_should_not_leak": "to user"}'
+    exc = LLMValidationError("internal mismatch", raw_text=leaky_raw)
+    with patch("main.extract_knowledge_map", side_effect=exc):
+        resp = _post(client)
+    assert resp.status_code == 502
+    body = resp.json()
+    detail = body.get("detail", "")
+    assert "this_should_not_leak" not in detail
+    assert "to user" not in detail

--- a/tests/test_extract_route_error_mapping.py
+++ b/tests/test_extract_route_error_mapping.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 import main
 from auth.service import AuthSessionState
 from llm.errors import (
+    LLMClientError,
     LLMMissingKeyError,
     LLMRateLimitError,
     LLMServiceError,
@@ -65,6 +66,7 @@ def _post(client):
         (LLMMissingKeyError, 401),
         (LLMRateLimitError, 429),
         (LLMServiceError, 503),
+        (LLMClientError, 503),
         (LLMValidationError, 502),
     ],
 )
@@ -76,6 +78,21 @@ def test_route_maps_normalized_errors_to_http(client, exc_cls, expected_status):
     with patch("main.extract_knowledge_map", side_effect=exc_instance):
         resp = _post(client)
     assert resp.status_code == expected_status, resp.json()
+
+
+def test_route_client_error_does_not_leak_provider_message(client):
+    """LLMClientError carries operator-debug detail (e.g., 'API key expired').
+    The user-facing message must be stable copy; the operator gets the real
+    cause via the warning log only.
+    """
+    leaky = LLMClientError("Gemini API error (HTTP 400): API key expired")
+    with patch("main.extract_knowledge_map", side_effect=leaky):
+        resp = _post(client)
+    assert resp.status_code == 503
+    detail = resp.json().get("detail", "")
+    assert "API key" not in detail
+    assert "HTTP 400" not in detail
+    assert "Gemini" not in detail
 
 
 def test_route_validation_error_does_not_leak_raw_text(client):

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -46,3 +46,54 @@ def test_explicit_key_overrides_missing_env(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="intercepted"):
         adapter.call_once(_request())
+
+
+# --- Error-code classification (Task 5.2) ------------------------------------
+
+
+class _FakeAPIError(Exception):
+    """Stand-in for google.genai.errors.APIError; same .code/.message contract."""
+
+    def __init__(self, code: int, message: str = "boom"):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _patch_genai_client(monkeypatch, *, raises=None, response=None):
+    """Replace genai.Client(...) construction with a fake whose
+    .models.generate_content either raises or returns response.
+    """
+    fake_models = MagicMock()
+    if raises is not None:
+        fake_models.generate_content.side_effect = raises
+    else:
+        fake_models.generate_content.return_value = response
+    fake_client = MagicMock()
+    fake_client.models = fake_models
+
+    import llm.gemini_adapter as ga
+    monkeypatch.setattr(ga.genai, "Client", lambda **_: fake_client)
+
+
+def test_429_maps_to_rate_limit_error(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    import llm.gemini_adapter as ga
+    monkeypatch.setattr(ga, "APIError", _FakeAPIError)
+    _patch_genai_client(monkeypatch, raises=_FakeAPIError(429))
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMRateLimitError):
+        adapter.call_once(_request())
+
+
+@pytest.mark.parametrize("code", [500, 503, 504, 401, 400])
+def test_other_codes_map_to_service_error(monkeypatch, code):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    import llm.gemini_adapter as ga
+    monkeypatch.setattr(ga, "APIError", _FakeAPIError)
+    _patch_genai_client(monkeypatch, raises=_FakeAPIError(code))
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMServiceError):
+        adapter.call_once(_request())

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -148,3 +148,46 @@ def test_empty_text_raises_service_error(monkeypatch):
     adapter = GeminiAdapter(model="gemini-2.5-flash")
     with pytest.raises(LLMServiceError):
         adapter.call_once(_request())
+
+
+# --- Happy path (Task 5.4) ---------------------------------------------------
+
+
+def test_happy_path_returns_structured_result(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    fake_response = MagicMock()
+    fake_response.parsed = _Schema(x="hello")
+    fake_response.text = '{"x": "hello"}'
+    fake_response.usage_metadata = MagicMock(
+        prompt_token_count=42, candidates_token_count=7
+    )
+    _patch_genai_client(monkeypatch, response=fake_response)
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    result = adapter.call_once(_request())
+
+    assert isinstance(result.parsed, _Schema)
+    assert result.parsed.x == "hello"
+    assert result.raw_text == '{"x": "hello"}'
+    assert result.usage.input_tokens == 42
+    assert result.usage.output_tokens == 7
+    assert result.model == "gemini-2.5-flash"
+    assert result.provider == "gemini"
+    assert result.latency_ms >= 0.0
+
+
+def test_happy_path_handles_missing_usage_metadata(monkeypatch):
+    """Some Gemini responses (e.g., short circuits) may omit usage_metadata."""
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    fake_response = MagicMock()
+    fake_response.parsed = _Schema(x="hello")
+    fake_response.text = '{"x":"hello"}'
+    fake_response.usage_metadata = None
+    _patch_genai_client(monkeypatch, response=fake_response)
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    result = adapter.call_once(_request())
+    assert result.usage.input_tokens == 0
+    assert result.usage.output_tokens == 0

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from llm.errors import (
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
+from llm.gemini_adapter import GeminiAdapter
+from llm.types import StructuredLLMRequest
+
+
+class _Schema(BaseModel):
+    x: str
+
+
+def _request() -> StructuredLLMRequest:
+    return StructuredLLMRequest(
+        system_prompt="sys", user_prompt="user", response_schema=_Schema
+    )
+
+
+def test_missing_key_raises_missing_key_error(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    adapter = GeminiAdapter(api_key=None, model="gemini-2.5-flash")
+    with pytest.raises(LLMMissingKeyError):
+        adapter.call_once(_request())
+
+
+def test_explicit_key_overrides_missing_env(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    # No SDK call should happen here — _resolve_key passes; we'll patch the
+    # client to fail loudly if anything tries to use it. Construction must succeed.
+    adapter = GeminiAdapter(api_key="explicit-key", model="gemini-2.5-flash")
+    # Replace the SDK call so we do not actually hit Gemini in this minimal check.
+    import llm.gemini_adapter as ga
+    monkeypatch.setattr(
+        ga.genai,
+        "Client",
+        lambda **_: MagicMock(models=MagicMock(generate_content=MagicMock(side_effect=RuntimeError("intercepted")))),
+    )
+    with pytest.raises(RuntimeError, match="intercepted"):
+        adapter.call_once(_request())

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from llm.errors import (
+    LLMClientError,
     LLMMissingKeyError,
     LLMRateLimitError,
     LLMServiceError,
@@ -87,12 +88,45 @@ def test_429_maps_to_rate_limit_error(monkeypatch):
         adapter.call_once(_request())
 
 
-@pytest.mark.parametrize("code", [500, 503, 504, 401, 400])
-def test_other_codes_map_to_service_error(monkeypatch, code):
+@pytest.mark.parametrize("code", [500, 502, 503, 504])
+def test_5xx_codes_map_to_service_error(monkeypatch, code):
+    """5xx are transient upstream failures — retried by LLMClient."""
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")
     import llm.gemini_adapter as ga
     monkeypatch.setattr(ga, "APIError", _FakeAPIError)
     _patch_genai_client(monkeypatch, raises=_FakeAPIError(code))
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMServiceError):
+        adapter.call_once(_request())
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404])
+def test_4xx_non_429_codes_map_to_client_error(monkeypatch, code):
+    """Non-429 4xx are permanent client failures — NOT retried.
+
+    Reproduces the "API key expired" 400 we saw end-to-end on a stale
+    GEMINI_API_KEY: the adapter must classify it as LLMClientError so
+    LLMClient skips the retry loop.
+    """
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    import llm.gemini_adapter as ga
+    monkeypatch.setattr(ga, "APIError", _FakeAPIError)
+    _patch_genai_client(monkeypatch, raises=_FakeAPIError(code))
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMClientError):
+        adapter.call_once(_request())
+
+
+def test_unknown_error_code_treated_as_service_error(monkeypatch):
+    """When .code is not an int (e.g., None), treat as transient service."""
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    import llm.gemini_adapter as ga
+    monkeypatch.setattr(ga, "APIError", _FakeAPIError)
+    err = _FakeAPIError(0)
+    err.code = None  # type: ignore[assignment]
+    _patch_genai_client(monkeypatch, raises=err)
 
     adapter = GeminiAdapter(model="gemini-2.5-flash")
     with pytest.raises(LLMServiceError):

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -97,3 +97,54 @@ def test_other_codes_map_to_service_error(monkeypatch, code):
     adapter = GeminiAdapter(model="gemini-2.5-flash")
     with pytest.raises(LLMServiceError):
         adapter.call_once(_request())
+
+
+# --- Schema validation failure (Task 5.3) ------------------------------------
+
+
+def test_parsed_none_with_text_raises_validation_error(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    fake_response = MagicMock()
+    fake_response.parsed = None
+    fake_response.text = '{"oops": "wrong shape"}'
+    fake_response.usage_metadata = MagicMock(
+        prompt_token_count=10, candidates_token_count=5
+    )
+    _patch_genai_client(monkeypatch, response=fake_response)
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMValidationError) as exc_info:
+        adapter.call_once(_request())
+    assert exc_info.value.raw_text == '{"oops": "wrong shape"}'
+
+
+def test_parsed_wrong_type_raises_validation_error(monkeypatch):
+    """parsed exists but is the wrong Pydantic class."""
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    class _OtherSchema(BaseModel):
+        y: str
+
+    fake_response = MagicMock()
+    fake_response.parsed = _OtherSchema(y="something")
+    fake_response.text = '{"y":"something"}'
+    fake_response.usage_metadata = MagicMock(prompt_token_count=1, candidates_token_count=1)
+    _patch_genai_client(monkeypatch, response=fake_response)
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMValidationError):
+        adapter.call_once(_request())
+
+
+def test_empty_text_raises_service_error(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    fake_response = MagicMock()
+    fake_response.parsed = None
+    fake_response.text = ""
+    _patch_genai_client(monkeypatch, response=fake_response)
+
+    adapter = GeminiAdapter(model="gemini-2.5-flash")
+    with pytest.raises(LLMServiceError):
+        adapter.call_once(_request())

--- a/tests/test_llm_adapter_protocol.py
+++ b/tests/test_llm_adapter_protocol.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+
+from llm.adapter import LLMAdapter
+from llm.types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
+
+
+class _Schema(BaseModel):
+    x: str
+
+
+class FakeAdapter:
+    """A duck-typed adapter that should satisfy the Protocol."""
+
+    def call_once(self, request: StructuredLLMRequest) -> StructuredLLMResult:
+        parsed = _Schema(x="ok")
+        return StructuredLLMResult(
+            parsed=parsed,
+            raw_text='{"x":"ok"}',
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+            model="fake",
+            provider="fake",
+            latency_ms=1.0,
+        )
+
+
+def test_fake_adapter_satisfies_protocol_at_runtime():
+    adapter = FakeAdapter()
+    assert isinstance(adapter, LLMAdapter)
+
+
+def test_protocol_documents_call_once():
+    # call_once is the single primitive the Protocol exposes.
+    assert hasattr(LLMAdapter, "call_once")
+
+
+def test_non_adapter_class_does_not_satisfy_protocol():
+    class _NotAnAdapter:
+        def something_else(self) -> None: ...
+
+    assert not isinstance(_NotAnAdapter(), LLMAdapter)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from llm.client import LLMClient
+from llm.errors import (
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
+from llm.types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
+
+
+class _Schema(BaseModel):
+    x: str
+
+
+def _ok_result() -> StructuredLLMResult:
+    return StructuredLLMResult(
+        parsed=_Schema(x="ok"),
+        raw_text='{"x":"ok"}',
+        usage=TokenUsage(input_tokens=1, output_tokens=1),
+        model="fake",
+        provider="fake",
+        latency_ms=10.0,
+    )
+
+
+def _request() -> StructuredLLMRequest:
+    return StructuredLLMRequest(
+        system_prompt="sys",
+        user_prompt="user",
+        response_schema=_Schema,
+        max_retries=2,
+        task_name="test_task",
+        prompt_version="v1",
+    )
+
+
+class _CountingAdapter:
+    """Minimal LLMAdapter — counts calls; can be primed to raise or return."""
+
+    def __init__(self, *, raises=None, returns=None):
+        self.calls = 0
+        self._raises = list(raises) if raises else []
+        self._returns = returns
+
+    def call_once(self, request):
+        self.calls += 1
+        if self._raises:
+            exc = self._raises.pop(0)
+            if exc is not None:
+                raise exc
+        return self._returns or _ok_result()
+
+
+def test_happy_path_delegates_once():
+    adapter = _CountingAdapter()
+    client = LLMClient(adapter=adapter)
+    result = client.generate_structured(_request())
+    assert result.parsed.x == "ok"
+    assert adapter.calls == 1

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from llm.client import LLMClient
 from llm.errors import (
+    LLMClientError,
     LLMMissingKeyError,
     LLMRateLimitError,
     LLMServiceError,
@@ -109,6 +110,20 @@ def test_does_not_retry_on_missing_key_error():
     adapter = _CountingAdapter(raises=[LLMMissingKeyError("no key")])
     client = LLMClient(adapter=adapter)
     with pytest.raises(LLMMissingKeyError):
+        client.generate_structured(_request())
+    assert adapter.calls == 1
+
+
+def test_does_not_retry_on_client_error():
+    """4xx-non-429 errors are permanent — LLMClient must NOT retry them.
+
+    This was a real bug discovered live: an expired GEMINI_API_KEY (HTTP
+    400) was being retried 3 times before giving up, wasting quota and
+    time. LLMClientError is the fix; this test prevents regression.
+    """
+    adapter = _CountingAdapter(raises=[LLMClientError("expired key")])
+    client = LLMClient(adapter=adapter)
+    with pytest.raises(LLMClientError):
         client.generate_structured(_request())
     assert adapter.calls == 1
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -62,3 +62,34 @@ def test_happy_path_delegates_once():
     result = client.generate_structured(_request())
     assert result.parsed.x == "ok"
     assert adapter.calls == 1
+
+
+def test_retries_on_rate_limit_then_succeeds():
+    adapter = _CountingAdapter(raises=[LLMRateLimitError("rate"), None])
+    client = LLMClient(adapter=adapter)
+    result = client.generate_structured(_request())
+    assert result.parsed.x == "ok"
+    assert adapter.calls == 2  # one fail + one success
+
+
+def test_retries_on_service_error_then_succeeds():
+    adapter = _CountingAdapter(raises=[LLMServiceError("svc"), None])
+    client = LLMClient(adapter=adapter)
+    result = client.generate_structured(_request())
+    assert result.parsed.x == "ok"
+    assert adapter.calls == 2
+
+
+def test_gives_up_after_max_retries_on_rate_limit():
+    adapter = _CountingAdapter(
+        raises=[
+            LLMRateLimitError("r1"),
+            LLMRateLimitError("r2"),
+            LLMRateLimitError("r3"),
+        ]
+    )
+    client = LLMClient(adapter=adapter)
+    with pytest.raises(LLMRateLimitError):
+        client.generate_structured(_request())
+    # max_retries=2 → up to 2 retries beyond initial → 3 total calls
+    assert adapter.calls == 3

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 from pydantic import BaseModel
 
@@ -109,3 +111,37 @@ def test_does_not_retry_on_missing_key_error():
     with pytest.raises(LLMMissingKeyError):
         client.generate_structured(_request())
     assert adapter.calls == 1
+
+
+def test_emits_structured_log_on_success(caplog):
+    adapter = _CountingAdapter()
+    client = LLMClient(adapter=adapter)
+    with caplog.at_level(logging.INFO, logger="llm.client"):
+        client.generate_structured(_request())
+    matches = [
+        r
+        for r in caplog.records
+        if r.name == "llm.client"
+        and getattr(r, "task_name", None) == "test_task"
+        and getattr(r, "prompt_version", None) == "v1"
+        and getattr(r, "provider", None) == "fake"
+        and getattr(r, "input_tokens", None) == 1
+        and getattr(r, "output_tokens", None) == 1
+    ]
+    assert matches, f"no structured success log matched. records: {caplog.records}"
+
+
+def test_emits_structured_log_on_failure(caplog):
+    adapter = _CountingAdapter(raises=[LLMValidationError("bad")])
+    client = LLMClient(adapter=adapter)
+    with caplog.at_level(logging.WARNING, logger="llm.client"):
+        with pytest.raises(LLMValidationError):
+            client.generate_structured(_request())
+    matches = [
+        r
+        for r in caplog.records
+        if r.name == "llm.client"
+        and getattr(r, "task_name", None) == "test_task"
+        and getattr(r, "error_class", None) == "LLMValidationError"
+    ]
+    assert matches, f"no structured failure log matched. records: {caplog.records}"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -93,3 +93,19 @@ def test_gives_up_after_max_retries_on_rate_limit():
         client.generate_structured(_request())
     # max_retries=2 → up to 2 retries beyond initial → 3 total calls
     assert adapter.calls == 3
+
+
+def test_does_not_retry_on_validation_error():
+    adapter = _CountingAdapter(raises=[LLMValidationError("bad shape")])
+    client = LLMClient(adapter=adapter)
+    with pytest.raises(LLMValidationError):
+        client.generate_structured(_request())
+    assert adapter.calls == 1
+
+
+def test_does_not_retry_on_missing_key_error():
+    adapter = _CountingAdapter(raises=[LLMMissingKeyError("no key")])
+    client = LLMClient(adapter=adapter)
+    with pytest.raises(LLMMissingKeyError):
+        client.generate_structured(_request())
+    assert adapter.calls == 1

--- a/tests/test_llm_errors.py
+++ b/tests/test_llm_errors.py
@@ -1,0 +1,41 @@
+from llm.errors import (
+    LLMError,
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServiceError,
+    LLMValidationError,
+)
+
+
+def test_all_subclasses_inherit_from_llm_error():
+    for cls in (
+        LLMMissingKeyError,
+        LLMRateLimitError,
+        LLMServiceError,
+        LLMValidationError,
+    ):
+        assert issubclass(cls, LLMError)
+        assert issubclass(cls, Exception)
+
+
+def test_subclasses_are_distinct():
+    classes = {
+        LLMMissingKeyError,
+        LLMRateLimitError,
+        LLMServiceError,
+        LLMValidationError,
+    }
+    assert len(classes) == 4
+    assert not issubclass(LLMValidationError, LLMServiceError)
+    assert not issubclass(LLMRateLimitError, LLMServiceError)
+
+
+def test_validation_error_carries_message_and_optional_raw_text():
+    err = LLMValidationError("bad shape", raw_text='{"oops":')
+    assert "bad shape" in str(err)
+    assert err.raw_text == '{"oops":'
+
+
+def test_validation_error_raw_text_defaults_none():
+    err = LLMValidationError("bad shape")
+    assert err.raw_text is None

--- a/tests/test_llm_errors.py
+++ b/tests/test_llm_errors.py
@@ -5,6 +5,7 @@ from llm.errors import (
     LLMRateLimitError,
     LLMServiceError,
     LLMValidationError,
+    RetriableLLMError,
 )
 
 
@@ -15,6 +16,7 @@ def test_all_subclasses_inherit_from_llm_error():
         LLMRateLimitError,
         LLMServiceError,
         LLMValidationError,
+        RetriableLLMError,
     ):
         assert issubclass(cls, LLMError)
         assert issubclass(cls, Exception)
@@ -35,6 +37,21 @@ def test_subclasses_are_distinct():
     # LLMClient's retry loop would erroneously retry permanent 4xx failures.
     assert not issubclass(LLMClientError, LLMServiceError)
     assert not issubclass(LLMClientError, LLMRateLimitError)
+
+
+def test_retriable_marker_governs_retry_set():
+    """RetriableLLMError is the single source of truth for "LLMClient retries this."
+    Lock in the membership so a future error class added without thinking
+    about retries can't accidentally land in (or out of) the retry set.
+    """
+    # Retried — must subclass RetriableLLMError
+    assert issubclass(LLMRateLimitError, RetriableLLMError)
+    assert issubclass(LLMServiceError, RetriableLLMError)
+
+    # Permanent — must NOT subclass RetriableLLMError
+    assert not issubclass(LLMMissingKeyError, RetriableLLMError)
+    assert not issubclass(LLMClientError, RetriableLLMError)
+    assert not issubclass(LLMValidationError, RetriableLLMError)
 
 
 def test_validation_error_carries_message_and_optional_raw_text():

--- a/tests/test_llm_errors.py
+++ b/tests/test_llm_errors.py
@@ -1,4 +1,5 @@
 from llm.errors import (
+    LLMClientError,
     LLMError,
     LLMMissingKeyError,
     LLMRateLimitError,
@@ -9,6 +10,7 @@ from llm.errors import (
 
 def test_all_subclasses_inherit_from_llm_error():
     for cls in (
+        LLMClientError,
         LLMMissingKeyError,
         LLMRateLimitError,
         LLMServiceError,
@@ -20,14 +22,19 @@ def test_all_subclasses_inherit_from_llm_error():
 
 def test_subclasses_are_distinct():
     classes = {
+        LLMClientError,
         LLMMissingKeyError,
         LLMRateLimitError,
         LLMServiceError,
         LLMValidationError,
     }
-    assert len(classes) == 4
+    assert len(classes) == 5
     assert not issubclass(LLMValidationError, LLMServiceError)
     assert not issubclass(LLMRateLimitError, LLMServiceError)
+    # Critical: LLMClientError must NOT subclass LLMServiceError, otherwise
+    # LLMClient's retry loop would erroneously retry permanent 4xx failures.
+    assert not issubclass(LLMClientError, LLMServiceError)
+    assert not issubclass(LLMClientError, LLMRateLimitError)
 
 
 def test_validation_error_carries_message_and_optional_raw_text():

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -1,0 +1,56 @@
+import pytest
+
+
+def test_public_imports_resolve():
+    # These names must all be importable from `llm` directly.
+    from llm import (
+        LLMClient,
+        StructuredLLMRequest,
+        StructuredLLMResult,
+        TokenUsage,
+        LLMError,
+        LLMMissingKeyError,
+        LLMRateLimitError,
+        LLMServiceError,
+        LLMValidationError,
+        build_llm_client,
+    )
+    assert callable(build_llm_client)
+
+
+def test_build_llm_client_default_provider_is_gemini(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    from llm import build_llm_client, LLMClient
+    client = build_llm_client()
+    assert isinstance(client, LLMClient)
+
+
+def test_build_llm_client_unknown_provider_errors(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    from llm import build_llm_client
+    with pytest.raises(NotImplementedError):
+        build_llm_client()
+
+
+def test_build_llm_client_passes_api_key_to_adapter(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    from llm import build_llm_client
+
+    client = build_llm_client(api_key="explicit-key")
+    # The adapter should hold the explicit key, ready to resolve on call.
+    from llm.gemini_adapter import GeminiAdapter
+    assert isinstance(client.adapter, GeminiAdapter)
+    assert client.adapter._explicit_key == "explicit-key"
+
+
+def test_build_llm_client_respects_model_env(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    monkeypatch.setenv("LLM_MODEL", "gemini-2.5-pro")
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    from llm import build_llm_client
+
+    client = build_llm_client()
+    assert client.adapter._model == "gemini-2.5-pro"

--- a/tests/test_llm_seam_isolation.py
+++ b/tests/test_llm_seam_isolation.py
@@ -77,15 +77,18 @@ def test_gemini_sdk_only_imported_in_adapter():
     )
 
 
-@pytest.mark.xfail(
-    reason="Closes after Task 9 migrates extract_knowledge_map onto llm.LLMClient",
-    strict=True,
-)
 def test_extract_knowledge_map_uses_llm_seam():
-    """Stronger invariant after Task 9: ai_service.py must use llm.LLMClient
-    at least for the extract path. Marked xfail until that lands.
+    """ai_service.py must use llm.LLMClient at least for the extract path.
+
+    Closed by Task 9. drill_chat and generate_repair_reps still use the
+    legacy SDK, so the file still imports google.genai overall — but
+    extract_knowledge_map now goes through the seam. When those paths
+    migrate, the broader isolation test above will tighten too.
     """
     ai_service = (REPO_ROOT / "ai_service.py").read_text(encoding="utf-8")
     assert (
-        "from llm" in ai_service or "import llm" in ai_service
-    ), "ai_service.py must use llm.LLMClient at least for the extract path"
+        "from llm import" in ai_service
+    ), "ai_service.py must import from llm for the extract path"
+    assert (
+        "ProvisionalMap" in ai_service
+    ), "ai_service.py must reference ProvisionalMap as the extract return type"

--- a/tests/test_llm_seam_isolation.py
+++ b/tests/test_llm_seam_isolation.py
@@ -1,0 +1,91 @@
+"""Architectural invariant: the Gemini SDK lives ONLY behind the seam.
+
+If this test fails, application code re-coupled to a provider. The fix is
+NOT to add the file to ``_ALLOWED``; it is to route the call through
+``llm.LLMClient`` instead.
+
+See ADR-0003 for the rationale.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Paths that may import the Gemini SDK directly. Keep this set MINIMAL.
+_ALLOWED = {"llm/gemini_adapter.py"}
+
+# Substrings that indicate a Gemini-SDK import.
+_FORBIDDEN_IMPORT_NEEDLES = (
+    "from google import genai",
+    "from google.genai",
+    "import google.genai",
+    "from google.generativeai",
+    "import google.generativeai",
+)
+
+# Directories to skip entirely.
+_SKIP_DIR_PARTS = {
+    ".venv",
+    "venv",
+    ".git",
+    "node_modules",
+    "__pycache__",
+    "tmp",
+    ".pytest_cache",
+    "test-results",
+    "logs",
+    ".worktrees",
+}
+
+
+def _iter_repo_python_files():
+    for py_path in REPO_ROOT.rglob("*.py"):
+        if any(part in _SKIP_DIR_PARTS for part in py_path.parts):
+            continue
+        yield py_path
+
+
+def test_gemini_sdk_only_imported_in_adapter():
+    """No file outside llm/gemini_adapter.py may import the Gemini SDK.
+
+    Exception (temporary): ai_service.py still uses the legacy Gemini SDK
+    for drill_chat and generate_repair_reps. Those paths migrate in a
+    follow-up sweep. Once migrated, remove ai_service.py from the exception
+    list and tighten the assertion.
+    """
+    violations: list[str] = []
+    for py_path in _iter_repo_python_files():
+        rel = py_path.relative_to(REPO_ROOT).as_posix()
+        if rel in _ALLOWED:
+            continue
+        if rel == "ai_service.py":
+            # Temporary exception until drill_chat + generate_repair_reps migrate.
+            continue
+        try:
+            text = py_path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        for needle in _FORBIDDEN_IMPORT_NEEDLES:
+            if needle in text:
+                violations.append(f"{rel}: contains {needle!r}")
+    assert not violations, (
+        "LLM seam violation — provider import outside the adapter:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+@pytest.mark.xfail(
+    reason="Closes after Task 9 migrates extract_knowledge_map onto llm.LLMClient",
+    strict=True,
+)
+def test_extract_knowledge_map_uses_llm_seam():
+    """Stronger invariant after Task 9: ai_service.py must use llm.LLMClient
+    at least for the extract path. Marked xfail until that lands.
+    """
+    ai_service = (REPO_ROOT / "ai_service.py").read_text(encoding="utf-8")
+    assert (
+        "from llm" in ai_service or "import llm" in ai_service
+    ), "ai_service.py must use llm.LLMClient at least for the extract path"

--- a/tests/test_llm_types.py
+++ b/tests/test_llm_types.py
@@ -1,0 +1,54 @@
+import pytest
+from pydantic import BaseModel
+
+from llm.types import StructuredLLMRequest, StructuredLLMResult, TokenUsage
+
+
+class _DummySchema(BaseModel):
+    foo: str
+
+
+def test_request_constructs_with_required_and_defaults():
+    req = StructuredLLMRequest(
+        system_prompt="sys",
+        user_prompt="user",
+        response_schema=_DummySchema,
+    )
+    assert req.system_prompt == "sys"
+    assert req.user_prompt == "user"
+    assert req.response_schema is _DummySchema
+    assert req.temperature == 0.0
+    assert req.max_retries == 2
+    assert req.task_name is None
+    assert req.prompt_version is None
+
+
+def test_request_is_frozen():
+    req = StructuredLLMRequest(
+        system_prompt="s", user_prompt="u", response_schema=_DummySchema
+    )
+    with pytest.raises(Exception):
+        req.temperature = 0.5  # type: ignore[misc]
+
+
+def test_token_usage_constructs():
+    usage = TokenUsage(input_tokens=100, output_tokens=50)
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 50
+
+
+def test_result_constructs():
+    parsed = _DummySchema(foo="bar")
+    usage = TokenUsage(input_tokens=10, output_tokens=20)
+    result = StructuredLLMResult(
+        parsed=parsed,
+        raw_text='{"foo": "bar"}',
+        usage=usage,
+        model="gemini-2.5-flash",
+        provider="gemini",
+        latency_ms=123.4,
+    )
+    assert result.parsed is parsed
+    assert result.usage.input_tokens == 10
+    assert result.provider == "gemini"
+    assert result.raw_provider_metadata is None

--- a/tests/test_provisional_map.py
+++ b/tests/test_provisional_map.py
@@ -52,3 +52,87 @@ def test_invalid_ids_raise(bad_id):
 
 def test_core_thesis_constant():
     assert CORE_THESIS == "core-thesis"
+
+
+# ---------------------------------------------------------------------------
+# ProvisionalMap shape — Task 8.2
+# ---------------------------------------------------------------------------
+
+from models.provisional_map import ProvisionalMap
+
+
+VALID_MAP = {
+    "metadata": {
+        "source_title": "Entropy in closed systems",
+        "core_thesis": "Entropy increases in closed systems.",
+        "architecture_type": "system_description",
+        "difficulty": "medium",
+        "governing_assumptions": ["The system is closed."],
+        "low_density": False,
+    },
+    "backbone": [
+        {
+            "id": "b1",
+            "principle": "Disorder grows over time in isolated systems.",
+            "dependent_clusters": ["c1"],
+        }
+    ],
+    "clusters": [
+        {
+            "id": "c1",
+            "label": "Microstate counting drives entropy",
+            "description": "Each macrostate corresponds to many microstates; entropy reflects that count.",
+            "subnodes": [
+                {
+                    "id": "c1_s1",
+                    "label": "Boltzmann distribution",
+                    "mechanism": "Probability of a microstate is weighted by its energy.",
+                    "drill_status": None,
+                    "gap_type": None,
+                    "gap_description": None,
+                    "last_drilled": None,
+                }
+            ],
+        }
+    ],
+    "relationships": {
+        "domain_mechanics": [],
+        "learning_prerequisites": [],
+    },
+    "frameworks": [],
+}
+
+
+def test_provisional_map_parses_valid_input():
+    m = ProvisionalMap.model_validate(VALID_MAP)
+    assert m.metadata.core_thesis.startswith("Entropy")
+    assert len(m.backbone) == 1
+    assert len(m.clusters) == 1
+    assert len(m.clusters[0].subnodes) == 1
+    assert m.frameworks == []
+
+
+def test_provisional_map_rejects_bad_id():
+    bad = {
+        **VALID_MAP,
+        "backbone": [{"id": "X1", "principle": "x", "dependent_clusters": ["c1"]}],
+    }
+    with pytest.raises(ValueError):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_provisional_map_rejects_missing_metadata():
+    bad = {k: v for k, v in VALID_MAP.items() if k != "metadata"}
+    with pytest.raises(ValueError):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_provisional_map_tolerates_unknown_field_for_gemini_compat():
+    """Unknown fields must NOT raise — Gemini rejects extra='forbid' schemas
+    (additionalProperties: false in JSON Schema). Field-level correctness is
+    governed by the prompt + closure validators, not by extra='forbid'.
+    See ai_service.py:_parse_repair_reps_response for precedent.
+    """
+    permissive = {**VALID_MAP, "unexpected_top_level": "ignored"}
+    m = ProvisionalMap.model_validate(permissive)
+    assert m.metadata.core_thesis == "Entropy increases in closed systems."

--- a/tests/test_provisional_map.py
+++ b/tests/test_provisional_map.py
@@ -1,0 +1,54 @@
+import pytest
+
+from models.identifiers import (
+    BackboneId,
+    ClusterId,
+    SubnodeId,
+    parse_id,
+    IdKind,
+    CORE_THESIS,
+)
+
+
+def test_core_thesis_is_a_known_id():
+    kind, parsed = parse_id("core-thesis")
+    assert kind is IdKind.CORE_THESIS
+    assert parsed == "core-thesis"
+
+
+@pytest.mark.parametrize("good_id", ["b1", "b2", "b10", "b99"])
+def test_backbone_ids_parse(good_id):
+    kind, parsed = parse_id(good_id)
+    assert kind is IdKind.BACKBONE
+    assert isinstance(parsed, BackboneId)
+    assert str(parsed) == good_id
+
+
+@pytest.mark.parametrize("good_id", ["c1", "c2", "c10", "c99"])
+def test_cluster_ids_parse(good_id):
+    kind, parsed = parse_id(good_id)
+    assert kind is IdKind.CLUSTER
+    assert isinstance(parsed, ClusterId)
+    assert str(parsed) == good_id
+
+
+@pytest.mark.parametrize("good_id", ["c1_s1", "c2_s5", "c10_s12"])
+def test_subnode_ids_parse(good_id):
+    kind, parsed = parse_id(good_id)
+    assert kind is IdKind.SUBNODE
+    assert isinstance(parsed, SubnodeId)
+    assert parsed.cluster_id == good_id.split("_")[0]
+    assert str(parsed) == good_id
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    ["", "x1", "B1", "b", "c", "c1_s", "c1_s_1", "c-1", "1", "core_thesis", "framework_1"],
+)
+def test_invalid_ids_raise(bad_id):
+    with pytest.raises(ValueError):
+        parse_id(bad_id)
+
+
+def test_core_thesis_constant():
+    assert CORE_THESIS == "core-thesis"

--- a/tests/test_provisional_map.py
+++ b/tests/test_provisional_map.py
@@ -136,3 +136,184 @@ def test_provisional_map_tolerates_unknown_field_for_gemini_compat():
     permissive = {**VALID_MAP, "unexpected_top_level": "ignored"}
     m = ProvisionalMap.model_validate(permissive)
     assert m.metadata.core_thesis == "Entropy increases in closed systems."
+
+
+# ---------------------------------------------------------------------------
+# Closure-violation tests — Task 8.3
+# ---------------------------------------------------------------------------
+
+
+def _two_cluster_map():
+    """Returns a deep-copied valid two-cluster map for closure-violation tests."""
+    import copy
+    return copy.deepcopy(
+        {
+            "metadata": VALID_MAP["metadata"],
+            "backbone": [
+                {"id": "b1", "principle": "x", "dependent_clusters": ["c1", "c2"]}
+            ],
+            "clusters": [
+                {
+                    "id": "c1",
+                    "label": "x",
+                    "description": "x",
+                    "subnodes": [
+                        {
+                            "id": "c1_s1",
+                            "label": "x",
+                            "mechanism": "x",
+                            "drill_status": None,
+                            "gap_type": None,
+                            "gap_description": None,
+                            "last_drilled": None,
+                        }
+                    ],
+                },
+                {
+                    "id": "c2",
+                    "label": "y",
+                    "description": "y",
+                    "subnodes": [
+                        {
+                            "id": "c2_s1",
+                            "label": "y",
+                            "mechanism": "y",
+                            "drill_status": None,
+                            "gap_type": None,
+                            "gap_description": None,
+                            "last_drilled": None,
+                        }
+                    ],
+                },
+            ],
+            "relationships": {"domain_mechanics": [], "learning_prerequisites": []},
+            "frameworks": [],
+        }
+    )
+
+
+def test_subnode_in_wrong_cluster_rejected():
+    bad = _two_cluster_map()
+    # Move c1_s1 into c2 — it does not belong there.
+    bad["clusters"][0]["subnodes"] = []  # c1 needs at least 1 subnode → must keep one
+    bad["clusters"][1]["subnodes"].append(
+        {
+            "id": "c1_s2",  # subnode of c1, but inside c2
+            "label": "x",
+            "mechanism": "x",
+            "drill_status": None,
+            "gap_type": None,
+            "gap_description": None,
+            "last_drilled": None,
+        }
+    )
+    # Restore c1's subnode to satisfy the drillability rule
+    bad["clusters"][0]["subnodes"] = [
+        {
+            "id": "c1_s1",
+            "label": "x",
+            "mechanism": "x",
+            "drill_status": None,
+            "gap_type": None,
+            "gap_description": None,
+            "last_drilled": None,
+        }
+    ]
+    with pytest.raises(ValueError, match="does not belong to cluster"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_backbone_pointing_at_unknown_cluster_rejected():
+    bad = _two_cluster_map()
+    bad["backbone"][0]["dependent_clusters"] = ["c1", "c9"]  # c9 unknown
+    with pytest.raises(ValueError, match="unknown dependent_cluster"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_orphan_cluster_rejected():
+    bad = _two_cluster_map()
+    bad["backbone"][0]["dependent_clusters"] = ["c1"]  # c2 now uncovered
+    with pytest.raises(ValueError, match="not covered by any backbone"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_cluster_without_subnode_rejected():
+    bad = _two_cluster_map()
+    bad["clusters"][0]["subnodes"] = []  # empty cluster
+    with pytest.raises(ValueError, match="must contain at least one subnode"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_learning_prerequisite_self_loop_rejected():
+    bad = _two_cluster_map()
+    bad["relationships"]["learning_prerequisites"] = [
+        {"from": "c1", "to": "c1", "rationale": "x"}
+    ]
+    with pytest.raises(ValueError, match="self-loop"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_learning_prerequisite_reciprocal_rejected():
+    bad = _two_cluster_map()
+    bad["relationships"]["learning_prerequisites"] = [
+        {"from": "c1", "to": "c2", "rationale": "x"},
+        {"from": "c2", "to": "c1", "rationale": "y"},
+    ]
+    with pytest.raises(ValueError, match="reciprocal"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_learning_prerequisite_cycle_rejected():
+    """A 3-node cycle: c1 -> c2 -> c3 -> c1."""
+    bad = _two_cluster_map()
+    bad["clusters"].append(
+        {
+            "id": "c3",
+            "label": "z",
+            "description": "z",
+            "subnodes": [
+                {
+                    "id": "c3_s1",
+                    "label": "z",
+                    "mechanism": "z",
+                    "drill_status": None,
+                    "gap_type": None,
+                    "gap_description": None,
+                    "last_drilled": None,
+                }
+            ],
+        }
+    )
+    bad["backbone"][0]["dependent_clusters"] = ["c1", "c2", "c3"]
+    bad["relationships"]["learning_prerequisites"] = [
+        {"from": "c1", "to": "c2", "rationale": "x"},
+        {"from": "c2", "to": "c3", "rationale": "y"},
+        {"from": "c3", "to": "c1", "rationale": "z"},
+    ]
+    with pytest.raises(ValueError, match="cycle"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_framework_source_clusters_must_exist():
+    bad = _two_cluster_map()
+    bad["frameworks"] = [
+        {
+            "id": "f1",
+            "name": "Test framework",
+            "statement": "x",
+            "source_clusters": ["c9"],  # unknown
+            "external_application": "x",
+        }
+    ]
+    with pytest.raises(ValueError, match="references unknown cluster"):
+        ProvisionalMap.model_validate(bad)
+
+
+def test_duplicate_cluster_ids_rejected():
+    bad = _two_cluster_map()
+    # Duplicate the first cluster wholesale — same id, same subnodes — so the
+    # cluster-level validators all pass and only the top-level duplicate-id
+    # check is left to fire.
+    bad["clusters"][1] = {**bad["clusters"][0]}
+    with pytest.raises(ValueError, match="duplicate cluster ids"):
+        ProvisionalMap.model_validate(bad)


### PR DESCRIPTION
## Summary

Application code now asks for a validated cognitive artifact, never for "Gemini output." Provider-specific code (Google's `google-genai` SDK) lives behind a single seam (`llm/`) enforced by an architectural-invariant test. `extract_knowledge_map` is the first production path migrated through the seam; drill_chat and generate_repair_reps follow in a later sweep.

- Seam package: `llm/types.py`, `llm/errors.py`, `llm/adapter.py` (Protocol), `llm/client.py` (retry + telemetry), `llm/gemini_adapter.py` (the only file outside `llm/` that imports `google.genai`), `llm/factory.py`
- Typed contract: `models/identifiers.py` + `models/provisional_map.py` mirroring `app_prompts/extract-system-v1.txt`
- Architectural invariant: `tests/test_llm_seam_isolation.py`
- Migration: `extract_knowledge_map` returns `ProvisionalMap`; `/api/extract` route preserves wire shape via `.model_dump()`

Spec: `docs/superpowers/specs/2026-05-01-foundation-design.md`
Plan: `docs/superpowers/plans/2026-05-01-llm-seam-foundation.md`

## Design thesis

The seam is shaped by domain, not infrastructure: the application says "give me a `ProvisionalMap`," and what's behind that is a swappable provider concern. The retry contract is encoded in the type system via `RetriableLLMError` — the retry loop reads `except RetriableLLMError`, so a future error class can't silently land in the wrong category. Stable user-facing copy across the entire `LLMError` hierarchy means the learner is never told which AI provider we use.

## What changes for callers

- `extract_knowledge_map(raw_text, *, llm=None, api_key=None, telemetry_context=None) -> ProvisionalMap` (was `-> dict`)
- `/api/extract` response wire shape unchanged: `{"knowledge_map": {...}}`
- `/api/extract` error mapping: `LLMMissingKeyError -> 401`, `LLMRateLimitError -> 429`, `LLMValidationError -> 502`, `LLMServiceError -> 503`, `LLMClientError -> 503`, `ValueError -> 422`. All produce stable user-facing copy; provider-internal strings flow into operator logs only.
- One internal caller updated: `scripts/run_tasting_fixture.py` calls `.model_dump()` on the returned `ProvisionalMap` so its dict-walking helpers (and downstream `drill_chat`, which is unmigrated) continue to work.

## Validation

- 562 unit tests passing (95 new). Includes parametrized leak-test across the entire LLM error hierarchy, retry-classification regression gates, and architectural isolation invariant.
- Live smoke against real Gemini (`python tmp/smoke_extract.py`): SUCCESS — `ProvisionalMap` returned with sensible structure, all closure validators passing on real LLM output.
- Sandbox run with Gemini sanity check (codex-style review with `gemini -m gemini-2.5-pro --approval-mode plan`); 4 of its findings actioned in this branch (orphaned constant, unmigrated script caller, retry-contract abstraction, error-copy consistency).

## Out of scope (deferred)

- Migrate `drill_chat` and `generate_repair_reps` through the seam — closes the temporary `ai_service.py` exception in `tests/test_llm_seam_isolation.py`
- Anthropic / OpenAI adapters — seam is ready; adding new providers is later focused work
- Prompt registry filesystem layout (spec section 5.4)
- Static-analysis baseline ruff/mypy (spec section 5.8)
- `ImportedSource.intake_mode` (spec section 5.7)
- Golden fixtures for `ProvisionalMap` extraction (spec section 5.6)
- ADRs 0001 / 0002 / 0003 — to be written alongside this branch's design before merge

## Test plan

- [x] `pytest tests/ --ignore=tests/e2e` → 562 passing
- [x] `python tmp/smoke_extract.py` (live Gemini, bypasses route + auth) → SUCCESS
- [ ] Browser smoke after merge: paste a passage in the Concept Threshold form on a deploy preview; confirm a Provisional graph renders and `/api/extract` returns 200 with the expected `knowledge_map` shape
- [ ] `bash scripts/qa-smoke.sh` against a deploy preview before promoting

🤖 Generated with [Claude Code](https://claude.com/claude-code)