### PR TITLE
feat(admin): add /admin/health liveness probe

### DIFF
--- a/admin/router.py
+++ b/admin/router.py
@@ -354,6 +354,14 @@ def admin_feedback_dismiss(feedback_id: str, request: Request):
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
+@admin_router.get("/admin/health")
+def admin_health_check():
+    """Liveness probe for the admin router. Confirms the router is mounted
+    and reachable. Does not check upstream dependencies (Supabase, etc.).
+    """
+    return JSONResponse({"status": "ok"})
+
+
 def register_admin_router(app: FastAPI) -> bool:
     """Include admin_router into `app` IFF dev-environment + Tink TODO file exists.
 

--- a/tests/test_admin_router.py
+++ b/tests/test_admin_router.py
@@ -333,3 +333,24 @@ class AdminRegistrationTests(unittest.TestCase):
             self.assertFalse(admin_module._is_dev_environment())
         finally:
             os.environ.pop("APP_BASE_URL")
+
+
+class AdminHealthCheckTests(unittest.TestCase):
+    """The /admin/health endpoint is an unauthenticated liveness probe.
+
+    It is intentionally NOT gated by `_require_admin` — it just confirms
+    the router is mounted. Authentication on a health check would defeat
+    the purpose (infra needs to probe before any session exists).
+    """
+
+    def test_health_check_returns_200_for_anonymous(self):
+        client = TestClient(_build_app())
+        r = client.get("/admin/health")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"status": "ok"})
+
+    def test_health_check_returns_200_for_admin(self):
+        client = TestClient(_build_app(_admin_state()))
+        r = client.get("/admin/health")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"status": "ok"})


### PR DESCRIPTION
## Summary

Adds an unauthenticated `GET /admin/health` endpoint to `admin_router` returning `{"status": "ok"}`. Useful as an infra/dev liveness probe to confirm the dev-environment gating in `register_admin_router` actually mounted the router.

The endpoint is intentionally not gated by `_require_admin` — a health check must work before any session exists, and `admin_router` is already only registered in dev environments (`_is_dev_environment()` + `TINK_TODO_PATH.exists()` per `register_admin_router`).

## Origin

A WIP edit in another session also added this endpoint, but accidentally produced a duplicate of `admin_feedback_dismiss` (same function name, same `@admin_router.delete(...)` decorator, same body). FastAPI would error on duplicate route registration on app startup. This PR is the clean version — health-check only, no duplicate.

## Test plan

- [x] `pytest tests/test_admin_router.py` → 24 passing (22 existing + 2 new health-check tests)
- [x] `pytest tests/ --ignore=tests/e2e` → 465 passing, no regressions
- [ ] After merge: hit `/admin/health` on a local dev server; confirm 200 OK with the expected JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)