### PR TITLE
feat(ui): conversational concept creation — chat → summary card + design follow-ups

### DIFF
--- a/app_prompts/threshold-chat-system-v1.txt
+++ b/app_prompts/threshold-chat-system-v1.txt
@@ -41,10 +41,14 @@ The analogy must be:
 - Familiar to a typical adult learner — no domain expertise required to
   follow it
 - Mapped cleanly onto the target concept's causal structure
-- Generated fresh from the concept, NOT templated. The kitchen-meal
-  analogy works for photosynthesis but not for kubernetes; for kubernetes
-  use a shipping yard with containers; for cognitive bias use a familiar
-  perception illusion. Always derive from the concept, never template.
+- Generated fresh from the concept, NOT templated. Example shape, not a
+  template. Ask the learner to give one example of the concept — anywhere
+  they've encountered it, even a small detail. The 'one example' framing
+  is universal and works across concept types (processes, state quantities,
+  abstract nouns). For example: 'Give me one place you've seen this concept
+  come up — a moment in something you've read, or in your own experience.'
+  Always derive the surface phrasing from the concept; never reuse the
+  literal example.
 
 After the fallback question lands and the learner replies (substantive or
 not), the chat ends. There is no third real turn.

--- a/docs/superpowers/plans/2026-05-04-conversational-concept-creation-frontend.md
+++ b/docs/superpowers/plans/2026-05-04-conversational-concept-creation-frontend.md
@@ -1,0 +1,1944 @@
+# Conversational Concept Creation — Frontend (Plan B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the form-based `showNameField` branch of `buildContentInputUI` (in `public/js/app.js:684`) with a two-stage conversational flow — Threshold chat → Summary card with three chips and a state-dependent build CTA — wired to the Plan A backend at `POST /api/extract` (already on `dev` at commit `086e617`).
+
+**Architecture:**
+- A small chat surface drives a 2-turn (+ optional analogical-fallback) state machine and exits to a summary card. The card holds three editable chips (`Concept`, `Your sketch`, `Source material`) and one CTA whose copy + enabled state derives from a 4-state truth table (spec §3.2). Submit posts `{name, starting_sketch, source}` to `/api/extract`; the backend dispatches between `generate_provisional_map_from_sketch` (no source) and `extract_knowledge_map` (source attached).
+- Substantiveness is enforced server-side as the authority; the frontend ports `models/sketch_validation.py` to JS as a UX optimisation that disables the CTA preemptively. Parity is locked by `tests/fixtures/sketch_validation_parity.json` (28 entries incl. unicode) and verified by a node-based fixture test that runs in `pytest`.
+- Frontend telemetry events fire through a tiny `Bus.emit('telemetry', …)` + `console.info('telemetry', …)` helper. No backend post endpoint exists yet for client telemetry; that is a documented Plan B follow-up. Server-side telemetry from Plan A is unchanged.
+
+**Tech Stack:**
+- Vanilla ES modules in `public/js/`, plain CSS in `public/css/`. No frameworks, no build step, no new npm packages.
+- Tests run via `pytest` shelling out to `node --check` (see `tests/test_frontend_syntax.py` for the existing pattern). The new parity test will follow the same shape: load fixture JSON, run a small node script that requires the JS module, compare verdicts.
+- Backend is already shipped on `dev`. This plan touches **zero Python production code**; only JS, CSS, and one new test file plus a small node-side runner.
+
+---
+
+## File Structure
+
+### Created
+- `public/js/sketch-validation.js` — JS port of `models/sketch_validation.py`. Exported `isSubstantiveSketch(text: string): boolean`. Module-only (no DOM access).
+- `public/js/telemetry.js` — Tiny helper. Single export `emitTelemetry(event, extra)`. Wraps `Bus.emit('telemetry', …)` and `console.info('telemetry', …)`. No network calls in v1.
+- `public/js/concept-create.js` — New module owning the conversational flow. Exports `buildConversationalCreateUI(container, { onSubmit, onCancel })`. Internal state machine for chat turns + summary card. Imports `isSubstantiveSketch` and `emitTelemetry`.
+- `tests/test_frontend_sketch_validation.py` — Pytest harness that runs a node script against `tests/fixtures/sketch_validation_parity.json` and asserts byte-for-byte parity with the Python heuristic. Skips when `node` is not on PATH (mirrors `test_frontend_syntax.py`).
+- `tests/_helpers/run_sketch_parity.mjs` — Node runner used by the pytest harness. Loads the fixture, calls `isSubstantiveSketch` for each entry, prints JSON `[{idx, text, expected, actual}]` to stdout. No deps, single file.
+
+### Modified
+- `public/js/app.js` — Remove the entire `showNameField === true` branch from `buildContentInputUI` (line 684 onward, including its HTML template, placeholder rotators `PLACEHOLDERS` / `NAME_PLACEHOLDERS` / `phTimer` / `namePhTimer`, and submit construction of `thresholdContext`). The `showNameField === false` branch stays intact (used by other inline-overlay flows). Update `startAddConcept` (line 1199) to call `buildConversationalCreateUI` from the new module instead of `buildContentInputUI({ showNameField: true })`. Update the success path to consume `{provisional_map}` for the new payload while still consuming `{knowledge_map}` for legacy (server returns one or the other depending on dispatch).
+- `public/js/ai_service.js` — Add a new export `submitConceptCreate({ name, startingSketch, source, apiKey })` that posts the new payload shape and surfaces 422 `{error, message}` to callers. Keep `generateKnowledgeMap(rawText)` for back-compat (some callers may still use it) but it is no longer invoked by the modal.
+- `public/css/components.css` — **Delete** the form-only classes: `.creation-intro`, `.creation-intro-compact`, `.creation-intro-row`, `.creation-intro-title`, `.creation-intro-copy`, `.creation-name-input` + focus/placeholder, `.creation-threshold` + head/copy/input/focus/placeholder, `.creation-fuzzy-toggle` + states, `.creation-fuzzy-row`, `.creation-fuzzy-hint`, `.creation-fuzzy-panel`, `.creation-fuzzy-input`, `.creation-source-meta`, `.creation-source-copy`, `.creation-source-header`, `.creation-validation`. **Keep** the modal shell classes (`.creation-dialog*`), the redesigned `.creation-source-tabs .overlay-tab` styles, `.creation-cancel`, `.creation-submit`, `.creation-footer`, and the `.paste-clipboard-btn` / `.paste-actions` row. **Add** new classes for the chat surface and summary card (Task 7 spells these out explicitly).
+
+### Untouched
+- `public/js/api-client.js`, `public/js/auth.js`, `public/js/login.js`, `public/js/feedback.js`, `public/js/graph-view.js`, `public/js/store.js`, `public/js/dom.js`, `public/js/welcome.js`, `public/js/intro-particles.js`, `public/js/tooltips.js`.
+- All Python production code under `main.py`, `ai_service.py`, `learning_commons.py`, `models/`, `app_prompts/`. These ship from Plan A and the frontend trusts the contract.
+- All existing tests under `tests/` (apart from the new parity test added in this plan).
+
+---
+
+## Self-Review Anchor (read before starting Task 1)
+
+Spec coverage map (each spec section → tasks that cover it):
+- §3.1 (Stage A — chat) → Task 4, Task 5.
+- §3.2 (Stage B — summary card incl. chip table, CTA truth table, validation copy, edit interactions) → Task 6, Task 7, Task 8.
+- §3.3 (Stage C — submit dispatch + LC-as-enrichment trust) → Task 9.
+- §4 (frontend file map) → Task 8 (deletion), Task 11 (CSS delete + add).
+- §5.4 (telemetry events) → Task 2 (helper) + the events are planted at the correct call sites in Tasks 4, 6, 7, 9.
+- §8 (acceptance criteria) → Task 12 (verification gate).
+- Anti-pattern list (Appendix B + handoff §"Anti-patterns") → enforced by the absolute bans the implementer must reject; checked in Task 12.
+
+Type/name consistency lock-in (used across tasks):
+- `isSubstantiveSketch(text)` — JS export name. Camel-case (JS convention) even though the Python is `is_substantive_sketch`.
+- `emitTelemetry(event, extra)` — single argument shape; `event` is a string like `concept_create.summary.shown`, `extra` is a plain object.
+- `buildConversationalCreateUI(container, { onSubmit, onCancel })` — top-level public API of `concept-create.js`. Returns `{ destroy() }` to mirror the existing `buildContentInputUI` contract.
+- Internal stage constants: `'chat:turn-1' | 'chat:turn-2' | 'chat:fallback' | 'summary'`.
+- Chip identifiers used in telemetry: `'concept' | 'sketch' | 'source'`.
+- Source `type` values: `'text' | 'url' | 'file'` — matches backend `SourceAttachment` model.
+- Submit payload shape: `{ name: string, starting_sketch: string, source: null | { type, text?, url?, filename? } }`.
+- Response shape: `{ provisional_map: {...} }` (no source) or `{ knowledge_map: {...} }` (source attached). Both render with the same downstream graph code; the caller normalizes.
+
+---
+
+## Task 1: JS port of `isSubstantiveSketch` (parity-locked)
+
+**Goal:** A single-file ES module that returns the same verdict as `models/sketch_validation.py` for every entry in `tests/fixtures/sketch_validation_parity.json`. Unicode-correct (`\p{L}\p{N}_\s` with `/u` flag), `MIN_SUBSTANTIVE_TOKENS = 8`, identical stopword set, identical "don't know" pattern list, identical repeated-character rule.
+
+**Files:**
+- Create: `public/js/sketch-validation.js`
+- Create: `tests/_helpers/run_sketch_parity.mjs`
+- Create: `tests/test_frontend_sketch_validation.py`
+
+- [ ] **Step 1: Write the parity-fixture pytest harness (failing test)**
+
+The Python test runs the node helper once and asserts every fixture entry agrees. This is the harness; the JS module does not exist yet.
+
+```python
+# tests/test_frontend_sketch_validation.py
+"""JS parity test for is_substantive_sketch.
+
+Loads the shared fixture (used by both Python tests and this JS harness),
+shells out to a small node runner, and asserts byte-for-byte verdict parity.
+A divergence is a release-blocker per spec §5.3 / handoff §2.
+
+Skipped when `node` is unavailable (mirrors tests/test_frontend_syntax.py).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "sketch_validation_parity.json"
+RUNNER = REPO_ROOT / "tests" / "_helpers" / "run_sketch_parity.mjs"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_js_sketch_validation_matches_python_for_every_fixture_entry() -> None:
+    assert FIXTURE.exists(), f"fixture missing: {FIXTURE}"
+    assert RUNNER.exists(), f"node runner missing: {RUNNER}"
+
+    result = subprocess.run(
+        ["node", str(RUNNER)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"node runner failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    rows = json.loads(result.stdout)
+    assert isinstance(rows, list) and rows, "runner produced no rows"
+
+    mismatches = [r for r in rows if r["expected"] != r["actual"]]
+    if mismatches:
+        msg = "\n".join(
+            f"  idx={r['idx']} text={r['text']!r} expected={r['expected']} actual={r['actual']}"
+            for r in mismatches
+        )
+        pytest.fail(
+            f"JS sketch_validation diverges from Python on {len(mismatches)}/{len(rows)} entries:\n{msg}"
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_frontend_sketch_validation.py -v`
+Expected: FAIL with `node runner missing` (the runner does not exist yet).
+
+- [ ] **Step 3: Write the node runner**
+
+```javascript
+// tests/_helpers/run_sketch_parity.mjs
+// Loads the shared parity fixture, runs the JS implementation, prints JSON rows.
+// No deps — uses Node's built-in fs and URL handling.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { isSubstantiveSketch } from "../../public/js/sketch-validation.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(__dirname, "..", "fixtures", "sketch_validation_parity.json");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+const rows = fixture.entries.map((entry, idx) => ({
+  idx,
+  text: entry.text,
+  expected: entry.expected_substantive,
+  actual: isSubstantiveSketch(entry.text),
+}));
+
+process.stdout.write(JSON.stringify(rows));
+```
+
+- [ ] **Step 4: Run test again to verify it still fails (different reason)**
+
+Run: `.venv/bin/pytest tests/test_frontend_sketch_validation.py -v`
+Expected: FAIL — node now reports it cannot resolve `../../public/js/sketch-validation.js` (the JS module does not exist yet).
+
+- [ ] **Step 5: Write the JS implementation (parity-locked)**
+
+```javascript
+// public/js/sketch-validation.js
+//
+// Substantiveness heuristic — JS port of models/sketch_validation.py.
+// Verified against tests/fixtures/sketch_validation_parity.json by
+// tests/test_frontend_sketch_validation.py. A divergence is a
+// release-blocker per spec §5.3.
+//
+// Why /u everywhere: Python's \w is Unicode by default; JS's is ASCII-only.
+// Without /u, the same input ("café résumé naïve …") would tokenize differently
+// in the two languages and the parity fixture's unicode rows would silently
+// fail. See models/sketch_validation.py "JS PORT NOTE" docstring.
+
+export const MIN_SUBSTANTIVE_TOKENS = 8;
+
+const DONT_KNOW_PATTERNS = [
+  "idk",
+  "i dont know",
+  "i don't know",
+  "no idea",
+  "no clue",
+  "dunno",
+  "not sure",
+];
+
+const STOPWORDS = new Set(
+  (
+    "a an the and or but if of for in on at to from by with as is are was were " +
+    "be been being do does did has have had this that these those it its"
+  ).split(/\s+/)
+);
+
+const PUNCT_RE = /[^\p{L}\p{N}_\s]/gu;
+const WHITESPACE_RE = /\s+/gu;
+const REPEATED_CHAR_RE = /^(.)\1{4,}$/u;
+
+function normalize(text) {
+  let t = text.trim().toLowerCase();
+  t = t.replace(PUNCT_RE, " ");
+  t = t.replace(WHITESPACE_RE, " ");
+  return t.trim();
+}
+
+function isDontKnow(normalized) {
+  if (!normalized) return true;
+  if (REPEATED_CHAR_RE.test(normalized)) return true;
+  for (const pattern of DONT_KNOW_PATTERNS) {
+    if (normalized === pattern) return true;
+    if (normalized.startsWith(pattern + " ")) {
+      const extra = normalized.slice(pattern.length + 1).split(/\s+/u).filter(Boolean);
+      if (extra.length <= 3) return true;
+    }
+  }
+  return false;
+}
+
+function countSubstantiveTokens(normalized) {
+  const tokens = normalized.split(/\s+/u).filter((t) => t && t.length >= 2);
+  let count = 0;
+  for (const t of tokens) {
+    if (!STOPWORDS.has(t)) count += 1;
+  }
+  return count;
+}
+
+export function isSubstantiveSketch(text) {
+  if (text === null || text === undefined) return false;
+  if (typeof text !== "string") return false;
+  const normalized = normalize(text);
+  if (!normalized) return false;
+  if (isDontKnow(normalized)) return false;
+  if (countSubstantiveTokens(normalized) < MIN_SUBSTANTIVE_TOKENS) return false;
+  return true;
+}
+```
+
+- [ ] **Step 6: Run parity test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_frontend_sketch_validation.py -v`
+Expected: PASS.
+
+If any fixture entry fails, do **not** edit the fixture. Edit the JS until it conforms — see the failure message; the most common drift is forgetting the `/u` flag on a regex or letting `length >= 2` exclude a 2-byte multi-codepoint glyph.
+
+- [ ] **Step 7: Run the existing module-syntax test to make sure the new JS file parses**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS — including a parametrized case for `sketch-validation.mjs`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add public/js/sketch-validation.js \
+        tests/_helpers/run_sketch_parity.mjs \
+        tests/test_frontend_sketch_validation.py
+git commit -m "feat(ui): port is_substantive_sketch to JS with parity test"
+```
+
+---
+
+## Task 2: Frontend telemetry helper
+
+**Goal:** A single-line emit point that flows the spec §5.4 frontend events through `Bus` and `console.info`. No backend post endpoint in v1; that's a follow-up tracked in the PR description.
+
+**Files:**
+- Create: `public/js/telemetry.js`
+- Test: `tests/test_frontend_syntax.py` (already covers — verifies the new module parses)
+
+- [ ] **Step 1: Write the telemetry helper**
+
+```javascript
+// public/js/telemetry.js
+//
+// Frontend telemetry emit point for the conversational concept-creation flow.
+// Spec §5.4 lists the events. The events are observable in three places:
+//
+//   1. Browser console (`console.info('telemetry', { event, ...extra })`)
+//   2. Bus listeners (`Bus.on('telemetry', fn)`) — for in-app debug overlays
+//   3. Future: a /api/telemetry endpoint. Not wired in v1 — the helper takes
+//      one shape so adding the network post is a one-line change later.
+//
+// Server-side telemetry (concept_create.lc.queried, .build_blocked, .ai_call,
+// etc.) flows through Python's structured logger from main.py — that path is
+// already shipped in Plan A. Client events use `origin: 'client'` so the
+// dashboards can detect client/server validation drift.
+
+import { Bus } from "./bus.js";
+
+export function emitTelemetry(event, extra = {}) {
+  if (typeof event !== "string" || !event) return;
+  const payload = { event, ...extra };
+  try {
+    Bus.emit("telemetry", payload);
+  } catch (err) {
+    /* Bus is best-effort. Never let telemetry break the UI. */
+  }
+  // eslint-disable-next-line no-console
+  console.info("telemetry", payload);
+}
+```
+
+- [ ] **Step 2: Verify module-syntax test picks up the new file**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS, including `telemetry.mjs` as a parametrized case.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/telemetry.js
+git commit -m "feat(ui): add minimal telemetry helper for concept-create events"
+```
+
+---
+
+## Task 3: Scaffold `concept-create.js` module shell
+
+**Goal:** Stand up the new module with its public API and a no-op stage machine, so subsequent tasks can fill in the surfaces without a name/wiring scramble at the end.
+
+**Files:**
+- Create: `public/js/concept-create.js`
+
+- [ ] **Step 1: Write the module skeleton**
+
+```javascript
+// public/js/concept-create.js
+//
+// Conversational concept creation — Stage A (chat) → Stage B (summary card).
+// Replaces the form-based showNameField branch of buildContentInputUI.
+// Spec: docs/superpowers/specs/2026-05-02-conversational-concept-creation-design.md
+// Plan: docs/superpowers/plans/2026-05-04-conversational-concept-creation-frontend.md
+//
+// Public API: buildConversationalCreateUI(container, { onSubmit, onCancel }).
+// Returns { destroy() } so callers can clean up on dialog close.
+//
+// This module owns ZERO graph rendering and ZERO API key reading. It receives
+// onSubmit({ name, startingSketch, source }) and the caller posts to the
+// backend — same separation of concerns the form-based flow used.
+
+import { isSubstantiveSketch } from "./sketch-validation.js";
+import { emitTelemetry } from "./telemetry.js";
+
+const STAGE = Object.freeze({
+  CHAT_TURN_1: "chat:turn-1",
+  CHAT_TURN_2: "chat:turn-2",
+  CHAT_FALLBACK: "chat:fallback",
+  SUMMARY: "summary",
+});
+
+// Hardcoded chat copy for v1. The shape is locked by the spec; the literal
+// strings derive verbatim from the threshold-chat system prompt example
+// (app_prompts/threshold-chat-system-v1.txt) so no voice drift can sneak in
+// while the frontend still hardcodes them. A future plan wires these to a
+// /api/threshold-chat-turn endpoint and removes the hardcode.
+const CHAT_COPY = Object.freeze({
+  TURN_1: "What do you want to understand?",
+  TURN_2: "Sketch what you think it does — rough is fine. What parts come to mind?",
+  // The fallback is generic-but-honest for v1: "inputs and outputs" is the
+  // input-output frame most causal concepts share, derived in spirit from the
+  // spec's analogical-fallback rule. Concept-derived analogy generation is a
+  // documented Plan B follow-up — see plan §"Out of scope".
+  FALLBACK:
+    "Try this: think of something familiar that takes inputs and produces outputs. " +
+    "What inputs does this concept take, and what does it produce?",
+});
+
+const FOOTER_DEFAULT = "Study content stays locked until the cold attempt.";
+const SKETCH_FOOTER_BLOCKED =
+  "A few words about how you think it works will give socratink something to draft from. " +
+  "Or attach source material — either path opens the build.";
+
+export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
+  const state = {
+    stage: STAGE.CHAT_TURN_1,
+    concept: "",
+    sketchTurns: [],          // verbatim learner replies; concatenated into chip value
+    source: null,              // { type, text?, url?, filename? } once attached
+    usedFallback: false,
+    submitting: false,
+  };
+
+  function destroy() {
+    container.innerHTML = "";
+  }
+
+  // Subsequent tasks fill in renderChat / renderSummary / submit logic and
+  // call them from here. For now, stub with a placeholder so the module is
+  // importable without errors.
+  container.innerHTML = "";
+
+  return { destroy };
+}
+```
+
+- [ ] **Step 2: Run the module-syntax test**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS — concept-create.mjs parses.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/concept-create.js
+git commit -m "feat(ui): scaffold concept-create module shell"
+```
+
+---
+
+## Task 4: Stage A — chat surface + state machine
+
+**Goal:** Render the breadcrumb header (eyebrow `NEW CONCEPT`, title `Start a concept`), an AI-question line, a textarea composer, and a submit button. Drive the turn-1 → turn-2 → (fallback?) → exit transitions. Emit `concept_create.chat.turn_started` and `concept_create.chat.turn_replied` per spec §5.4. Cancel calls `onCancel()`. No chat bubbles, no avatars, no typing indicators — text on the page, calm composer.
+
+**Files:**
+- Modify: `public/js/concept-create.js`
+
+- [ ] **Step 1: Add the chat renderer**
+
+Inside `buildConversationalCreateUI`, add functions and call the first one when the stage is one of the chat stages.
+
+```javascript
+  // Helper: minimal escape for inline text (we only inject sanitized strings,
+  // but defensive-by-default — these never escape into innerHTML untrusted).
+  function escHtml(s) {
+    return String(s ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function questionForStage(stage) {
+    if (stage === STAGE.CHAT_TURN_1) return CHAT_COPY.TURN_1;
+    if (stage === STAGE.CHAT_TURN_2) return CHAT_COPY.TURN_2;
+    if (stage === STAGE.CHAT_FALLBACK) return CHAT_COPY.FALLBACK;
+    return "";
+  }
+
+  function turnNumberForStage(stage) {
+    if (stage === STAGE.CHAT_TURN_1) return 1;
+    if (stage === STAGE.CHAT_TURN_2) return 2;
+    if (stage === STAGE.CHAT_FALLBACK) return "fallback";
+    return null;
+  }
+
+  function renderChat() {
+    const turn = turnNumberForStage(state.stage);
+    const question = questionForStage(state.stage);
+    const hasPrior = state.sketchTurns.length > 0 || state.concept !== "";
+
+    container.innerHTML = `
+      <div class="creation-chat" data-stage="${escHtml(state.stage)}">
+        <p class="creation-chat-question" id="creation-chat-question">${escHtml(question)}</p>
+        <textarea
+          class="creation-chat-composer"
+          id="creation-chat-composer"
+          aria-labelledby="creation-chat-question"
+          maxlength="2000"
+          rows="3"
+          placeholder=""></textarea>
+        <div class="creation-footer">
+          <button class="creation-cancel" type="button">Cancel</button>
+          <button class="creation-submit" type="button" disabled>Continue</button>
+        </div>
+      </div>
+    `;
+
+    const composer = container.querySelector(".creation-chat-composer");
+    const cancelBtn = container.querySelector(".creation-cancel");
+    const submitBtn = container.querySelector(".creation-submit");
+
+    composer.focus();
+    composer.addEventListener("input", () => {
+      submitBtn.disabled = composer.value.trim().length === 0;
+    });
+    composer.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !submitBtn.disabled) {
+        e.preventDefault();
+        submitChatTurn(composer.value.trim());
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel?.();
+      }
+    });
+
+    cancelBtn.addEventListener("click", () => onCancel?.());
+    submitBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (submitBtn.disabled) return;
+      submitChatTurn(composer.value.trim());
+    });
+
+    emitTelemetry("concept_create.chat.turn_started", {
+      turn,
+      has_prior_reply: hasPrior,
+    });
+  }
+
+  function submitChatTurn(reply) {
+    if (!reply) return;
+    const turn = turnNumberForStage(state.stage);
+
+    if (state.stage === STAGE.CHAT_TURN_1) {
+      // Turn 1 reply is the concept name (verbatim for v1; canonicalisation
+      // is a documented follow-up). The learner can edit the chip later.
+      state.concept = reply;
+      emitTelemetry("concept_create.chat.turn_replied", {
+        turn,
+        reply_len: reply.length,
+        used_fallback: false,
+      });
+      state.stage = STAGE.CHAT_TURN_2;
+      renderChat();
+      return;
+    }
+
+    if (state.stage === STAGE.CHAT_TURN_2) {
+      state.sketchTurns.push(reply);
+      const isThin = !isSubstantiveSketch(reply);
+      emitTelemetry("concept_create.chat.turn_replied", {
+        turn,
+        reply_len: reply.length,
+        used_fallback: false,
+      });
+      if (isThin) {
+        state.stage = STAGE.CHAT_FALLBACK;
+        state.usedFallback = true;
+        renderChat();
+        return;
+      }
+      state.stage = STAGE.SUMMARY;
+      renderSummary();
+      return;
+    }
+
+    if (state.stage === STAGE.CHAT_FALLBACK) {
+      state.sketchTurns.push(reply);
+      emitTelemetry("concept_create.chat.turn_replied", {
+        turn,
+        reply_len: reply.length,
+        used_fallback: true,
+      });
+      state.stage = STAGE.SUMMARY;
+      renderSummary();
+      return;
+    }
+  }
+
+  // Placeholder until Task 5 ships the real summary renderer.
+  function renderSummary() {
+    container.innerHTML =
+      '<div class="creation-summary"><p>Summary card pending (Task 5).</p></div>';
+  }
+
+  // Boot the first chat turn.
+  renderChat();
+```
+
+- [ ] **Step 2: Module-parse smoke**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/js/concept-create.js
+git commit -m "feat(ui): chat stage state machine + composer"
+```
+
+---
+
+## Task 5: Stage B skeleton — summary card with three chips (read-only)
+
+**Goal:** Render the chip layout (concept, sketch, source-material) in a non-edit, read-only state with the chat collapsed to a one-line breadcrumb. CTA copy/state lands in Task 6; edit interactions in Task 7; source-material panel in Task 8. This task locks the DOM shape so subsequent tasks plug in.
+
+**Files:**
+- Modify: `public/js/concept-create.js`
+
+- [ ] **Step 1: Replace the placeholder `renderSummary` with the real layout**
+
+```javascript
+  function joinSketch() {
+    return state.sketchTurns.filter((s) => s && s.trim()).join("\n\n");
+  }
+
+  function sketchIsSubstantive() {
+    return isSubstantiveSketch(joinSketch());
+  }
+
+  function ctaCopyForState() {
+    if (state.source && sketchIsSubstantive()) return "Build from my map and source";
+    if (state.source && !sketchIsSubstantive()) return "Build from source";
+    if (!state.source && sketchIsSubstantive()) return "Build from my starting map";
+    // Disabled state — copy still reads "Build from my starting map" so the
+    // CTA does not flicker text on every keystroke; the disabled attribute +
+    // the sketch-chip footer copy carry the strategy framing instead.
+    return "Build from my starting map";
+  }
+
+  function ctaEnabledForState() {
+    const concept = state.concept.trim();
+    if (!concept) return false;
+    if (state.source) return true;
+    return sketchIsSubstantive();
+  }
+
+  function sourceChipDescriptor() {
+    if (!state.source) return null;
+    if (state.source.type === "url") {
+      const len = (state.source.text || "").length.toLocaleString();
+      return `${len} chars from a URL`;
+    }
+    if (state.source.type === "file") {
+      const filename = state.source.filename || "file";
+      const len = (state.source.text || "").length.toLocaleString();
+      return `${filename} · ${len} chars`;
+    }
+    // text
+    const len = (state.source.text || "").length.toLocaleString();
+    return `${len} chars pasted`;
+  }
+
+  function renderSummary() {
+    const concept = state.concept.trim();
+    const sketch = joinSketch();
+    const sketchOk = isSubstantiveSketch(sketch);
+    const sourceDesc = sourceChipDescriptor();
+    const ctaCopy = ctaCopyForState();
+    const ctaEnabled = ctaEnabledForState();
+
+    const breadcrumbLabel =
+      concept ? `↑ chat (collapsed): "${escHtml(concept)}" · sketch captured`
+              : "↑ chat (collapsed): sketch captured";
+
+    const sketchBlockedFooter = !state.source && !sketchOk;
+
+    container.innerHTML = `
+      <div class="creation-summary">
+        <p class="creation-chat-breadcrumb" aria-hidden="true">${breadcrumbLabel}</p>
+
+        <span class="creation-section-eyebrow">STARTING MAP</span>
+
+        <article class="creation-chip" data-chip="concept">
+          <div class="creation-chip-label-row">
+            <span class="creation-chip-label">CONCEPT</span>
+            <button class="creation-chip-action" type="button" data-action="edit-concept">edit</button>
+          </div>
+          <div class="creation-chip-value" data-role="concept-value">${escHtml(concept)}</div>
+        </article>
+
+        <article class="creation-chip" data-chip="sketch">
+          <div class="creation-chip-label-row">
+            <span class="creation-chip-label">YOUR SKETCH</span>
+            <button class="creation-chip-action" type="button" data-action="edit-sketch">edit</button>
+          </div>
+          <div class="creation-chip-value" data-role="sketch-value">${escHtml(sketch)}</div>
+          ${sketchBlockedFooter
+            ? `<p class="creation-chip-footer" data-role="sketch-footer">${escHtml(SKETCH_FOOTER_BLOCKED)}</p>`
+            : ""}
+        </article>
+
+        <article class="creation-chip ${sourceDesc ? "" : "creation-chip-empty"}" data-chip="source">
+          <div class="creation-chip-label-row">
+            <span class="creation-chip-label">SOURCE MATERIAL</span>
+            <button class="creation-chip-action" type="button" data-action="${sourceDesc ? "replace-source" : "add-source"}">
+              ${sourceDesc ? "replace" : "Add source"}
+            </button>
+          </div>
+          <div class="creation-chip-value" data-role="source-value">
+            ${sourceDesc
+              ? escHtml(sourceDesc)
+              : '<span class="creation-chip-empty-text">None added — build will start from your model only</span>'}
+          </div>
+        </article>
+
+        <div class="creation-footer">
+          <button class="creation-cancel" type="button">Cancel</button>
+          <button class="creation-submit creation-build-cta" type="button" ${ctaEnabled ? "" : "disabled"}>
+            ${escHtml(ctaCopy)}
+          </button>
+        </div>
+
+        <p class="creation-dialog-meta">${FOOTER_DEFAULT}</p>
+      </div>
+    `;
+
+    // Wire cancel + submit (the chip edit + source actions land in Tasks 7-8).
+    container.querySelector(".creation-cancel").addEventListener("click", () => onCancel?.());
+    const submitBtn = container.querySelector(".creation-submit");
+    submitBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (submitBtn.disabled) return;
+      doSubmit();
+    });
+
+    emitTelemetry("concept_create.summary.shown", {
+      has_concept: Boolean(concept),
+      has_sketch: Boolean(sketch),
+      sketch_len: sketch.length,
+    });
+  }
+
+  // Stub — real submit ships in Task 9.
+  function doSubmit() {
+    /* implemented in Task 9 */
+  }
+```
+
+- [ ] **Step 2: Manually drive the state machine in DevTools**
+
+Run: `python -m http.server 8000` (or the existing dev server) and open the modal. Type a concept name, then a substantive 12-word sketch. Confirm the summary appears with the three chips, the chat breadcrumb shows the concept name, the build CTA is enabled and reads `Build from my starting map`. Type a thin sketch (`idk`) and confirm the fallback turn appears, then exits to a summary where the build CTA is disabled and the sketch chip shows the strategy-framed footer copy.
+
+(This is exploratory — the visual smoke is logged formally in Task 12.)
+
+- [ ] **Step 3: Module-parse smoke**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/concept-create.js
+git commit -m "feat(ui): summary card layout (read-only chips)"
+```
+
+---
+
+## Task 6: CTA truth table + state-dependent copy + sketch-blocked footer
+
+**Goal:** Lock the CTA + footer to the spec §3.2 truth table. Already partly done in Task 5; this task wires re-renders so the CTA + footer track state mutations and adds the `concept_create.build_blocked` telemetry on disabled-state submit attempts.
+
+**Files:**
+- Modify: `public/js/concept-create.js`
+
+- [ ] **Step 1: Add a `rerenderSummary()` shorthand and use it everywhere chip state mutates**
+
+This is mostly a no-op until Tasks 7-8 add the chip edit + source-attach paths, but defining it here keeps later tasks tight.
+
+```javascript
+  function rerenderSummary() {
+    // Cheap full re-render — chip state is small, DOM is shallow, no
+    // animation interrupted by re-render in v1. If perf bites later,
+    // swap to surgical updates per chip.
+    renderSummary();
+  }
+
+  // Wire the disabled-CTA telemetry. The CTA's disabled attribute prevents
+  // the click in normal use, but if an integration test or assistive tech
+  // somehow triggers an activation we want telemetry to log the block.
+  // (Server-side validation is the authority either way.)
+  function handleDisabledClickAttempt(reason) {
+    emitTelemetry("concept_create.build_blocked", {
+      reason,
+      origin: "client",
+    });
+  }
+```
+
+- [ ] **Step 2: Wire `handleDisabledClickAttempt` into the submit binding**
+
+In `renderSummary`, replace the current submit binding with:
+
+```javascript
+    submitBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (submitBtn.disabled) {
+        const reason = !state.concept.trim()
+          ? "missing_concept"
+          : "thin_sketch_no_source";
+        handleDisabledClickAttempt(reason);
+        return;
+      }
+      doSubmit();
+    });
+```
+
+- [ ] **Step 3: Module-parse smoke**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/concept-create.js
+git commit -m "feat(ui): CTA truth table + blocked-build telemetry"
+```
+
+---
+
+## Task 7: Chip edit interactions (concept + sketch)
+
+**Goal:** Click `edit` on the concept chip → swap the value for an `<input>`; click `edit` on the sketch chip → swap for a `<textarea>`. Save on blur, on `Enter` (concept only), or on `Cmd/Ctrl+Enter` (sketch). Cancel via `Escape` reverts to the prior value. Emit `concept_create.summary.edited` with `{chip}` per spec §5.4.
+
+**Files:**
+- Modify: `public/js/concept-create.js`
+
+- [ ] **Step 1: Add edit-mode renderers for the concept and sketch chips**
+
+```javascript
+  function attachChipEditHandlers() {
+    const editConceptBtn = container.querySelector('[data-action="edit-concept"]');
+    const editSketchBtn = container.querySelector('[data-action="edit-sketch"]');
+    if (editConceptBtn) editConceptBtn.addEventListener("click", () => beginEditConcept());
+    if (editSketchBtn) editSketchBtn.addEventListener("click", () => beginEditSketch());
+  }
+
+  function beginEditConcept() {
+    const valueEl = container.querySelector('[data-role="concept-value"]');
+    if (!valueEl) return;
+    const prior = state.concept;
+    valueEl.innerHTML = `
+      <input
+        class="creation-chip-input"
+        type="text"
+        maxlength="200"
+        value="${escHtml(prior)}"
+        aria-label="Concept name">
+    `;
+    const input = valueEl.querySelector(".creation-chip-input");
+    input.focus();
+    input.select();
+
+    function save() {
+      const next = input.value.trim();
+      if (next !== prior) {
+        state.concept = next;
+        emitTelemetry("concept_create.summary.edited", { chip: "concept" });
+      }
+      rerenderSummary();
+    }
+    function cancel() {
+      rerenderSummary();
+    }
+    input.addEventListener("blur", save);
+    input.addEventListener("keydown", (e) => {
+      // stopPropagation: prevent the modal-level Escape handler from closing
+      // the dialog while we're editing a chip in place.
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        e.preventDefault();
+        cancel();
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        save();
+      }
+    });
+  }
+
+  function beginEditSketch() {
+    const valueEl = container.querySelector('[data-role="sketch-value"]');
+    if (!valueEl) return;
+    const prior = joinSketch();
+    valueEl.innerHTML = `
+      <textarea
+        class="creation-chip-textarea"
+        maxlength="10000"
+        rows="4"
+        aria-label="Your sketch">${escHtml(prior)}</textarea>
+    `;
+    const textarea = valueEl.querySelector(".creation-chip-textarea");
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+
+    function save() {
+      const next = textarea.value;
+      if (next !== prior) {
+        // Replace all sketchTurns with the edited value as a single turn.
+        // Subsequent edits are a single-turn sketch from the learner's POV.
+        state.sketchTurns = next.trim() ? [next] : [];
+        emitTelemetry("concept_create.summary.edited", { chip: "sketch" });
+      }
+      rerenderSummary();
+    }
+    function cancel() {
+      rerenderSummary();
+    }
+    textarea.addEventListener("blur", save);
+    textarea.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        e.preventDefault();
+        cancel();
+      }
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        save();
+      }
+    });
+  }
+```
+
+- [ ] **Step 2: Call `attachChipEditHandlers()` at the end of `renderSummary`**
+
+```javascript
+    // last line of renderSummary, after the existing wiring:
+    attachChipEditHandlers();
+```
+
+- [ ] **Step 3: Module-parse smoke**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/concept-create.js
+git commit -m "feat(ui): inline chip edit for concept + sketch"
+```
+
+---
+
+## Task 8: Source-material chip + source panel
+
+**Goal:** Click `Add source` on the source chip → expand an inline panel with `Text | URL | File` tabs (reusing the existing redesigned `.creation-source-tabs` styles + `.overlay-tab` + `.overlay-textarea` + `.overlay-url-input` + `.overlay-dropzone`). On attach, collapse the panel and show the descriptor. Emit `concept_create.source.added` with `{type}`. Click `replace` to re-open.
+
+This task **does not** add new CSS for the panel itself — it reuses the existing tab/textarea/dropzone classes already in `components.css` (which the 2026-05-01 polish redesigned). The chip wrapper styles are added in Task 11.
+
+**Files:**
+- Modify: `public/js/concept-create.js`
+
+- [ ] **Step 1: Add the source-panel renderer + attach logic**
+
+```javascript
+  function beginEditSource() {
+    const sourceChip = container.querySelector('[data-chip="source"]');
+    if (!sourceChip) return;
+    const valueEl = sourceChip.querySelector('[data-role="source-value"]');
+    valueEl.innerHTML = `
+      <div class="creation-source-panel">
+        <div class="overlay-tabs creation-source-tabs">
+          <button class="overlay-tab active" type="button" data-tab="paste">Text</button>
+          <button class="overlay-tab" type="button" data-tab="url">URL</button>
+          <button class="overlay-tab" type="button" data-tab="upload">File</button>
+        </div>
+        <div class="overlay-panel" data-panel="paste">
+          <textarea class="overlay-textarea" placeholder="Paste source material here." maxlength="500000"></textarea>
+        </div>
+        <div class="overlay-panel" data-panel="url" style="display:none">
+          <input class="overlay-url-input" type="url" placeholder="https://example.com/article">
+          <p class="overlay-dropfeedback overlay-url-feedback"></p>
+        </div>
+        <div class="overlay-panel" data-panel="upload" style="display:none">
+          <div class="overlay-dropzone">
+            Drop a file or click to browse<br>
+            <span style="font-size:11px;opacity:0.65">.txt &nbsp; .md &nbsp; .pdf &nbsp; up to 2MB</span>
+          </div>
+          <input type="file" accept=".txt,.md,.pdf" style="display:none">
+          <p class="overlay-dropfeedback overlay-file-feedback"></p>
+        </div>
+        <div class="creation-source-panel-footer">
+          <button class="creation-source-panel-cancel" type="button">Cancel</button>
+          <button class="creation-source-panel-attach" type="button" disabled>Attach</button>
+        </div>
+      </div>
+    `;
+
+    const tabs = valueEl.querySelectorAll(".overlay-tab");
+    const panels = valueEl.querySelectorAll(".overlay-panel");
+    let activeTab = "paste";
+    let pendingFileText = "";
+    let pendingFileName = "";
+
+    const textarea = valueEl.querySelector(".overlay-textarea");
+    const urlInput = valueEl.querySelector(".overlay-url-input");
+    const dropzone = valueEl.querySelector(".overlay-dropzone");
+    const fileInput = valueEl.querySelector('input[type="file"]');
+    const fileFeedback = valueEl.querySelector(".overlay-file-feedback");
+    const urlFeedback = valueEl.querySelector(".overlay-url-feedback");
+    const cancelBtn = valueEl.querySelector(".creation-source-panel-cancel");
+    const attachBtn = valueEl.querySelector(".creation-source-panel-attach");
+
+    function panelHasContent() {
+      if (activeTab === "paste") return textarea.value.trim().length > 0;
+      if (activeTab === "url") return urlInput.value.trim().length > 0;
+      return pendingFileText.length > 0;
+    }
+    function refreshAttachEnabled() {
+      attachBtn.disabled = !panelHasContent();
+    }
+
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        activeTab = tab.dataset.tab;
+        tabs.forEach((t) => t.classList.toggle("active", t.dataset.tab === activeTab));
+        panels.forEach((p) => {
+          p.style.display = p.dataset.panel === activeTab ? "" : "none";
+        });
+        refreshAttachEnabled();
+      });
+    });
+
+    textarea.addEventListener("input", refreshAttachEnabled);
+    urlInput.addEventListener("input", refreshAttachEnabled);
+
+    dropzone.addEventListener("click", () => fileInput.click());
+    dropzone.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      dropzone.classList.add("dragover");
+    });
+    dropzone.addEventListener("dragleave", () => dropzone.classList.remove("dragover"));
+    dropzone.addEventListener("drop", (e) => {
+      e.preventDefault();
+      dropzone.classList.remove("dragover");
+      const f = e.dataTransfer.files?.[0];
+      if (f) handleFile(f);
+    });
+    fileInput.addEventListener("change", () => {
+      const f = fileInput.files?.[0];
+      if (f) handleFile(f);
+    });
+
+    function handleFile(file) {
+      // Two-megabyte cap mirrors the form-era constraint.
+      if (file.size > 2 * 1024 * 1024) {
+        fileFeedback.className = "overlay-dropfeedback error";
+        fileFeedback.textContent = "File is over 2MB.";
+        pendingFileText = "";
+        pendingFileName = "";
+        refreshAttachEnabled();
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        pendingFileText = String(reader.result || "");
+        pendingFileName = file.name;
+        fileFeedback.className = "overlay-dropfeedback ok";
+        fileFeedback.textContent = `${file.name} · ${pendingFileText.length.toLocaleString()} chars`;
+        refreshAttachEnabled();
+      };
+      reader.onerror = () => {
+        fileFeedback.className = "overlay-dropfeedback error";
+        fileFeedback.textContent = "Couldn't read that file.";
+        pendingFileText = "";
+        pendingFileName = "";
+        refreshAttachEnabled();
+      };
+      reader.readAsText(file);
+    }
+
+    cancelBtn.addEventListener("click", () => rerenderSummary());
+
+    attachBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (attachBtn.disabled) return;
+      if (activeTab === "paste") {
+        const text = textarea.value.trim();
+        if (!text) return;
+        state.source = { type: "text", text };
+      } else if (activeTab === "url") {
+        // The Plan A backend expects URL fetching to go through /api/extract-url
+        // (separate endpoint). For now we capture the URL on the client; Task 9
+        // routes URL submits through that endpoint. The chip stores the URL
+        // and the fetched text once the URL endpoint succeeds.
+        const url = urlInput.value.trim();
+        if (!url) return;
+        state.source = { type: "url", url, text: "", filename: "" };
+      } else {
+        if (!pendingFileText) return;
+        state.source = { type: "file", text: pendingFileText, filename: pendingFileName };
+      }
+      emitTelemetry("concept_create.source.added", { type: state.source.type });
+      rerenderSummary();
+    });
+  }
+
+  // Hook into renderSummary's chip wiring.
+  function attachSourceChipHandlers() {
+    const addBtn = container.querySelector('[data-action="add-source"]');
+    const replaceBtn = container.querySelector('[data-action="replace-source"]');
+    if (addBtn) addBtn.addEventListener("click", () => beginEditSource());
+    if (replaceBtn) replaceBtn.addEventListener("click", () => beginEditSource());
+  }
+```
+
+- [ ] **Step 2: Call `attachSourceChipHandlers()` at the end of `renderSummary`**
+
+```javascript
+    // alongside attachChipEditHandlers():
+    attachSourceChipHandlers();
+```
+
+- [ ] **Step 3: Module-parse smoke**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/concept-create.js
+git commit -m "feat(ui): source-material chip with inline tabs panel"
+```
+
+---
+
+## Task 9: Submit pipeline → POST `/api/extract` with new payload + 422 handling
+
+**Goal:** When the build CTA fires, post `{name, starting_sketch, source}` to `/api/extract`, surface the response's `provisional_map` (or `knowledge_map` for source path) to the caller, and render the server's `message` field in the appropriate chip footer when 422s come back. Add the new `submitConceptCreate` export to `ai_service.js` and call it from `concept-create.js`'s `doSubmit`. URL-source submits go through `/api/extract-url` first to fetch the text, then through `/api/extract` with `type: "text"` (mirrors today's behavior so the new code path doesn't accidentally regress URL handling).
+
+**Files:**
+- Modify: `public/js/ai_service.js`
+- Modify: `public/js/concept-create.js`
+
+- [ ] **Step 1: Extend `ai_service.js` with `submitConceptCreate`**
+
+```javascript
+// public/js/ai_service.js (full file after edit)
+
+export async function generateKnowledgeMap(rawText, onProgress) {
+  if (onProgress) onProgress("Drafting map...");
+  const apiKey = localStorage.getItem("gemini_key") || undefined;
+  const response = await fetch("/api/extract", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: rawText, api_key: apiKey }),
+  });
+  if (!response.ok) {
+    const err = await response.text().catch(() => "");
+    throw new Error(`Server error ${response.status}: ${err}`);
+  }
+  const data = await response.json();
+  return data.knowledge_map;
+}
+
+/**
+ * Conversational concept-create submit. Posts the spec §5.3 payload shape
+ * and returns the parsed `provisional_map` (no source) or `knowledge_map`
+ * (source attached). On 422, throws an Error with `.status` and `.body`
+ * (the parsed `{error, message}` payload) so the caller can render the
+ * message inline.
+ *
+ * @param {{ name: string, startingSketch: string,
+ *           source: null | { type: 'text'|'url'|'file', text?: string, url?: string, filename?: string },
+ *           apiKey?: string }} args
+ * @returns {Promise<{ provisional_map?: object, knowledge_map?: object }>}
+ */
+export async function submitConceptCreate({ name, startingSketch, source, apiKey }) {
+  const body = {
+    name,
+    starting_sketch: startingSketch,
+    source,
+    api_key: apiKey,
+  };
+  const response = await fetch("/api/extract", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (response.status === 422) {
+    const payload = await response.json().catch(() => ({}));
+    const detail = payload.detail || payload || {};
+    const err = new Error(detail.message || "Submission rejected.");
+    err.status = 422;
+    err.body = detail;
+    throw err;
+  }
+  if (!response.ok) {
+    const txt = await response.text().catch(() => "");
+    const err = new Error(`Server error ${response.status}: ${txt}`);
+    err.status = response.status;
+    throw err;
+  }
+  return response.json();
+}
+```
+
+- [ ] **Step 2: Wire `doSubmit` in `concept-create.js`**
+
+```javascript
+  async function doSubmit() {
+    if (state.submitting) return;
+    state.submitting = true;
+
+    const concept = state.concept.trim();
+    const sketch = joinSketch();
+
+    emitTelemetry("concept_create.build_clicked", {
+      has_source: Boolean(state.source),
+      has_sketch: Boolean(sketch),
+    });
+
+    let resolvedSource = state.source;
+
+    // URL source path: hop through /api/extract-url first to materialise text.
+    // The /api/extract dispatcher rejects URL sources directly (see main.py
+    // _resolve_extract_path: 'URL sources go through /api/extract-url.').
+    if (resolvedSource && resolvedSource.type === "url" && !resolvedSource.text) {
+      try {
+        const { extractUrl } = await import("./api-client.js");
+        const fetched = await extractUrl({ url: resolvedSource.url });
+        // /api/extract-url returns {text, title, url} per source_intake.
+        resolvedSource = {
+          type: "text",
+          text: String(fetched.text || ""),
+          // Keep the original URL on the client for telemetry / display only.
+          // Backend payload uses type: "text" so the dispatcher takes the
+          // existing extract_knowledge_map path on this submit.
+        };
+      } catch (err) {
+        state.submitting = false;
+        showSubmitError(
+          "source",
+          err && err.message ? err.message : "Couldn't fetch that URL."
+        );
+        return;
+      }
+    }
+
+    try {
+      const { submitConceptCreate } = await import("./ai_service.js");
+      const apiKey = (typeof localStorage !== "undefined" && localStorage.getItem("gemini_key")) || undefined;
+      const data = await submitConceptCreate({
+        name: concept,
+        startingSketch: sketch,
+        source: resolvedSource,
+        apiKey,
+      });
+      state.submitting = false;
+      // Hand off to the caller; one of provisional_map / knowledge_map is set.
+      onSubmit?.({
+        name: concept,
+        startingSketch: sketch,
+        source: resolvedSource,
+        provisionalMap: data.provisional_map || data.knowledge_map || null,
+      });
+    } catch (err) {
+      state.submitting = false;
+      if (err && err.status === 422 && err.body) {
+        const code = err.body.error;
+        const message = err.body.message || "Submission rejected.";
+        if (code === "missing_concept") {
+          showSubmitError("concept", message);
+          return;
+        }
+        if (code === "thin_sketch_no_source") {
+          showSubmitError("sketch", message);
+          return;
+        }
+      }
+      showSubmitError("submit", (err && err.message) || "Couldn't submit. Try again.");
+    }
+  }
+
+  function showSubmitError(target, message) {
+    rerenderSummary();
+    if (target === "concept") {
+      const valueEl = container.querySelector('[data-role="concept-value"]');
+      if (valueEl) {
+        valueEl.insertAdjacentHTML(
+          "afterend",
+          `<p class="creation-chip-footer">${escHtml(message)}</p>`
+        );
+      }
+      return;
+    }
+    if (target === "sketch") {
+      // The footer slot was either already rendered (blocked state) or not.
+      // If not present, append it so the message lands beneath the sketch chip.
+      const sketchChip = container.querySelector('[data-chip="sketch"]');
+      if (!sketchChip) return;
+      const existing = sketchChip.querySelector(".creation-chip-footer");
+      if (existing) existing.textContent = message;
+      else
+        sketchChip.insertAdjacentHTML(
+          "beforeend",
+          `<p class="creation-chip-footer">${escHtml(message)}</p>`
+        );
+      return;
+    }
+    if (target === "source") {
+      const sourceChip = container.querySelector('[data-chip="source"]');
+      if (!sourceChip) return;
+      sourceChip.insertAdjacentHTML(
+        "beforeend",
+        `<p class="creation-chip-footer">${escHtml(message)}</p>`
+      );
+      return;
+    }
+    // Generic fallback: prepend a banner above the footer.
+    const summary = container.querySelector(".creation-summary");
+    if (!summary) return;
+    summary.insertAdjacentHTML(
+      "beforeend",
+      `<p class="creation-chip-footer">${escHtml(message)}</p>`
+    );
+  }
+```
+
+- [ ] **Step 3: Module-parse smoke**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/js/ai_service.js public/js/concept-create.js
+git commit -m "feat(ui): submit pipeline + 422 handling for concept-create"
+```
+
+---
+
+## Task 10: Replace `buildContentInputUI`'s `showNameField` branch in `app.js`
+
+**Goal:** Have `startAddConcept` call the new `buildConversationalCreateUI` instead of `buildContentInputUI({ showNameField: true })`. Delete the dead form template, the placeholder rotators, and the form-only event handlers from `buildContentInputUI`. The non-`showNameField` branch (the inline overlay extract path) stays intact.
+
+**Files:**
+- Modify: `public/js/app.js`
+
+- [ ] **Step 1: In `startAddConcept` (currently around line 1219), replace the `buildContentInputUI({ showNameField: true, ... })` call with `buildConversationalCreateUI`**
+
+The existing call site needs the success-path branching adjusted because the response shape changes. Replace the relevant section:
+
+```javascript
+    // public/js/app.js — inside startAddConcept, after the guest-mode early return:
+    const { buildConversationalCreateUI } = await import("./concept-create.js");
+    buildConversationalCreateUI(dialog.shellContent, {
+      onCancel: () => closeCreationDialog(),
+      onSubmit: async ({ name, startingSketch, source, provisionalMap }) => {
+        const concepts = loadConcepts();
+        if (concepts.length >= 4) { renderAddTrigger(); return; }
+        closeCreationDialog();
+
+        const id = generateId();
+        const extractStartedAt = new Date().toISOString();
+        const extractStartedPerf = performance.now();
+
+        // The provisional_map is already drafted by /api/extract before
+        // onSubmit fires. We still render the extract-overlay for the brief
+        // moment between dialog close and graph mount so the transition is
+        // not a jump cut. (TODO: refactor the overlay to mount before submit
+        // for true progress feedback once this lands.)
+
+        // Reuse today's provisional-map handling code path. The map is one
+        // of {provisional_map, knowledge_map} from the response; we pass
+        // whichever is set and the existing render code consumes it the same.
+        const knowledgeMap = provisionalMap;
+        if (!isValidKnowledgeMap(knowledgeMap)) {
+          // Fall through to the existing error banner code.
+          mountCreationDialog();
+          dialog.bannerSlot.appendChild(
+            buildErrorBanner(sanitizeExtractError(new Error("invalid map")))
+          );
+          return;
+        }
+
+        // Persist the new concept the same way the form path did.
+        // (The existing post-submit code is untouched — we just hand it the
+        // already-extracted map. The function below mirrors today's
+        // pattern around saveConcept + selectConcept + showMapView.)
+        finishConceptCreate({
+          id,
+          name,
+          knowledgeMap,
+          startedAt: extractStartedAt,
+          startedPerf: extractStartedPerf,
+          startingSketch,
+          source,
+        });
+      },
+    });
+```
+
+The existing `startAddConcept` body has substantial overlay/animation logic (the `extract-overlay`, particle grid, progress bar, etc.) that runs while `extract_knowledge_map` is fetching. Two options exist:
+
+**Option A (recommended for v1):** Move the overlay into `concept-create.js`'s `doSubmit` so it shows during the network call. Cleanest semantics; the dialog already closes before the network call resolves.
+
+**Option B (lighter touch):** Leave the overlay code where it is and call it from `onSubmit` with the already-resolved map. Faster to implement; the overlay flickers briefly but the UX is acceptable for v1.
+
+**Choose Option B for v1.** Refactor to Option A is logged as a Plan B follow-up. Implementation:
+
+```javascript
+      onSubmit: async ({ name, startingSketch, source, provisionalMap }) => {
+        // Validate before destroying the dialog (so we can recover inline).
+        if (!isValidKnowledgeMap(provisionalMap)) {
+          // Re-mount; show the error banner; let the user retry.
+          const dialog2 = mountCreationDialog();
+          dialog2.bannerSlot.appendChild(
+            buildErrorBanner(sanitizeExtractError(new Error("invalid map")))
+          );
+          buildConversationalCreateUI(dialog2.shellContent, { /* same handlers */ });
+          return;
+        }
+
+        const concepts = loadConcepts();
+        if (concepts.length >= 4) { renderAddTrigger(); return; }
+        closeCreationDialog();
+
+        // Hand the validated map to the existing post-submit flow. The
+        // existing code path mounts the extract-overlay → renders the graph
+        // → persists via saveConcept. For v1 we wrap that path into a
+        // helper, finishConceptCreate, that takes the map directly and skips
+        // the network call.
+        finishConceptCreateWithMap({
+          id: generateId(),
+          name,
+          knowledgeMap: provisionalMap,
+          startedAtIso: new Date().toISOString(),
+          startedPerf: performance.now(),
+          startingSketch,
+          source,
+        });
+      },
+```
+
+`finishConceptCreateWithMap` is a new helper extracted from the existing `startAddConcept` body that runs everything after the network call resolves. Lift the overlay-mount → graph-render → persistence code into it. Specific instructions:
+
+- Cut the body of `startAddConcept` from `closeCreationDialog();` (line ~1229) through the end of the `onSubmit` handler — the `extractOverlay` creation, particle grid, progress bar, the `try { const knowledgeMap = await generateKnowledgeMap(...) }` block, the `saveConcept(...)` call, the `selectConcept(...)` and `showMapView(...)` calls, and the cleanup teardown.
+- Wrap that body in `function finishConceptCreateWithMap({ id, name, knowledgeMap, startedAtIso, startedPerf, startingSketch, source }) { ... }`.
+- Replace the network call (`generateKnowledgeMap(text)`) with a no-op since the map is already passed in. Keep the overlay+progress UI for visual continuity (it shows briefly between dialog close and graph mount; the existing code's animation cycle is short enough).
+- The existing `saveConcept` call should still receive the `name`, `knowledgeMap`, and any threshold context it expects. If today's `saveConcept` reads from a `thresholdContext` field, pass `startingSketch` (the new equivalent) under that name to preserve the contract.
+
+- [ ] **Step 2: Delete the `showNameField === true` branch of `buildContentInputUI`**
+
+Inside `buildContentInputUI` (line 684), the function has two paths controlled by `showNameField`. Remove the form-only HTML template (the `${showNameField ? '<div class="creation-intro …">…</div>' : ''}` branch and onward through `creation-source-meta`, `creation-validation`, the threshold/fuzzy panels, etc.), the form-only event handlers (`creation-name-input` listeners, `creation-threshold-input` listeners, fuzzy toggle handler, the `PLACEHOLDERS` and `NAME_PLACEHOLDERS` rotators with their `phTimer` / `namePhTimer`), and the form-only state in `doSubmit` (the `thresholdContext` construction, the `name` / `fuzzyText` references). The `showNameField === false` branch (which is the inline overlay extract path) and its non-form behavior remain untouched.
+
+After the cut, the function should accept either:
+- `showNameField: false` (today's other call site, unchanged), or
+- (no other code path remains; the function's `showNameField === true` branch is gone).
+
+If `showNameField` is now always false, simplify by removing the parameter and the conditional. Search the codebase for other callers that pass `showNameField: true` and update them; if none remain, drop the parameter from `buildContentInputUI`.
+
+- [ ] **Step 3: Run module-syntax test**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS — `app.js` parses cleanly.
+
+- [ ] **Step 4: Manually load the dev server and walk the flow**
+
+```bash
+cd .worktrees/concept-create-frontend
+.venv/bin/uvicorn main:app --reload --port 8000
+```
+
+Open `http://localhost:8000`, click `new tink`, walk through:
+1. Type a concept name in turn 1.
+2. Type a substantive sketch in turn 2.
+3. Confirm summary card appears with three chips.
+4. Confirm CTA reads `Build from my starting map` and is enabled.
+5. Click build; confirm the modal closes, the extract overlay shows briefly, the graph renders.
+
+Repeat with a thin sketch (`idk`) — confirm fallback chat appears, then summary appears with CTA disabled and the strategy-framed footer beneath the sketch chip.
+
+Repeat with a substantive sketch + `Add source` → paste text → `Attach`. Confirm CTA reads `Build from my map and source`, click build, confirm graph renders.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/js/app.js
+git commit -m "feat(ui): replace form modal with conversational create flow"
+```
+
+---
+
+## Task 11: CSS — delete dead form classes, add chat + summary classes
+
+**Goal:** Update `public/css/components.css`. Remove the form-only classes; add the chat surface, summary card, and chip styles. Respect cream/ink/violet palette, single violet accent at rest (the build CTA), violet-tinted shadows, and `prefers-reduced-motion`. No emoji, no exclamation marks, no gradient text, no glass-morphism, no left-stripe borders.
+
+**Files:**
+- Modify: `public/css/components.css`
+
+- [ ] **Step 1: Delete the form-only classes**
+
+Remove every rule whose selector starts with one of:
+- `.creation-intro`, `.creation-intro-compact`, `.creation-intro-row`, `.creation-intro-title`, `.creation-intro-copy`
+- `.creation-name-input` (and its `:focus`, `::placeholder` rules)
+- `.creation-threshold`, `.creation-threshold-head`, `.creation-threshold-copy`, `.creation-threshold-input` (incl. `:focus`, `::placeholder`)
+- `.creation-fuzzy-toggle` (incl. `:hover`, `:focus-visible`), `.creation-fuzzy-row`, `.creation-fuzzy-hint` (incl. `[hidden]`), `.creation-fuzzy-panel` (incl. `[hidden]`), `.creation-fuzzy-input` (incl. `:focus`, `::placeholder`)
+- `.creation-source-meta`, `.creation-source-copy`, `.creation-source-header`
+- `.creation-validation`
+- `.creation-field`
+- `.creation-section-label` (re-introduce a replacement under the new names below if needed for the source panel — Task 8 reuses the existing `.overlay-tab` system, which doesn't depend on `.creation-section-label`).
+- `.creation-capacity-pill` (only used in the form path; Plan B removes it).
+
+Also remove the `.creation-intro-row` block inside the `@media (max-width: ...)` responsive section if present.
+
+Keep:
+- `.creation-dialog`, `.creation-dialog-scrim`, `.creation-dialog-shell`, `.creation-dialog-header`, `.creation-dialog-kicker`, `.creation-dialog-close`, `.creation-dialog-title`, `.creation-dialog-meta`, `.creation-dialog-banner-slot`, `.creation-dialog-content` — modal shell.
+- `.creation-source-tabs .overlay-tab` (and `.active`, `:hover`) — redesigned 2026-05-01 polish, reused by the source panel.
+- `.creation-cancel`, `.creation-submit` (and disabled / hover) — button styles.
+- `.creation-footer` — flex row at the bottom of any creation surface.
+- `.creation-banner`, `.creation-banner--guest`, `.creation-banner--error`, `.creation-guest-actions`, `.btn-browse-starters`, `.auth-link` — guest mode + error banners.
+- `.paste-actions`, `.paste-clipboard-btn` — used inside the source panel.
+- `.creation-dialog-content .overlay-textarea` — sizing rule for textareas inside the modal.
+
+- [ ] **Step 2: Append the new chat + summary classes**
+
+Append these rules at the bottom of the existing `creation-*` section in `components.css` (around the area where the deleted classes used to live, after `.creation-footer`):
+
+```css
+/* ─────────────────────────────────────────────────────────────
+ * Conversational concept creation (Plan B, 2026-05-04).
+ * Two surfaces: chat (Stage A) and summary card (Stage B).
+ * One violet accent at rest = the build CTA. Eyebrows are
+ * lavender (--accent-secondary), which is secondary and does
+ * not double-count.
+ * ─────────────────────────────────────────────────────────── */
+
+.creation-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0 0;
+}
+.creation-chat-question {
+  margin: 0;
+  font-family: var(--font-display, var(--font-body));
+  font-size: 16px;
+  line-height: 1.45;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
+.creation-chat-composer {
+  width: 100%;
+  min-height: 88px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-card);
+  color: var(--text);
+  padding: 11px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    box-shadow var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-chat-composer:focus {
+  border-color: var(--primary);
+  box-shadow: var(--accent-ring);
+}
+.creation-chat-breadcrumb {
+  margin: 0 0 4px;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-sub);
+  font-style: normal;
+}
+
+.creation-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0 0;
+}
+.creation-section-eyebrow {
+  display: inline-block;
+  margin: 4px 0 -4px;
+  font-family: var(--font-body);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--accent-secondary, var(--text-sub));
+  text-transform: uppercase;
+}
+
+.creation-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: 12px;
+  background: var(--surface-card);
+  /* Inset 1px lit-edge highlight — the cream-paper feel. */
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+  transition:
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    background-color var(--theme-transition-ms) var(--theme-transition-ease),
+    color var(--theme-transition-ms) var(--theme-transition-ease);
+}
+.creation-chip-empty {
+  background: transparent;
+  border-style: dashed;
+  box-shadow: none;
+}
+.creation-chip-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.creation-chip-label {
+  font-family: var(--font-body);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--text-sub);
+  text-transform: uppercase;
+}
+.creation-chip-action {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-sub);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-chip-action:hover {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.creation-chip-action:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+  border-radius: 4px;
+}
+.creation-chip-value {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.creation-chip-empty-text {
+  font-style: italic;
+  color: var(--text-sub);
+}
+.creation-chip-input,
+.creation-chip-textarea {
+  width: 100%;
+  background: var(--surface-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--text);
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    box-shadow var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-chip-textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+.creation-chip-input:focus,
+.creation-chip-textarea:focus {
+  border-color: var(--primary);
+  box-shadow: var(--accent-ring);
+}
+.creation-chip-footer {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-sub);
+}
+
+/* Source-material panel inside the source chip (when expanded). Reuses the
+ * existing .overlay-tabs / .overlay-panel / .overlay-textarea / .overlay-url-input
+ * / .overlay-dropzone styles already in components.css; this block adds only
+ * the wrapper + footer styles specific to the panel-inside-chip presentation. */
+.creation-source-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.creation-source-panel-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.creation-source-panel-cancel {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-sub);
+  cursor: pointer;
+  transition:
+    color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-source-panel-cancel:hover {
+  color: var(--text);
+  border-color: var(--primary);
+}
+.creation-source-panel-attach {
+  background: var(--primary);
+  color: var(--accent-on-primary, white);
+  border: 0;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-inline);
+  transition: opacity var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-source-panel-attach:disabled {
+  background: var(--locked, var(--border));
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.creation-source-panel-attach:not(:disabled):hover {
+  opacity: 0.88;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .creation-chat-composer,
+  .creation-chip,
+  .creation-chip-action,
+  .creation-chip-input,
+  .creation-chip-textarea,
+  .creation-source-panel-cancel,
+  .creation-source-panel-attach {
+    transition: none;
+  }
+}
+```
+
+If `--accent-secondary`, `--accent-ring`, `--border-subtle`, `--shadow-inline`, `--accent-on-primary`, or `--ease-standard` are not defined in the project's token files, drop them and use the closest existing token (most are referenced in `colors_and_type.css`; verify before removing). Do **not** invent new hex values.
+
+- [ ] **Step 2 (verification): grep for forbidden patterns**
+
+Run from the worktree root:
+
+```bash
+grep -nE 'background-clip:\s*text|backdrop-filter:\s*blur\([^)]*\)\s*[^;]*\s+blur\(|border-left:\s*[2-9]px|border-right:\s*[2-9]px' public/css/components.css
+```
+
+Expected: no matches inside the new chat/summary classes (some matches in unrelated parts of the file are fine — only the new rules need to be clean).
+
+Also grep for emoji / exclamation marks in the new copy strings:
+
+```bash
+grep -nE '[!]|🎉|✨|💡|🔥|⚡' public/js/concept-create.js
+```
+
+Expected: no matches (the only `!` in the file should be JS negation operators in identifiers like `!state.source` — those are fine).
+
+- [ ] **Step 3: Module-parse smoke (no JS changes but quick to run)**
+
+Run: `.venv/bin/pytest tests/test_frontend_syntax.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/css/components.css
+git commit -m "feat(ui): chat + summary chip styles; remove dead form CSS"
+```
+
+---
+
+## Task 12: Acceptance verification + visual smoke
+
+**Goal:** Walk all 12 acceptance criteria from the handoff. Capture screenshots. Run the full local test suite. Run `bash scripts/qa-smoke.sh` against the local server.
+
+**Files:**
+- (No code changes; verification + PR description.)
+
+- [ ] **Step 1: Local end-to-end smoke (no source)**
+
+Boot the server (`uvicorn main:app --reload --port 8000`), open `http://localhost:8000`, click `new tink`. Walk:
+
+1. Turn 1 question: `What do you want to understand?` — type `Photosynthesis`, submit.
+2. Turn 2 question: `Sketch what you think it does — rough is fine. What parts come to mind?` — type a substantive sketch like `Plants take in light through leaves and convert CO2 and water into sugar and oxygen, somehow stored in chloroplasts.`, submit.
+3. Summary card appears: chips show concept and sketch; source chip is empty with the "None added — build will start from your model only" copy; CTA reads `Build from my starting map` and is enabled.
+4. Click build. Confirm the extract overlay shows briefly and the provisional graph renders.
+
+- [ ] **Step 2: Local end-to-end smoke (with source attached)**
+
+Repeat the flow; on the summary card, click `Add source`, paste a passage of source text, click `Attach`. Confirm:
+- Source chip transitions from `None added…` to `<N> chars pasted` with a `replace` action.
+- CTA copy updates to `Build from my map and source`.
+- Click build; confirm graph renders via the source-attached path.
+
+- [ ] **Step 3: Local end-to-end smoke (thin sketch + no source)**
+
+Repeat the flow with a thin sketch (e.g., `idk`). Confirm:
+- The fallback chat turn appears with the input-output framing copy.
+- After the fallback reply, the summary card appears.
+- CTA is **disabled** (visually muted, `disabled` attribute set).
+- The sketch chip shows the strategy-framed footer copy verbatim: `A few words about how you think it works will give socratink something to draft from. Or attach source material — either path opens the build.`
+- Edit the sketch chip to a substantive value: confirm CTA re-enables.
+- Re-edit to thin again, then click `Add source` and attach text: confirm CTA re-enables and copy reads `Build from source`.
+
+- [ ] **Step 4: 422 round-trip smoke (server-side defense in depth)**
+
+In DevTools console, force a thin-sketch + no-source submit by manipulating the chip state:
+
+```javascript
+// quick manual repro in the console:
+fetch("/api/extract", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Test", starting_sketch: "idk", source: null }),
+}).then(r => r.json()).then(console.log);
+```
+
+Expected: 422 with `{detail: {error: "thin_sketch_no_source", message: "..."}}`.
+
+In the actual UI, the client-side check disables the CTA before this can happen — the test is to confirm the server-side gate is the safety net.
+
+- [ ] **Step 5: Hard-stop verification**
+
+Confirm there is no UI affordance to:
+- Trigger a third AI chat turn after turn 2 (or after the fallback if it fired).
+- Re-open the chat once the summary card appears.
+- Edit the chat breadcrumb (it's a `<p>`, not a button).
+
+- [ ] **Step 6: Single-violet-at-rest verification**
+
+On the summary card with all chips populated, confirm exactly one element uses the hard `--primary` fill at rest: the build CTA. The eyebrow (`STARTING MAP`) uses `--accent-secondary` (lavender), which is secondary by definition. Chip `edit` actions are violet on `:hover` but `--text-sub` at rest.
+
+- [ ] **Step 7: Reduced-motion check**
+
+In DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce`. Walk the flow again: confirm chip swaps, edit-mode entries, and CTA re-enables happen instantly with no transitions.
+
+- [ ] **Step 8: Run the full Python test suite**
+
+```bash
+.venv/bin/pytest tests/ --ignore=tests/e2e -q
+```
+
+Expected: all green. The new parity test, the existing module-syntax test, the existing extract-route tests, and the existing telemetry tests all pass.
+
+- [ ] **Step 9: Run `bash scripts/qa-smoke.sh` against local**
+
+```bash
+bash scripts/qa-smoke.sh local
+```
+
+Expected: PASS. (If pre-existing playwright tests rely on the old form selectors, those tests are already updated by the handoff's premise that the form is replaced — confirm by inspecting `tests/e2e/test_smoke.py` and updating selectors if needed; that update is a permitted scope-extension within Plan B.)
+
+- [ ] **Step 10: Visual smoke screenshots**
+
+Capture, for the PR description:
+- Chat turn 1 (question + composer, light mode)
+- Chat turn 2 (question + composer, light mode)
+- Summary card with no source attached (light mode)
+- Summary card with source attached (light mode)
+- Summary card with thin sketch + no source (CTA disabled with footer copy, light mode)
+- Same five in dark mode
+
+Save under `docs/superpowers/handoff-evidence/2026-05-04-concept-create-frontend/` (create the directory). Reference the screenshots in the PR body.
+
+- [ ] **Step 11: Final grep sweep — banned patterns**
+
+Run from worktree root:
+
+```bash
+grep -rnE '[!]\)|exclamation|emoji|🎉|✨|💡|🔥|⚡|background-clip:\s*text' public/js/concept-create.js public/css/components.css | grep -vE '!disabled|!== ?null|!==|!== undefined|!== ""|!=='
+```
+
+Expected: no matches. (`!==` style operators are filtered out by the second grep; only literal exclamation marks in copy or true emoji should remain — none are expected.)
+
+Run a separate sweep for accidental affirmation phrases:
+
+```bash
+grep -nE 'Great start|Got it|Fair enough|interesting!|Awesome|Nice work' public/js/concept-create.js
+```
+
+Expected: no matches.
+
+- [ ] **Step 12: Commit the screenshot evidence + final touch-up if needed**
+
+```bash
+git add docs/superpowers/handoff-evidence/2026-05-04-concept-create-frontend/
+git commit -m "docs(handoff): visual smoke evidence for concept-create frontend"
+```
+
+- [ ] **Step 13: Open the PR**
+
+```bash
+gh pr create --title "feat(ui): conversational concept creation — chat → summary card flow" --body "$(cat <<'EOF'
+## Summary
+- Replaces the form-based concept-creation modal with a 2-turn (+ analogical fallback) chat → summary-card flow per spec docs/superpowers/specs/2026-05-02-conversational-concept-creation-design.md
+- Wires to the Plan A backend (already on dev at 086e617): POST /api/extract dispatches between source-less generate_provisional_map_from_sketch and existing extract_knowledge_map
+- Ports models/sketch_validation.is_substantive_sketch to JS with a fixture-locked parity test (28 entries incl. unicode); divergence is a release-blocker
+
+## Test plan
+- [x] .venv/bin/pytest tests/ --ignore=tests/e2e -q passes
+- [x] bash scripts/qa-smoke.sh local passes
+- [x] Visual smoke (light + dark, all 5 states) — see screenshots under docs/superpowers/handoff-evidence/2026-05-04-concept-create-frontend/
+- [x] Hard-stop verification: no UI path to a 3rd AI turn or to reopen the chat
+- [x] Single-violet-at-rest: the build CTA is the only --primary element at rest
+- [x] Server-side 422 round-trip: thin sketch + no source via direct POST returns thin_sketch_no_source
+
+## Follow-ups (Plan C / future)
+- Reconcile DESIGN.md §3 Screen 1 to reflect conversational threshold capture
+- Wire chat turns to a real /api/threshold-chat-turn endpoint (currently hardcoded turn-2 + fallback copy that mirrors app_prompts/threshold-chat-system-v1.txt verbatim)
+- Concept-derived analogy generation (currently a generic input-output fallback)
+- Frontend telemetry network post (currently console + Bus only)
+EOF
+)"
+```
+
+---
+
+## Out of scope — explicitly deferred to Plan C / follow-ups
+
+These show up here so the executor doesn't try to land them in this branch:
+
+1. **DESIGN.md §3 Screen 1 update** describing the conversational threshold capture. Plan C reconciles the binding doc; this branch ships the implementation.
+2. **`/api/threshold-chat-turn` endpoint.** Turn 2 + fallback copy are hardcoded for v1. Their literal text mirrors `app_prompts/threshold-chat-system-v1.txt` verbatim; voice drift cannot sneak in even with the hardcode in place.
+3. **Concept-derived analogy generation.** The v1 fallback is the input-output frame, generic-but-honest. Real concept-derived analogies require the new endpoint above.
+4. **Frontend telemetry network post.** Events flow through `Bus.emit('telemetry', …)` and `console.info`. Adding a `/api/telemetry` post is one line in `telemetry.js` once the backend endpoint exists.
+5. **`finishConceptCreate` overlay refactor (Option A).** The extract-overlay flicker between dialog close and graph mount is acceptable for v1. Option A in Task 10 moves the overlay into `concept-create.js`'s `doSubmit` so it covers the network call cleanly.
+6. **Standards-alignment metadata on tiles**, **Prerequisite-aware Interleaving Bridge**, **LC Evaluator gating** — already declared out-of-scope by spec §7. Listed here for completeness.
+
+---
+
+## Risk register (operational reminders for the executor)
+
+| Risk | Mitigation in this plan |
+|---|---|
+| JS substantiveness heuristic diverges from Python | Task 1 fixture-locked parity test, runs in CI; release-blocker if any entry mismatches. |
+| Voice drift in hardcoded chat copy | Turn-2 + fallback text are literal mirrors of `app_prompts/threshold-chat-system-v1.txt`'s example shape. Acceptance criterion #10 (handoff) reviews against the prompt. |
+| Edit-chip Escape closes the modal mid-edit | `e.stopPropagation()` in chip edit Escape handlers (Task 7), so the modal-level Escape handler does not fire. |
+| Server returns `provisional_map` (new path) but frontend expects `knowledge_map` | Task 9's `submitConceptCreate` consumer normalises with `data.provisional_map || data.knowledge_map`. |
+| URL source attached, but `/api/extract` rejects URL types | Task 9 hops through `/api/extract-url` first to materialise text, then submits as `type: "text"`; mirrors today's behavior. |
+| Telemetry events fire at the wrong shape and confuse the dashboards | Each event's `extra={...}` shape is fixed in spec §5.4; tasks plant events at the named call sites with the named fields. |
+| CSS deletion accidentally removes a class still in use elsewhere | Task 11 enumerates the keep-list explicitly; before deleting any class, the executor must `grep -n` for it across `public/` to confirm no other surface uses it. |
+| Source-panel breaks file uploads on Safari (FileReader) | Plan B keeps the existing `FileReader.readAsText` pattern — same as the form-based flow used; no new platform surface. |
+| Modal focus-trap drops focus when the source panel mounts | `creation-dialog-shell`'s `trapFocusHandler` walks the live `focusables` list each Tab keypress, so newly-mounted inputs join the cycle automatically. |

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -820,68 +820,6 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   display:flex; flex-direction:column; gap:10px;
   padding:12px 16px 16px; border-top:1px solid var(--border);
 }
-.creation-intro {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 2px 0 4px;
-}
-.creation-intro-compact {
-  gap: 6px;
-  padding: 0 0 6px;
-}
-.creation-intro-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-.creation-intro-title {
-  font-size: 15px;
-  line-height: 1.35;
-  font-weight: 700;
-  color: var(--text);
-}
-.creation-intro-copy {
-  margin: 2px 0 0;
-  font-size: 12.5px;
-  line-height: 1.55;
-  color: var(--text-sub);
-}
-.creation-capacity-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 28px;
-  padding: 0 10px;
-  border-radius: 999px;
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-soft-strong);
-  color: var(--primary);
-  font-size: 11px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-.creation-field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.creation-section-label {
-  font-size:11px; font-weight:700; letter-spacing:0.02em;
-  color:var(--text-sub); margin-top:2px;
-}
-.creation-name-input {
-  width:100%; background:var(--card-bg); border:1px solid var(--border);
-  border-radius:8px; padding:8px 10px; font-size:13px; color:var(--text);
-  outline:none; font-family:inherit;
-  transition:border-color 0.2s, background-color var(--theme-transition-ms) var(--theme-transition-ease), color var(--theme-transition-ms) var(--theme-transition-ease);
-  box-sizing:border-box;
-}
-.creation-name-input:focus { border-color:var(--primary); }
-.creation-name-input::placeholder { color:var(--text-sub); }
-.creation-source-header {
-  margin-top: 10px;
-}
 .creation-source-tabs {
   margin-top: 5px;
   margin-bottom: 6px;
@@ -907,140 +845,6 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   color: var(--text);
   border-color: var(--border-subtle);
   box-shadow: var(--shadow-inline);
-}
-.creation-source-meta {
-  margin: 0 0 8px;
-  padding: 0;
-  background: transparent;
-  border: 0;
-}
-.creation-source-copy {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1.45;
-  color: var(--text-sub);
-}
-.creation-threshold {
-  margin-top: 10px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-}
-.creation-threshold-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 10px;
-  margin-bottom: 6px;
-}
-.creation-threshold .creation-section-label {
-  margin: 0;
-}
-.creation-threshold-copy {
-  margin: 3px 0 0;
-  color: var(--text-sub);
-  font-size: 12px;
-  line-height: 1.45;
-}
-.creation-threshold-input {
-  width: 100%;
-  min-height: 86px;
-  resize: vertical;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface-card);
-  color: var(--text);
-  padding: 11px 12px;
-  font-family: var(--font-body);
-  font-size: 13px;
-  line-height: 1.45;
-  outline: none;
-  box-sizing: border-box;
-}
-.creation-threshold-input:focus {
-  border-color: var(--primary);
-  box-shadow: var(--accent-ring);
-}
-.creation-threshold-input::placeholder {
-  color: var(--text-sub);
-}
-.creation-fuzzy-toggle {
-  display: inline-flex;
-  align-items: center;
-  width: auto;
-  min-height: 28px;
-  margin-top: 6px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-  color: var(--text-sub);
-  cursor: pointer;
-  font: inherit;
-  font-size: 11.5px;
-  font-weight: 700;
-  letter-spacing: 0;
-  transition: color var(--duration-micro, 140ms) var(--ease-standard, ease);
-}
-.creation-fuzzy-toggle:hover {
-  color: var(--primary);
-  opacity: 1;
-  transform: none;
-  box-shadow: none;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-.creation-fuzzy-toggle:focus-visible {
-  outline: none;
-  box-shadow: var(--accent-ring);
-}
-.creation-fuzzy-row {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-.creation-fuzzy-hint {
-  font-size: 11.5px;
-  line-height: 1.45;
-  color: var(--text-sub);
-}
-.creation-fuzzy-hint[hidden] {
-  display: none;
-}
-.creation-fuzzy-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-top: 6px;
-}
-.creation-fuzzy-panel[hidden] {
-  display: none;
-}
-.creation-fuzzy-input {
-  width: 100%;
-  background: var(--card-bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 9px 10px;
-  color: var(--text);
-  font-family: inherit;
-  font-size: 13px;
-  outline: none;
-  box-sizing: border-box;
-}
-.creation-fuzzy-input:focus {
-  border-color: var(--primary);
-  box-shadow: var(--accent-ring);
-}
-.creation-fuzzy-input::placeholder {
-  color: var(--text-sub);
-}
-.creation-validation {
-  margin: 0;
-  font-size: 11.5px;
-  line-height: 1.5;
-  color: var(--text-sub);
 }
 .creation-footer { display:flex; gap:8px; margin-top:4px; }
 .creation-dialog-content .overlay-textarea {
@@ -1078,17 +882,245 @@ body[data-theme="dark"] .hero-primary-action:disabled {
 }
 .paste-clipboard-btn:hover { color:var(--primary); opacity:0.8; }
 
+/* ─────────────────────────────────────────────────────────────
+ * Conversational concept creation (Plan B, 2026-05-04).
+ * Two surfaces: chat (Stage A) and summary card (Stage B).
+ * One violet accent at rest = the build CTA. Eyebrows are
+ * lavender (--accent-secondary), which is secondary and does
+ * not double-count.
+ * ─────────────────────────────────────────────────────────── */
+
+.creation-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0 0;
+}
+.creation-chat-question {
+  margin: 0;
+  font-family: var(--font-display, var(--font-body));
+  font-size: 16px;
+  line-height: 1.45;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
+.creation-chat-composer {
+  width: 100%;
+  min-height: 88px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-card);
+  color: var(--text);
+  padding: 11px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    box-shadow var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-chat-composer:focus {
+  border-color: var(--primary);
+  box-shadow: var(--accent-ring);
+}
+.creation-chat-breadcrumb {
+  margin: 0 0 4px;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-sub);
+  font-style: normal;
+}
+
+.creation-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0 0;
+}
+.creation-section-eyebrow {
+  display: inline-block;
+  margin: 4px 0 -4px;
+  font-family: var(--font-body);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--accent-secondary, var(--text-sub));
+  text-transform: uppercase;
+}
+
+.creation-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: 12px;
+  background: var(--surface-card);
+  /* Inset 1px lit-edge highlight — the cream-paper feel. */
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+  transition:
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    background-color var(--theme-transition-ms) var(--theme-transition-ease),
+    color var(--theme-transition-ms) var(--theme-transition-ease);
+}
+.creation-chip-empty {
+  background: transparent;
+  border-style: dashed;
+  box-shadow: none;
+}
+.creation-chip-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.creation-chip-label {
+  font-family: var(--font-body);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--text-sub);
+  text-transform: uppercase;
+}
+.creation-chip-action {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-sub);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-chip-action:hover {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.creation-chip-action:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+  border-radius: 4px;
+}
+.creation-chip-value {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.creation-chip-empty-text {
+  font-style: italic;
+  color: var(--text-sub);
+}
+.creation-chip-input,
+.creation-chip-textarea {
+  width: 100%;
+  background: var(--surface-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--text);
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    box-shadow var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-chip-textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+.creation-chip-input:focus,
+.creation-chip-textarea:focus {
+  border-color: var(--primary);
+  box-shadow: var(--accent-ring);
+}
+.creation-chip-footer {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-sub);
+}
+
+/* Source-material panel inside the source chip (when expanded). Reuses the
+ * existing .overlay-tabs / .overlay-panel / .overlay-textarea / .overlay-url-input
+ * / .overlay-dropzone styles already in components.css; this block adds only
+ * the wrapper + footer styles specific to the panel-inside-chip presentation. */
+.creation-source-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.creation-source-panel-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.creation-source-panel-cancel {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-sub);
+  cursor: pointer;
+  transition:
+    color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-source-panel-cancel:hover {
+  color: var(--text);
+  border-color: var(--primary);
+}
+.creation-source-panel-attach {
+  background: var(--primary);
+  color: var(--accent-on-primary, white);
+  border: 0;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-inline);
+  transition: opacity var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.creation-source-panel-attach:disabled {
+  background: var(--locked, var(--border));
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.creation-source-panel-attach:not(:disabled):hover {
+  opacity: 0.88;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .creation-chat-composer,
+  .creation-chip,
+  .creation-chip-action,
+  .creation-chip-input,
+  .creation-chip-textarea,
+  .creation-source-panel-cancel,
+  .creation-source-panel-attach {
+    transition: none;
+  }
+}
+
 @media (max-width: 899px) {
   .add-trigger-card {
     width: calc(100% - 20px);
     margin: 10px;
-  }
-  .creation-intro-row {
-    flex-direction: column;
-    gap: 8px;
-  }
-  .creation-capacity-pill {
-    align-self: flex-start;
   }
 }
 

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -934,6 +934,28 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   color: var(--text-sub);
   font-style: normal;
 }
+.creation-chat-anchor {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin: 0 0 8px;
+  padding: 0;
+}
+.creation-chat-anchor-label {
+  font-family: var(--font-body);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--accent-secondary, var(--text-sub));
+  text-transform: uppercase;
+}
+.creation-chat-anchor-name {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
 
 .creation-summary {
   display: flex;

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -2198,6 +2198,52 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   }
 }
 
+/* Example chips — blank-page guidance for the empty-state hero */
+.hero-example-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+}
+.hero-example-chips__label {
+  font-family: var(--font-body);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-secondary, var(--text-sub));
+  margin-right: 4px;
+}
+.hero-example-chip {
+  background: transparent;
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: 999px;
+  padding: 5px 12px;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--text-sub);
+  cursor: pointer;
+  transition:
+    color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    background-color var(--duration-micro, 140ms) var(--ease-standard, ease);
+}
+.hero-example-chip:hover {
+  color: var(--text);
+  border-color: var(--accent-soft-strong, var(--primary));
+  background: var(--accent-soft);
+}
+.hero-example-chip:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+  border-color: var(--primary);
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero-example-chip { transition: none; }
+}
+
 .hero-info:has(.hero-state-chip[data-state="empty"]) {
   justify-content: flex-start;
   gap: 12px;

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1980,7 +1980,7 @@ body[data-theme="dark"] .first-run-welcome__crystal-stage::before {
 .hero-single-input__row {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 12px 16px;
 }
@@ -2170,16 +2170,6 @@ body[data-theme="dark"] .hero-single-input__submit:hover:not(:disabled) {
 }
 body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   color: var(--danger-light, #ffb4a8);
-}
-
-.hero-single-input__reassure {
-  font-family: var(--font-body);
-  font-size: var(--text-sm, 13px);
-  font-style: italic;
-  line-height: var(--leading-snug, 1.45);
-  color: var(--text-sub);
-  margin: 0;
-  text-align: center;
 }
 
 /* Empty-state rhythm: question (eyebrow + H1) -> action (input). */

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1932,7 +1932,7 @@ body[data-theme="dark"] .first-run-welcome__crystal-stage::before {
   text-align: left;
   width: 100%;
   max-width: 560px;
-  gap: 12px;
+  gap: 10px;
   margin: 0 auto;
 }
 
@@ -1954,8 +1954,8 @@ body[data-theme="dark"] .first-run-welcome__crystal-stage::before {
   line-height: var(--leading-relaxed, 1.55);
   color: var(--text-strong);
   width: 100%;
-  min-height: 64px;
-  padding: 14px 16px;
+  min-height: 52px;
+  padding: 12px 14px;
   border: 1px solid var(--border-subtle);
   border-radius: 12px;
   background: var(--surface-card);
@@ -1981,7 +1981,8 @@ body[data-theme="dark"] .first-run-welcome__crystal-stage::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 12px 16px;
 }
 
 .hero-single-input__attach {
@@ -2202,10 +2203,11 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
 .hero-example-chips {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
-  gap: 8px;
-  margin: 10px 0 0;
+  align-items: center;
+  gap: 6px 8px;
   padding: 0;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .hero-example-chips__label {
   font-family: var(--font-body);
@@ -2220,9 +2222,9 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   background: transparent;
   border: 1px solid var(--border-subtle, var(--border));
   border-radius: 999px;
-  padding: 5px 12px;
+  padding: 4px 10px;
   font: inherit;
-  font-size: 12.5px;
+  font-size: 12px;
   color: var(--text-sub);
   cursor: pointer;
   transition:

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1934,6 +1934,25 @@ body[data-theme="dark"] .first-run-welcome__crystal-stage::before {
   max-width: 560px;
   gap: 10px;
   margin: 0 auto;
+  position: relative;
+  isolation: isolate;
+}
+.hero-info:has(.hero-state-chip[data-state="empty"]) .hero-single-input::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: -32px -16px -32px -16px;
+  background: radial-gradient(
+    ellipse 65% 60% at 50% 40%,
+    rgba(var(--violet-600-rgb), 0.16) 0%,
+    rgba(var(--lavender-500-rgb), 0.08) 38%,
+    transparent 78%
+  );
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  /* The bloom is static — no motion change needed under reduced-motion.
+     Listed here for explicit accessibility-intent declaration. */
 }
 
 /* In empty state, hide the guidance sub-head (it re-introduces mode cognition),
@@ -2221,12 +2240,14 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   transition:
     color var(--duration-micro, 140ms) var(--ease-standard, ease),
     border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
-    background-color var(--duration-micro, 140ms) var(--ease-standard, ease);
+    background-color var(--duration-micro, 140ms) var(--ease-standard, ease),
+    transform var(--duration-micro, 140ms) var(--ease-standard, ease);
 }
 .hero-example-chip:hover {
   color: var(--text);
   border-color: var(--accent-soft-strong, var(--primary));
   background: var(--accent-soft);
+  transform: translateY(-1px);
 }
 .hero-example-chip:focus-visible {
   outline: none;

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -961,7 +961,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   border-radius: 12px;
   background: var(--surface-card);
   /* Inset 1px lit-edge highlight — the cream-paper feel. */
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 1px 0 rgba(var(--paper-0-rgb), 0.78);
   transition:
     border-color var(--duration-micro, 140ms) var(--ease-standard, ease),
     background-color var(--theme-transition-ms) var(--theme-transition-ease),
@@ -1085,7 +1085,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
 }
 .creation-source-panel-attach {
   background: var(--primary);
-  color: var(--accent-on-primary, white);
+  color: var(--text-on-primary, white);
   border: 0;
   border-radius: 8px;
   padding: 6px 14px;

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1980,7 +1980,7 @@ body[data-theme="dark"] .first-run-welcome__crystal-stage::before {
 .hero-single-input__row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   flex-wrap: wrap;
   gap: 12px 16px;
 }
@@ -2206,7 +2206,7 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   align-items: center;
   gap: 6px 8px;
   padding: 0;
-  flex: 1 1 auto;
+  flex: 1 1 100%;
   min-width: 0;
 }
 .hero-example-chips__label {
@@ -2227,6 +2227,7 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   font-size: 12px;
   color: var(--text-sub);
   cursor: pointer;
+  white-space: nowrap;
   transition:
     color var(--duration-micro, 140ms) var(--ease-standard, ease),
     border-color var(--duration-micro, 140ms) var(--ease-standard, ease),

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -181,6 +181,11 @@ body:not([data-map-open="true"]) .map-back-link {
   width: 100%;
   height: 100%;
   opacity: 0.9;
+  /* Feather the constellation edges so the field reads as atmospheric haze
+     rather than a fenced canvas. Without this, the canvas terminates at the
+     hero-card's bottom edge with a visible horizontal line. */
+  -webkit-mask-image: radial-gradient(ellipse 78% 68% at 50% 44%, #000 52%, rgba(0, 0, 0, 0.6) 78%, transparent 100%);
+  mask-image: radial-gradient(ellipse 78% 68% at 50% 44%, #000 52%, rgba(0, 0, 0, 0.6) 78%, transparent 100%);
 }
 .hero-card:has(.hero-state-chip[data-state="empty"]) {
   align-items: start;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -1043,6 +1043,13 @@ body:not([data-map-open="true"]) .map-back-link {
   font-weight: 700;
   letter-spacing: 0.02em;
 }
+.map-provisional-low-density {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-sub);
+  font-style: italic;
+}
 .map-first-room {
   display: flex;
   align-items: center;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -196,6 +196,13 @@ body:not([data-map-open="true"]) .map-back-link {
   background: transparent;
   box-shadow: none;
 }
+@media (min-height: 800px) {
+  .hero-card:has(.hero-state-chip[data-state="empty"]) {
+    min-height: calc(100dvh - 120px);
+    display: grid;
+    align-content: center;
+  }
+}
 .hero-card:has(.hero-state-chip[data-state="empty"]) .intro-content {
   grid-template-columns: 1fr;
   align-items: start;

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -598,7 +598,9 @@
   --card-bg:      var(--surface-card-theme);
   --text:         var(--text-strong);
   --text-sub:     var(--text-muted);
-  --drawer-bg:    var(--surface-panel-theme);
+  /* Dark-mode sidebar reads as neutral graphite, not violet-tinted —
+     calmer alongside the violet-tinted main canvas. */
+  --drawer-bg:    #18181b;
   --border:       var(--border-subtle);
   --tile-top:     var(--graph-tile-top);
   --tile-left:    var(--graph-tile-left);

--- a/public/index.html
+++ b/public/index.html
@@ -260,7 +260,6 @@
                 </svg>
               </button>
             </div>
-            <p class="hero-single-input__reassure">The first room is small.</p>
           </form>
 
           <div id="timer-display">24:00:00</div>

--- a/public/index.html
+++ b/public/index.html
@@ -244,23 +244,6 @@
                       placeholder='e.g. "Entropy", or paste a passage'
                       aria-label="What do you want to understand?"></textarea>
             <div class="hero-single-input__row">
-              <input class="hero-single-input__file"
-                     id="hero-single-input-file"
-                     type="file"
-                     accept=".txt,.md,.pdf,text/plain,text/markdown,application/pdf"
-                     hidden>
-              <button type="button"
-                      class="hero-single-input__attach"
-                      id="hero-single-input-attach"
-                      aria-describedby="hero-single-input-file-note"
-                      title="Attach TXT, MD, or PDF. Max 2 MB.">
-                <span class="hero-single-input__attach-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="m21.4 11.1-8.7 8.7a6 6 0 0 1-8.5-8.5l8.7-8.7a4 4 0 0 1 5.7 5.7l-8.8 8.7a2 2 0 0 1-2.8-2.8l8.1-8.1"/>
-                  </svg>
-                </span>
-                <span>Attach file</span>
-              </button>
               <button type="submit" class="hero-single-input__submit" disabled>
                 <span>Start first room</span>
                 <svg class="hero-single-input__submit-icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -269,7 +252,6 @@
                 </svg>
               </button>
             </div>
-            <p class="hero-single-input__file-note" id="hero-single-input-file-note" aria-live="polite">TXT, MD, or PDF · max 2 MB</p>
             <p class="hero-single-input__reassure">The first room is small.</p>
           </form>
 

--- a/public/index.html
+++ b/public/index.html
@@ -236,13 +236,21 @@
               </svg>
             </button>
           </div>
-          <!-- Empty-state single input: routes by input shape (short line → concept name, long/punctuated → passage). Shown only when hero-state-chip[data-state="empty"]; hidden otherwise via CSS. -->
+          <!-- Empty-state single input: single-purpose concept-name capture. Shown only when hero-state-chip[data-state="empty"]; hidden otherwise via CSS. -->
           <form class="hero-single-input" id="hero-single-input" onsubmit="return App.runHeroAction(event)" autocomplete="off">
             <textarea class="hero-single-input__field"
                       id="hero-single-input-field"
                       rows="1"
-                      placeholder='e.g. "Entropy", or paste a passage'
+                      maxlength="200"
+                      placeholder='e.g. Photosynthesis'
                       aria-label="What do you want to understand?"></textarea>
+            <div class="hero-example-chips" aria-label="Try one of these">
+              <span class="hero-example-chips__label">Try</span>
+              <button type="button" class="hero-example-chip" data-hero-example="Photosynthesis">Photosynthesis</button>
+              <button type="button" class="hero-example-chip" data-hero-example="Entropy">Entropy</button>
+              <button type="button" class="hero-example-chip" data-hero-example="The French Revolution">The French Revolution</button>
+              <button type="button" class="hero-example-chip" data-hero-example="Cognitive bias">Cognitive bias</button>
+            </div>
             <div class="hero-single-input__row">
               <button type="submit" class="hero-single-input__submit" disabled>
                 <span>Start first room</span>

--- a/public/index.html
+++ b/public/index.html
@@ -244,14 +244,14 @@
                       maxlength="200"
                       placeholder='e.g. Photosynthesis'
                       aria-label="What do you want to understand?"></textarea>
-            <div class="hero-example-chips" aria-label="Try one of these">
-              <span class="hero-example-chips__label">Try</span>
-              <button type="button" class="hero-example-chip" data-hero-example="Photosynthesis">Photosynthesis</button>
-              <button type="button" class="hero-example-chip" data-hero-example="Entropy">Entropy</button>
-              <button type="button" class="hero-example-chip" data-hero-example="The French Revolution">The French Revolution</button>
-              <button type="button" class="hero-example-chip" data-hero-example="Cognitive bias">Cognitive bias</button>
-            </div>
             <div class="hero-single-input__row">
+              <div class="hero-example-chips" aria-label="Try one of these">
+                <span class="hero-example-chips__label">Try</span>
+                <button type="button" class="hero-example-chip" data-hero-example="Photosynthesis">Photosynthesis</button>
+                <button type="button" class="hero-example-chip" data-hero-example="Entropy">Entropy</button>
+                <button type="button" class="hero-example-chip" data-hero-example="The French Revolution">The French Revolution</button>
+                <button type="button" class="hero-example-chip" data-hero-example="Cognitive bias">Cognitive bias</button>
+              </div>
               <button type="submit" class="hero-single-input__submit" disabled>
                 <span>Start first room</span>
                 <svg class="hero-single-input__submit-icon" viewBox="0 0 24 24" aria-hidden="true">

--- a/public/js/ai_service.js
+++ b/public/js/ai_service.js
@@ -2,17 +2,58 @@
 // Calls the local Python backend for AI extraction.
 
 export async function generateKnowledgeMap(rawText, onProgress) {
-  if (onProgress) onProgress('Drafting map...');
-  const apiKey = localStorage.getItem('gemini_key') || undefined;
-  const response = await fetch('/api/extract', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  if (onProgress) onProgress("Drafting map...");
+  const apiKey = localStorage.getItem("gemini_key") || undefined;
+  const response = await fetch("/api/extract", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text: rawText, api_key: apiKey }),
   });
   if (!response.ok) {
-    const err = await response.text().catch(() => '');
+    const err = await response.text().catch(() => "");
     throw new Error(`Server error ${response.status}: ${err}`);
   }
   const data = await response.json();
   return data.knowledge_map;
+}
+
+/**
+ * Conversational concept-create submit. Posts the spec §5.3 payload shape
+ * and returns the parsed `provisional_map` (no source) or `knowledge_map`
+ * (source attached). On 422, throws an Error with `.status` and `.body`
+ * (the parsed `{error, message}` payload) so the caller can render the
+ * message inline.
+ *
+ * @param {{ name: string, startingSketch: string,
+ *           source: null | { type: 'text'|'url'|'file', text?: string, url?: string, filename?: string },
+ *           apiKey?: string }} args
+ * @returns {Promise<{ provisional_map?: object, knowledge_map?: object }>}
+ */
+export async function submitConceptCreate({ name, startingSketch, source, apiKey }) {
+  const body = {
+    name,
+    starting_sketch: startingSketch,
+    source,
+    api_key: apiKey,
+  };
+  const response = await fetch("/api/extract", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (response.status === 422) {
+    const payload = await response.json().catch(() => ({}));
+    const detail = payload.detail || payload || {};
+    const err = new Error(detail.message || "Submission rejected.");
+    err.status = 422;
+    err.body = detail;
+    throw err;
+  }
+  if (!response.ok) {
+    const txt = await response.text().catch(() => "");
+    const err = new Error(`Server error ${response.status}: ${txt}`);
+    err.status = response.status;
+    throw err;
+  }
+  return response.json();
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -370,34 +370,10 @@ const App = (() => {
       if (classified.kind === 'empty') return false;
       showDashboard();
       openDrawer();
-      // `startAddConcept` is async (awaits auth), and `buildContentInputUI` mounts the
-      // name input + textarea only after it resolves. Poll for the fields, then pre-fill.
+      // The conversational dialog handles its own input focus; no pre-fill needed.
+      // TODO(v2): When threshold-chat-turn is wired to the backend, pass `classified.text`
+      // as an initial hero-input hint so the chat turn-1 can be pre-answered for the user.
       startAddConcept();
-      // TODO(v2): LLM-proposed concept name. On `classified.kind === 'passage'`, run a
-      // quick LLM pass on `classified.text` to suggest a name, pre-fill it in the name
-      // field, let the user accept via Begin or edit. Out of scope for v1 due to latency
-      // and cost.
-      const deadline = performance.now() + 2000;
-      const tryFill = () => {
-        const dialog = document.getElementById('creation-dialog');
-        const nameInput = dialog?.querySelector('.creation-name-input');
-        const textarea = dialog?.querySelector('.overlay-textarea');
-        if (!nameInput || !textarea) {
-          if (performance.now() < deadline) requestAnimationFrame(tryFill);
-          return;
-        }
-        if (classified.kind === 'name') {
-          nameInput.value = classified.text;
-          nameInput.dispatchEvent(new Event('input', { bubbles: true }));
-          nameInput.focus();
-          nameInput.setSelectionRange(nameInput.value.length, nameInput.value.length);
-        } else {
-          textarea.value = classified.text;
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-          nameInput.focus();
-        }
-      };
-      requestAnimationFrame(tryFill);
       return false;
     }
 
@@ -681,7 +657,7 @@ const App = (() => {
   }
 
   // ── 12. CRUD ───────────────────────────────────────────────
-  function buildContentInputUI(container, { onSubmit, onCancel, showNameField, showClipboard }) {
+  function buildContentInputUI(container, { onSubmit, onCancel, showClipboard }) {
     let uploadedText = '';
     let uploadedFilename = '';
     let fetchedUrlText = '';
@@ -690,55 +666,13 @@ const App = (() => {
     let activeTab = 'paste';
 
     container.innerHTML = `
-      ${showNameField ? `
-        <div class="creation-intro creation-intro-compact">
-          <div class="creation-intro-row">
-            <div>
-              <div class="creation-intro-title">Start with your rough map.</div>
-              <p class="creation-intro-copy">This is global context. The first room will ask one smaller question.</p>
-            </div>
-          </div>
-        </div>
-        <div class="creation-field">
-          <label class="creation-section-label" for="creation-name-input">Concept name</label>
-          <input id="creation-name-input" class="creation-name-input" type="text" placeholder="e.g. Photosynthesis" maxlength="80">
-        </div>
-        <section class="creation-threshold">
-          <div class="creation-threshold-head">
-            <div>
-              <span class="creation-section-label" id="creation-threshold-label">Starting map</span>
-              <p class="creation-threshold-copy">Write what you think is happening before socratink structures the source.</p>
-            </div>
-          </div>
-          <textarea class="creation-threshold-input"
-                    aria-labelledby="creation-threshold-label"
-                    maxlength="1200"
-                    placeholder="Write what you already think is going on: parts, guesses, examples, or confusion."></textarea>
-          <div class="creation-fuzzy-row">
-            <button class="creation-fuzzy-toggle" type="button" aria-expanded="false" aria-describedby="creation-fuzzy-hint">Add fuzzy area</button>
-            <span id="creation-fuzzy-hint" class="creation-fuzzy-hint">Optional. Marks where socratink should probe more carefully.</span>
-          </div>
-          <div class="creation-fuzzy-panel" hidden>
-            <label class="creation-section-label" for="creation-fuzzy-input">What feels fuzzy?</label>
-            <input id="creation-fuzzy-input" class="creation-fuzzy-input" type="text" maxlength="500" placeholder="Optional. e.g. I am not sure which part causes which.">
-          </div>
-        </section>
-        <div class="creation-source-header">
-          <span class="creation-section-label">Source material</span>
-        </div>
-      ` : ''}
       <div class="overlay-tabs creation-source-tabs">
-        <button class="overlay-tab active" data-tab="paste">${showNameField ? 'Text' : 'Paste'}</button>
+        <button class="overlay-tab active" data-tab="paste">Paste</button>
         <button class="overlay-tab" data-tab="url">URL</button>
-        <button class="overlay-tab" data-tab="upload">${showNameField ? 'File' : 'Upload'}</button>
+        <button class="overlay-tab" data-tab="upload">Upload</button>
       </div>
-      ${showNameField ? `
-        <div class="creation-source-meta">
-          <p class="creation-source-copy" data-role="source-copy">Paste notes, an article excerpt, a transcript, or any raw text you want socratink to structure.</p>
-        </div>
-      ` : ''}
       <div class="overlay-panel" data-panel="paste">
-        <textarea class="overlay-textarea" placeholder="${showNameField ? 'Paste any source material. socratink will sketch the room.' : 'Paste source material here.'}"></textarea>
+        <textarea class="overlay-textarea" placeholder="Paste source material here."></textarea>
         ${showClipboard ? '<div class="paste-actions"><button class="paste-clipboard-btn" type="button">Paste from clipboard</button></div>' : ''}
       </div>
       <div class="overlay-panel" data-panel="url" style="display:none">
@@ -753,10 +687,9 @@ const App = (() => {
         <input type="file" accept=".txt,.md,.pdf" style="display:none">
         <p class="overlay-dropfeedback overlay-file-feedback"></p>
       </div>
-      ${showNameField ? '<p class="creation-validation" data-role="validation-note">Add a concept name to continue.</p>' : ''}
-      <div class="${showNameField ? 'creation-footer' : 'overlay-footer'}">
-        <button class="${showNameField ? 'creation-cancel' : 'overlay-cancel'}">Cancel</button>
-        <button class="${showNameField ? 'creation-submit' : 'overlay-extract'}" disabled>${showNameField ? 'Draft from Text' : 'Extract'}</button>
+      <div class="overlay-footer">
+        <button class="overlay-cancel">Cancel</button>
+        <button class="overlay-extract" disabled>Extract</button>
       </div>
     `;
 
@@ -769,46 +702,8 @@ const App = (() => {
     const urlInput = container.querySelector('.overlay-url-input');
     const urlFeedback = container.querySelector('.overlay-url-feedback');
     const pasteClipBtn = container.querySelector('.paste-clipboard-btn');
-    const nameInput = container.querySelector('.creation-name-input');
-    const sourceCopy = container.querySelector('[data-role="source-copy"]');
-    const validationNote = container.querySelector('[data-role="validation-note"]');
-    const thresholdInput = container.querySelector('.creation-threshold-input');
-    const fuzzyToggle = container.querySelector('.creation-fuzzy-toggle');
-    const fuzzyPanel = container.querySelector('.creation-fuzzy-panel');
-    const fuzzyInput = container.querySelector('.creation-fuzzy-input');
-    const cancelBtn = container.querySelector(showNameField ? '.creation-cancel' : '.overlay-cancel');
-    const submitBtn = container.querySelector(showNameField ? '.creation-submit' : '.overlay-extract');
-
-    function getActiveTabMeta() {
-      if (activeTab === 'url') {
-        return {
-          label: 'Import URL',
-          copy: 'Bring in an article or text page that can be fetched directly by the app.',
-          action: showNameField ? 'Import URL' : 'Extract',
-          missing: 'Add a source URL before drafting.',
-        };
-      }
-      if (activeTab === 'upload') {
-        return {
-          label: 'Upload File',
-          copy: 'Use this for notes, markdown, or PDFs when the learner already has source material saved locally.',
-          action: showNameField ? 'Upload and Draft' : 'Extract',
-          missing: 'Upload a file before drafting.',
-        };
-      }
-      return {
-        label: 'Text Paste',
-        copy: 'Paste notes, an article excerpt, a transcript, or any raw text you want socratink to structure.',
-        action: showNameField ? 'Draft from Text' : 'Extract',
-        missing: 'Paste source text before drafting.',
-      };
-    }
-
-    function updateComposerMeta() {
-      const meta = getActiveTabMeta();
-      if (sourceCopy) sourceCopy.textContent = meta.copy;
-      if (submitBtn) submitBtn.textContent = meta.action;
-    }
+    const cancelBtn = container.querySelector('.overlay-cancel');
+    const submitBtn = container.querySelector('.overlay-extract');
 
     function hasContent() {
       if (activeTab === 'paste') return textarea.value.trim().length > 0;
@@ -818,27 +713,14 @@ const App = (() => {
       }
       return uploadedText.length > 0;
     }
-    function hasThresholdContext() {
-      return !showNameField || (thresholdInput && thresholdInput.value.trim().length > 0);
-    }
     function checkSubmitEnabled() {
       const blockedVideoUrl = activeTab === 'url' && isBlockedVideoUrl(urlInput.value.trim());
-      const ready = showNameField
-        ? (!blockedVideoUrl && hasContent() && nameInput.value.trim().length > 0 && hasThresholdContext())
-        : hasContent();
-      submitBtn.disabled = !ready;
-      if (showNameField) {
-        if (!validationNote) return;
-        if (blockedVideoUrl) {
-          validationNote.textContent = 'Video links are not supported in this build. Paste notes or transcript text instead.';
-        } else if (!nameInput.value.trim()) {
-          validationNote.textContent = 'Add a concept name to continue.';
-        } else if (!hasThresholdContext()) {
-          validationNote.textContent = 'Add your starting map. It is global context, not evidence.';
-        } else if (!hasContent()) {
-          validationNote.textContent = getActiveTabMeta().missing;
-        } else {
-          validationNote.textContent = 'Ready to build a provisional route.';
+      submitBtn.disabled = !(hasContent() && !blockedVideoUrl);
+      if (urlFeedback) {
+        const rawUrl = urlInput.value.trim();
+        if (rawUrl && isBlockedVideoUrl(rawUrl)) {
+          urlFeedback.className = 'overlay-dropfeedback overlay-url-feedback error';
+          urlFeedback.textContent = 'Video links are not supported in this build. Paste notes or transcript text instead.';
         }
       }
     }
@@ -848,52 +730,9 @@ const App = (() => {
         activeTab = tab.dataset.tab;
         tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === activeTab));
         panels.forEach(p => { p.style.display = p.dataset.panel === activeTab ? '' : 'none'; });
-        updateComposerMeta();
         checkSubmitEnabled();
       });
     });
-
-    let phTimer = null;
-    let namePhTimer = null;
-    if (showNameField) {
-      const PLACEHOLDERS = [
-        'Paste any source material. socratink will sketch the room.',
-        'Paste your notes, a transcript, or an article excerpt.',
-        'Paste a passage you want socratink to structure.',
-        'Paste a chapter, a brief, or your own writing.',
-      ];
-      const NAME_PLACEHOLDERS = [
-        'Metacognition',
-        'Tornadoes',
-        'Neuroscience',
-        'Photosynthesis',
-        'Game Theory',
-        'Plate Tectonics',
-        'Cognitive Biases',
-        'Black Holes',
-        'Impressionism',
-        'Natural Selection',
-        'Supply and Demand',
-        'Cell Division',
-        'The French Revolution',
-      ];
-      let phIdx = 0;
-      let namePhIdx = 0;
-      phTimer = setInterval(() => {
-        if (!document.contains(textarea)) { clearInterval(phTimer); return; }
-        if (textarea.value.length > 0) return;
-        phIdx = (phIdx + 1) % PLACEHOLDERS.length;
-        textarea.placeholder = PLACEHOLDERS[phIdx];
-      }, 2500);
-      if (nameInput) {
-        namePhTimer = setInterval(() => {
-          if (!document.contains(nameInput)) { clearInterval(namePhTimer); return; }
-          if (nameInput.value.length > 0) return;
-          namePhIdx = (namePhIdx + 1) % NAME_PLACEHOLDERS.length;
-          nameInput.placeholder = `e.g. ${NAME_PLACEHOLDERS[namePhIdx]}`;
-        }, 2500);
-      }
-    }
 
     if (showClipboard && pasteClipBtn) {
       pasteClipBtn.addEventListener('click', () => {
@@ -909,20 +748,6 @@ const App = (() => {
     }
 
     textarea.addEventListener('input', checkSubmitEnabled);
-    if (thresholdInput) {
-      thresholdInput.addEventListener('input', checkSubmitEnabled);
-    }
-    if (fuzzyToggle && fuzzyPanel) {
-      const fuzzyHint = container.querySelector('.creation-fuzzy-hint');
-      fuzzyToggle.addEventListener('click', () => {
-        const isOpening = fuzzyPanel.hasAttribute('hidden');
-        fuzzyPanel.toggleAttribute('hidden', !isOpening);
-        fuzzyToggle.setAttribute('aria-expanded', String(isOpening));
-        fuzzyToggle.textContent = isOpening ? 'Hide fuzzy area' : 'Add fuzzy area';
-        if (fuzzyHint) fuzzyHint.toggleAttribute('hidden', isOpening);
-        if (isOpening) fuzzyInput?.focus();
-      });
-    }
     if (urlInput) {
       urlInput.addEventListener('input', () => {
         fetchedUrlText = '';
@@ -942,17 +767,6 @@ const App = (() => {
       });
       urlInput.addEventListener('keydown', e => {
         if (e.key === 'Enter' && !submitBtn.disabled) { e.preventDefault(); doSubmit(); }
-      });
-    }
-    if (nameInput) {
-      nameInput.addEventListener('input', checkSubmitEnabled);
-      nameInput.addEventListener('keydown', e => {
-        if (e.key === 'Enter' && !submitBtn.disabled) { e.preventDefault(); doSubmit(); }
-        if (e.key === 'Escape') {
-          if (phTimer) clearInterval(phTimer);
-          if (namePhTimer) clearInterval(namePhTimer);
-          onCancel();
-        }
       });
     }
 
@@ -992,8 +806,6 @@ const App = (() => {
     }
 
     cancelBtn.addEventListener('click', () => {
-      if (phTimer) clearInterval(phTimer);
-      if (namePhTimer) clearInterval(namePhTimer);
       onCancel();
     });
 
@@ -1004,10 +816,6 @@ const App = (() => {
 
     function doSubmit() {
       let text, type, filename, url;
-      const thresholdText = thresholdInput ? thresholdInput.value.trim() : '';
-      const fuzzyVisible = fuzzyPanel && !fuzzyPanel.hasAttribute('hidden');
-      const fuzzyText = fuzzyInput && fuzzyVisible ? fuzzyInput.value.trim() : '';
-      const thresholdContext = fuzzyText ? `${thresholdText}\n\nFuzzy area: ${fuzzyText}` : thresholdText;
       if (activeTab === 'paste') {
         text = textarea.value.trim();
         type = 'text';
@@ -1024,25 +832,18 @@ const App = (() => {
         filename = uploadedFilename;
         url = null;
       }
-      if (phTimer) clearInterval(phTimer);
       onSubmit({
         text,
         type,
         filename,
         url,
-        name: nameInput ? nameInput.value.trim() : null,
-        thresholdContext,
       });
     }
 
-    if (showNameField && nameInput) nameInput.focus();
-    else textarea.focus();
-    updateComposerMeta();
+    textarea.focus();
     checkSubmitEnabled();
     return {
       destroy() {
-        if (phTimer) clearInterval(phTimer);
-        if (namePhTimer) clearInterval(namePhTimer);
         container.innerHTML = '';
       }
     };
@@ -1196,6 +997,339 @@ const App = (() => {
     return row;
   }
 
+  // ── finishConceptCreateWithMap ───────────────────────────────
+  // Called after the knowledge map is already in hand (either from the old
+  // form-based flow or, now, from the conversational flow in concept-create.js).
+  // This helper owns everything that happens AFTER the network call:
+  //   mount extract overlay → brief animation → saveConcept → selectConcept.
+  //
+  // NOTE (Option B): In the conversational flow the network call happens inside
+  // concept-create.js (doSubmit) before onSubmit fires. The overlay therefore
+  // shows briefly between dialog close and graph mount rather than during the
+  // network call. A future Option A refactor would stream progress events from
+  // concept-create.js so the overlay could mount before the POST.
+  //
+  // Parameters:
+  //   id            — pre-generated concept id (generateId())
+  //   name          — concept name string
+  //   knowledgeMap  — already-validated knowledge map object
+  //   startedAtIso  — ISO timestamp of when creation began
+  //   startedPerf   — performance.now() at creation start (unused here but
+  //                   preserved for future duration telemetry)
+  //   startingSketch — the learner's rough map text (stored as
+  //                    starting_map_context in metadata; maps to the old
+  //                    thresholdContext field for persistence shape parity)
+  //   source        — resolved source object { type, text } from concept-create.js
+  function finishConceptCreateWithMap({ id, name, knowledgeMap, startedAtIso, startedPerf, startingSketch, source }) {
+    const startingMapContext = String(startingSketch || '').trim().slice(0, 1200);
+
+    // Derive content fields from source (URL already resolved by concept-create.js)
+    const sourceText = (source && source.text) ? source.text : '';
+    const sourceType = (source && source.type) ? source.type : 'text';
+    const sourceFilename = (source && source.filename) ? source.filename : null;
+
+    const extractOverlay = document.createElement('div');
+    extractOverlay.id = 'extract-overlay';
+    extractOverlay.innerHTML = `
+      <canvas class="eo-particle-canvas"></canvas>
+      <div class="eo-glow-blob"></div>
+      <header class="eo-header">
+        <img src="/brand/socratink-mark-square.png?v=1" alt="" class="eo-brand-mark" aria-hidden="true">
+        <h1 class="eo-brand">socratink</h1>
+      </header>
+      <div class="eo-focal">
+        <div class="eo-radar"></div>
+        <div class="eo-ring-outer"></div>
+        <div class="eo-ring-inner"></div>
+        <svg class="eo-crystal-svg" xmlns="http://www.w3.org/2000/svg" viewBox="54 65 92 110" overflow="hidden">
+          <defs>
+            <filter id="eo-glow" x="-40%" y="-40%" width="180%" height="180%">
+              <feGaussianBlur stdDeviation="3" result="blur"/>
+              <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+            </filter>
+          </defs>
+          <g class="eo-crystal-grow">
+            <!-- glow halo — soft, no drop-shadow interference -->
+            <polygon points="100,73 121,91 131,119 117,145 100,167 83,145 69,119 79,91" fill="hsl(270,55%,65%)" opacity="0.18" filter="url(#eo-glow)"/>
+            <!-- lower-left -->
+            <polygon points="100,119 69,119 83,145 100,167" fill="hsl(270,42%,52%)"/>
+            <!-- lower-right -->
+            <polygon points="100,119 100,167 117,145 131,119" fill="hsl(270,38%,42%)"/>
+            <!-- upper-left -->
+            <polygon points="100,73 79,91 69,119 100,119" fill="hsl(270,48%,62%)"/>
+            <!-- upper-right -->
+            <polygon points="100,73 100,119 131,119 121,91" fill="hsl(270,42%,52%)"/>
+            <!-- bottom-tip -->
+            <polygon points="83,145 100,167 117,145" fill="hsl(270,38%,42%)"/>
+            <!-- top — brightest face -->
+            <polygon points="100,73 79,91 100,119 121,91" fill="hsl(270,52%,74%)"/>
+            <!-- specular -->
+            <polygon points="104,77 114,94 112,85" fill="hsl(270,60%,92%)" opacity="0.7"/>
+          </g>
+        </svg>
+        <div class="eo-pill eo-pill-top">
+          <span class="material-symbols-outlined eo-pill-icon">auto_awesome</span>
+          <span class="eo-status-label">Analyzing</span>
+        </div>
+        <div class="eo-pill eo-pill-bottom">
+          <span class="material-symbols-outlined eo-pill-icon">memory</span>
+          <span class="eo-concept-name">${escHtml(name)}</span>
+        </div>
+      </div>
+      <div class="eo-meta-status">
+        <span class="eo-meta-text">Parsing source content...</span>
+      </div>
+      <div class="eo-tip">
+        <p class="eo-tip-text">&ldquo;Retrieval practice strengthens memory more than passive exposure.&rdquo;</p>
+      </div>
+      <footer class="eo-footer">
+        <div class="eo-progress-meta">
+          <span class="eo-progress-label">Drafting</span>
+          <span class="eo-progress-pct">20%</span>
+        </div>
+        <div class="eo-progress-track">
+          <div class="eo-progress-bar" style="width:20%">
+            <div class="eo-progress-shimmer"></div>
+          </div>
+        </div>
+      </footer>
+    `;
+    document.body.appendChild(extractOverlay);
+
+    let trickleInterval = null;
+    let tipInterval = null;
+    let metaInterval = null;
+    let pgDots = [], pgCursor = null, pgRafId = null;
+
+    const PG = {
+      SPACING: 28, DOT_R: 1.2,
+      BASE_OP: 0.14, MAX_OP: 0.38,
+      INFLUENCE: 90, MAX_PUSH: 7, EASE: 0.07, OP_EASE: 0.10,
+      SETTLE_THRESH: 0.12,
+    };
+
+    const OVERLAY_TIPS = [
+      'Retrieval practice strengthens memory more than passive exposure.',
+      'Spacing retrieval over time helps short-term recall become more durable.',
+      'A draft map is a hypothesis. It earns trust only after you reconstruct rooms from memory.',
+      'Answering before the explanation appears gives study something specific to repair.',
+      'The generation effect: producing an answer, even imperfectly, encodes it deeper than passive exposure.',
+      'The graph records evidence from attempts and spaced reconstruction, not exposure.',
+      'Spacing works best when intervals grow: short gaps early, longer gaps later.',
+    ];
+
+    const META_STAGES = [
+      'Mapping concept graph...',
+      'Checking for contradictions...',
+      'Synthesizing relationships...',
+      'Drafting provisional route...',
+      'Structuring final map...',
+    ];
+
+    function setMetaStatus(txt) {
+      const el = extractOverlay.querySelector('.eo-meta-text');
+      if (!el) return;
+      el.classList.add('eo-meta-exit');
+      setTimeout(() => { el.textContent = txt; el.classList.remove('eo-meta-exit'); }, 260);
+    }
+
+    function startMetaCycle() {
+      let idx = 0;
+      setMetaStatus(META_STAGES[0]);
+      metaInterval = setInterval(() => {
+        idx = (idx + 1) % META_STAGES.length;
+        setMetaStatus(META_STAGES[idx]);
+      }, 3500);
+    }
+
+    function startTipCycle() {
+      let idx = 0;
+      tipInterval = setInterval(() => {
+        const tipEl = extractOverlay.querySelector('.eo-tip-text');
+        if (!tipEl) return;
+        tipEl.classList.add('eo-tip-exit');
+        setTimeout(() => {
+          idx = (idx + 1) % OVERLAY_TIPS.length;
+          tipEl.innerHTML = '“' + OVERLAY_TIPS[idx] + '”';
+          tipEl.classList.remove('eo-tip-exit');
+        }, 420);
+      }, 5500);
+    }
+
+    function pgInit() {
+      const canvas = extractOverlay.querySelector('.eo-particle-canvas');
+      if (!canvas) return;
+      const W = canvas.offsetWidth, H = canvas.offsetHeight;
+      canvas.width = W; canvas.height = H;
+      pgDots = [];
+      for (let y = PG.SPACING / 2; y < H; y += PG.SPACING) {
+        for (let x = PG.SPACING / 2; x < W; x += PG.SPACING) {
+          pgDots.push({ ox: x, oy: y, x, y, op: PG.BASE_OP });
+        }
+      }
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'white';
+      pgDraw(ctx);
+      canvas.closest('#extract-overlay').addEventListener('mousemove', e => {
+        const r = canvas.getBoundingClientRect();
+        pgCursor = { x: e.clientX - r.left, y: e.clientY - r.top };
+        if (!pgRafId) pgRafId = requestAnimationFrame(() => pgTick(ctx));
+      });
+      canvas.closest('#extract-overlay').addEventListener('mouseleave', () => {
+        pgCursor = null;
+        if (!pgRafId) pgRafId = requestAnimationFrame(() => pgTick(ctx));
+      });
+    }
+
+    function pgUpdate() {
+      const cx = pgCursor ? pgCursor.x : null;
+      const cy = pgCursor ? pgCursor.y : null;
+      for (const d of pgDots) {
+        if (cx !== null) {
+          const dx = d.ox - cx, dy = d.oy - cy;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < PG.INFLUENCE && dist > 0) {
+            const s = (1 - dist / PG.INFLUENCE) * PG.MAX_PUSH;
+            d.x += (d.ox + (dx / dist) * s - d.x) * 0.18;
+            d.y += (d.oy + (dy / dist) * s - d.y) * 0.18;
+            d.op += (PG.BASE_OP + (1 - dist / PG.INFLUENCE) * (PG.MAX_OP - PG.BASE_OP) - d.op) * PG.OP_EASE;
+          } else {
+            d.x += (d.ox - d.x) * PG.EASE;
+            d.y += (d.oy - d.y) * PG.EASE;
+            d.op += (PG.BASE_OP - d.op) * PG.OP_EASE;
+          }
+        } else {
+          d.x += (d.ox - d.x) * PG.EASE;
+          d.y += (d.oy - d.y) * PG.EASE;
+          d.op += (PG.BASE_OP - d.op) * PG.OP_EASE;
+        }
+      }
+    }
+
+    function pgDraw(ctx) {
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+      for (const d of pgDots) {
+        ctx.globalAlpha = d.op;
+        ctx.beginPath();
+        ctx.arc(d.x, d.y, PG.DOT_R, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    function pgSettled() {
+      return pgDots.every(d =>
+        Math.abs(d.x - d.ox) < PG.SETTLE_THRESH &&
+        Math.abs(d.y - d.oy) < PG.SETTLE_THRESH &&
+        Math.abs(d.op - PG.BASE_OP) < 0.004
+      );
+    }
+
+    function pgTick(ctx) {
+      pgUpdate();
+      pgDraw(ctx);
+      if (!pgSettled()) {
+        pgRafId = requestAnimationFrame(() => pgTick(ctx));
+      } else {
+        pgRafId = null;
+      }
+    }
+
+    function setCrystalScale(pct) {
+      const grow = extractOverlay.querySelector('.eo-crystal-grow');
+      if (!grow) return;
+      const t = pct / 100;
+      const scale = 0.025 + Math.pow(t, 2) * 0.975;
+      const opacity = 0.35 + t * 0.65;
+      grow.style.transform = `scale(${scale.toFixed(3)})`;
+      grow.style.opacity = opacity.toFixed(2);
+    }
+
+    function setOverlayProgress(pct, statusText) {
+      const bar = extractOverlay.querySelector('.eo-progress-bar');
+      const pctEl = extractOverlay.querySelector('.eo-progress-pct');
+      const statusEl = extractOverlay.querySelector('.eo-status-label');
+      if (bar) bar.style.width = pct + '%';
+      if (pctEl) pctEl.textContent = pct + '%';
+      if (statusText && statusEl) statusEl.textContent = statusText;
+      setCrystalScale(pct);
+    }
+
+    function startTrickle() {
+      let current = 65;
+      const target = 89;
+      const tickMs = 1000;
+      const increment = (target - current) / 28; // 28s matches CSS eoTrickle duration
+      trickleInterval = setInterval(() => {
+        current = Math.min(current + increment, target);
+        const pctEl = extractOverlay.querySelector('.eo-progress-pct');
+        if (pctEl) pctEl.textContent = Math.round(current) + '%';
+        setCrystalScale(Math.round(current));
+        if (current >= target) { clearInterval(trickleInterval); trickleInterval = null; }
+      }, tickMs);
+    }
+
+    function removeOverlay(success = false) {
+      if (trickleInterval) { clearInterval(trickleInterval); trickleInterval = null; }
+      if (tipInterval) { clearInterval(tipInterval); tipInterval = null; }
+      if (metaInterval) { clearInterval(metaInterval); metaInterval = null; }
+      if (pgRafId) { cancelAnimationFrame(pgRafId); pgRafId = null; }
+      if (success) {
+        extractOverlay.classList.remove('eo-mapping');
+        const bar = extractOverlay.querySelector('.eo-progress-bar');
+        const pctEl = extractOverlay.querySelector('.eo-progress-pct');
+        const statusEl = extractOverlay.querySelector('.eo-status-label');
+        if (bar) bar.style.width = '100%';
+        if (pctEl) pctEl.textContent = '100%';
+        if (statusEl) statusEl.textContent = 'Draft ready';
+        setCrystalScale(100);
+        setTimeout(() => {
+          extractOverlay.classList.remove('visible');
+          setTimeout(() => { if (extractOverlay.parentNode) extractOverlay.parentNode.removeChild(extractOverlay); }, 400);
+        }, 700);
+      } else {
+        extractOverlay.classList.remove('visible');
+        setTimeout(() => { if (extractOverlay.parentNode) extractOverlay.parentNode.removeChild(extractOverlay); }, 400);
+      }
+    }
+
+    requestAnimationFrame(() => {
+      extractOverlay.classList.add('visible');
+      startTipCycle();
+      pgInit();
+      setCrystalScale(20);
+      setOverlayProgress(65, 'Drafting map');
+      extractOverlay.classList.add('eo-mapping');
+      startTrickle();
+      startMetaCycle();
+    });
+
+    // The map is already in hand — stamp metadata then persist immediately.
+    const jsonPayload = knowledgeMap;
+    jsonPayload.metadata = jsonPayload.metadata || {};
+    jsonPayload.metadata.starting_map_context = startingMapContext;
+    jsonPayload.metadata.map_maturity = 'provisional';
+
+    removeOverlay(true);
+    const concepts = loadConcepts();
+    const concept = {
+      id, name, state: 'growing',
+      createdAt: Date.now(), timerStart: null,
+      contentPreview: sourceText.slice(0, 500),
+      contentType: sourceType,
+      contentFilename: sourceFilename,
+      sourceUrl: null,
+      startingMapContext,
+      graphData: JSON.stringify(jsonPayload)
+    };
+    contentStore.set(id, sourceText);
+    concepts.push(concept);
+    saveConcepts(concepts);
+    renderGrid(concepts);
+    renderConceptList(concepts);
+    selectConcept(concept.id);
+    closeDrawer();
+  }
+
   async function startAddConcept() {
     window.__creationDialogTrigger = document.activeElement;
     const dialog = mountCreationDialog();
@@ -1216,372 +1350,34 @@ const App = (() => {
       return;
     }
 
-    buildContentInputUI(dialog.shellContent, {
-      showNameField: true,
-      showClipboard: true,
-      onSubmit: async ({ text, type, filename, url, name, thresholdContext }) => {
-        if (!name) return;
-        const startingMapContext = String(thresholdContext || '').trim().slice(0, 1200);
-        if (!startingMapContext) return;
+    const { buildConversationalCreateUI } = await import('./concept-create.js');
+    buildConversationalCreateUI(dialog.shellContent, {
+      onCancel: () => closeCreationDialog(),
+      onSubmit: async ({ name, startingSketch, source, provisionalMap }) => {
+        if (!isValidKnowledgeMap(provisionalMap)) {
+          // The dialog has not closed yet; show the error banner inline.
+          dialog.bannerSlot.innerHTML = '';
+          dialog.bannerSlot.appendChild(
+            buildErrorBanner(sanitizeExtractError(new Error('invalid map')))
+          );
+          return;
+        }
+
         const concepts = loadConcepts();
         if (concepts.length >= 4) { renderAddTrigger(); return; }
-
         closeCreationDialog();
 
-        const id = generateId();
-        const extractStartedAt = new Date().toISOString();
-        const extractStartedPerf = performance.now();
-
-        const extractOverlay = document.createElement('div');
-        extractOverlay.id = 'extract-overlay';
-        extractOverlay.innerHTML = `
-          <canvas class="eo-particle-canvas"></canvas>
-          <div class="eo-glow-blob"></div>
-          <header class="eo-header">
-            <img src="/brand/socratink-mark-square.png?v=1" alt="" class="eo-brand-mark" aria-hidden="true">
-            <h1 class="eo-brand">socratink</h1>
-          </header>
-          <div class="eo-focal">
-            <div class="eo-radar"></div>
-            <div class="eo-ring-outer"></div>
-            <div class="eo-ring-inner"></div>
-            <svg class="eo-crystal-svg" xmlns="http://www.w3.org/2000/svg" viewBox="54 65 92 110" overflow="hidden">
-              <defs>
-                <filter id="eo-glow" x="-40%" y="-40%" width="180%" height="180%">
-                  <feGaussianBlur stdDeviation="3" result="blur"/>
-                  <feComposite in="SourceGraphic" in2="blur" operator="over"/>
-                </filter>
-              </defs>
-              <g class="eo-crystal-grow">
-                <!-- glow halo — soft, no drop-shadow interference -->
-                <polygon points="100,73 121,91 131,119 117,145 100,167 83,145 69,119 79,91" fill="hsl(270,55%,65%)" opacity="0.18" filter="url(#eo-glow)"/>
-                <!-- lower-left -->
-                <polygon points="100,119 69,119 83,145 100,167" fill="hsl(270,42%,52%)"/>
-                <!-- lower-right -->
-                <polygon points="100,119 100,167 117,145 131,119" fill="hsl(270,38%,42%)"/>
-                <!-- upper-left -->
-                <polygon points="100,73 79,91 69,119 100,119" fill="hsl(270,48%,62%)"/>
-                <!-- upper-right -->
-                <polygon points="100,73 100,119 131,119 121,91" fill="hsl(270,42%,52%)"/>
-                <!-- bottom-tip -->
-                <polygon points="83,145 100,167 117,145" fill="hsl(270,38%,42%)"/>
-                <!-- top — brightest face -->
-                <polygon points="100,73 79,91 100,119 121,91" fill="hsl(270,52%,74%)"/>
-                <!-- specular -->
-                <polygon points="104,77 114,94 112,85" fill="hsl(270,60%,92%)" opacity="0.7"/>
-              </g>
-            </svg>
-            <div class="eo-pill eo-pill-top">
-              <span class="material-symbols-outlined eo-pill-icon">auto_awesome</span>
-              <span class="eo-status-label">Analyzing</span>
-            </div>
-            <div class="eo-pill eo-pill-bottom">
-              <span class="material-symbols-outlined eo-pill-icon">memory</span>
-              <span class="eo-concept-name">${escHtml(name)}</span>
-            </div>
-          </div>
-          <div class="eo-meta-status">
-            <span class="eo-meta-text">Parsing source content...</span>
-          </div>
-          <div class="eo-tip">
-            <p class="eo-tip-text">&ldquo;Retrieval practice strengthens memory more than passive exposure.&rdquo;</p>
-          </div>
-          <footer class="eo-footer">
-            <div class="eo-progress-meta">
-              <span class="eo-progress-label">Drafting</span>
-              <span class="eo-progress-pct">20%</span>
-            </div>
-            <div class="eo-progress-track">
-              <div class="eo-progress-bar" style="width:20%">
-                <div class="eo-progress-shimmer"></div>
-              </div>
-            </div>
-          </footer>
-        `;
-        document.body.appendChild(extractOverlay);
-        requestAnimationFrame(() => {
-          extractOverlay.classList.add('visible');
-          startTipCycle();
-          pgInit();
-          setCrystalScale(20);
+        finishConceptCreateWithMap({
+          id: generateId(),
+          name,
+          knowledgeMap: provisionalMap,
+          startedAtIso: new Date().toISOString(),
+          startedPerf: performance.now(),
+          startingSketch,
+          source,
         });
-
-        let trickleInterval = null;
-        let tipInterval = null;
-        let metaInterval = null;
-
-        const META_STAGES = [
-          'Mapping concept graph...',
-          'Checking for contradictions...',
-          'Synthesizing relationships...',
-          'Drafting provisional route...',
-          'Structuring final map...',
-        ];
-
-        function setMetaStatus(text) {
-          const el = extractOverlay.querySelector('.eo-meta-text');
-          if (!el) return;
-          el.classList.add('eo-meta-exit');
-          setTimeout(() => { el.textContent = text; el.classList.remove('eo-meta-exit'); }, 260);
-        }
-
-        function startMetaCycle() {
-          let idx = 0;
-          setMetaStatus(META_STAGES[0]);
-          metaInterval = setInterval(() => {
-            idx = (idx + 1) % META_STAGES.length;
-            setMetaStatus(META_STAGES[idx]);
-          }, 3500);
-        }
-
-        const OVERLAY_TIPS = [
-          'Retrieval practice strengthens memory more than passive exposure.',
-          'Spacing retrieval over time helps short-term recall become more durable.',
-          'A draft map is a hypothesis. It earns trust only after you reconstruct rooms from memory.',
-          'Answering before the explanation appears gives study something specific to repair.',
-          'The generation effect: producing an answer, even imperfectly, encodes it deeper than passive exposure.',
-          'The graph records evidence from attempts and spaced reconstruction, not exposure.',
-          'Spacing works best when intervals grow: short gaps early, longer gaps later.',
-        ];
-
-        function startTipCycle() {
-          let idx = 0;
-          tipInterval = setInterval(() => {
-            const tipEl = extractOverlay.querySelector('.eo-tip-text');
-            if (!tipEl) return;
-            tipEl.classList.add('eo-tip-exit');
-            setTimeout(() => {
-              idx = (idx + 1) % OVERLAY_TIPS.length;
-              tipEl.innerHTML = '\u201c' + OVERLAY_TIPS[idx] + '\u201d';
-              tipEl.classList.remove('eo-tip-exit');
-            }, 420);
-          }, 5500);
-        }
-
-        // ── Particle grid ────────────────────────────────────────────
-        const PG = {
-          SPACING: 28, DOT_R: 1.2,
-          BASE_OP: 0.14, MAX_OP: 0.38,
-          INFLUENCE: 90, MAX_PUSH: 7, EASE: 0.07, OP_EASE: 0.10,
-          SETTLE_THRESH: 0.12,
-        };
-        let pgDots = [], pgCursor = null, pgRafId = null;
-
-        function pgInit() {
-          const canvas = extractOverlay.querySelector('.eo-particle-canvas');
-          if (!canvas) return;
-          const W = canvas.offsetWidth, H = canvas.offsetHeight;
-          canvas.width = W; canvas.height = H;
-          pgDots = [];
-          for (let y = PG.SPACING / 2; y < H; y += PG.SPACING) {
-            for (let x = PG.SPACING / 2; x < W; x += PG.SPACING) {
-              pgDots.push({ ox: x, oy: y, x, y, op: PG.BASE_OP });
-            }
-          }
-          const ctx = canvas.getContext('2d');
-          ctx.fillStyle = 'white';
-          pgDraw(ctx);
-
-          canvas.closest('#extract-overlay').addEventListener('mousemove', e => {
-            const r = canvas.getBoundingClientRect();
-            pgCursor = { x: e.clientX - r.left, y: e.clientY - r.top };
-            if (!pgRafId) pgRafId = requestAnimationFrame(() => pgTick(ctx));
-          });
-          canvas.closest('#extract-overlay').addEventListener('mouseleave', () => {
-            pgCursor = null;
-            if (!pgRafId) pgRafId = requestAnimationFrame(() => pgTick(ctx));
-          });
-        }
-
-        function pgUpdate() {
-          const cx = pgCursor ? pgCursor.x : null;
-          const cy = pgCursor ? pgCursor.y : null;
-          for (const d of pgDots) {
-            if (cx !== null) {
-              const dx = d.ox - cx, dy = d.oy - cy;
-              const dist = Math.sqrt(dx * dx + dy * dy);
-              if (dist < PG.INFLUENCE && dist > 0) {
-                const s = (1 - dist / PG.INFLUENCE) * PG.MAX_PUSH;
-                d.x += (d.ox + (dx / dist) * s - d.x) * 0.18;
-                d.y += (d.oy + (dy / dist) * s - d.y) * 0.18;
-                d.op += (PG.BASE_OP + (1 - dist / PG.INFLUENCE) * (PG.MAX_OP - PG.BASE_OP) - d.op) * PG.OP_EASE;
-              } else {
-                d.x += (d.ox - d.x) * PG.EASE;
-                d.y += (d.oy - d.y) * PG.EASE;
-                d.op += (PG.BASE_OP - d.op) * PG.OP_EASE;
-              }
-            } else {
-              d.x += (d.ox - d.x) * PG.EASE;
-              d.y += (d.oy - d.y) * PG.EASE;
-              d.op += (PG.BASE_OP - d.op) * PG.OP_EASE;
-            }
-          }
-        }
-
-        function pgDraw(ctx) {
-          ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-          for (const d of pgDots) {
-            ctx.globalAlpha = d.op;
-            ctx.beginPath();
-            ctx.arc(d.x, d.y, PG.DOT_R, 0, Math.PI * 2);
-            ctx.fill();
-          }
-        }
-
-        function pgSettled() {
-          return pgDots.every(d =>
-            Math.abs(d.x - d.ox) < PG.SETTLE_THRESH &&
-            Math.abs(d.y - d.oy) < PG.SETTLE_THRESH &&
-            Math.abs(d.op - PG.BASE_OP) < 0.004
-          );
-        }
-
-        function pgTick(ctx) {
-          pgUpdate();
-          pgDraw(ctx);
-          if (!pgSettled()) {
-            pgRafId = requestAnimationFrame(() => pgTick(ctx));
-          } else {
-            pgRafId = null;
-          }
-        }
-        // ─────────────────────────────────────────────────────────────
-
-        function setCrystalScale(pct) {
-          const grow = extractOverlay.querySelector('.eo-crystal-grow');
-          if (!grow) return;
-          const t = pct / 100;
-          const scale = 0.025 + Math.pow(t, 2) * 0.975;
-          const opacity = 0.35 + t * 0.65;
-          grow.style.transform = `scale(${scale.toFixed(3)})`;
-          grow.style.opacity = opacity.toFixed(2);
-        }
-
-        function setOverlayProgress(pct, statusText) {
-          const bar = extractOverlay.querySelector('.eo-progress-bar');
-          const pctEl = extractOverlay.querySelector('.eo-progress-pct');
-          const statusEl = extractOverlay.querySelector('.eo-status-label');
-          if (bar) bar.style.width = pct + '%';
-          if (pctEl) pctEl.textContent = pct + '%';
-          if (statusText && statusEl) statusEl.textContent = statusText;
-          setCrystalScale(pct);
-        }
-
-        function startTrickle() {
-          let current = 65;
-          const target = 89;
-          const tickMs = 1000;
-          const increment = (target - current) / 28; // 28s matches CSS eoTrickle duration
-          trickleInterval = setInterval(() => {
-            current = Math.min(current + increment, target);
-            const pctEl = extractOverlay.querySelector('.eo-progress-pct');
-            if (pctEl) pctEl.textContent = Math.round(current) + '%';
-            setCrystalScale(Math.round(current));
-            if (current >= target) { clearInterval(trickleInterval); trickleInterval = null; }
-          }, tickMs);
-        }
-
-        function removeOverlay(success = false) {
-          if (trickleInterval) { clearInterval(trickleInterval); trickleInterval = null; }
-          if (tipInterval) { clearInterval(tipInterval); tipInterval = null; }
-          if (metaInterval) { clearInterval(metaInterval); metaInterval = null; }
-          if (pgRafId) { cancelAnimationFrame(pgRafId); pgRafId = null; }
-          if (success) {
-            extractOverlay.classList.remove('eo-mapping');
-            const bar = extractOverlay.querySelector('.eo-progress-bar');
-            const pctEl = extractOverlay.querySelector('.eo-progress-pct');
-            const statusEl = extractOverlay.querySelector('.eo-status-label');
-            if (bar) bar.style.width = '100%';
-            if (pctEl) pctEl.textContent = '100%';
-            if (statusEl) statusEl.textContent = 'Draft ready';
-            setCrystalScale(100);
-            setTimeout(() => {
-              extractOverlay.classList.remove('visible');
-              setTimeout(() => { if (extractOverlay.parentNode) extractOverlay.parentNode.removeChild(extractOverlay); }, 400);
-            }, 700);
-          } else {
-            extractOverlay.classList.remove('visible');
-            setTimeout(() => { if (extractOverlay.parentNode) extractOverlay.parentNode.removeChild(extractOverlay); }, 400);
-          }
-        }
-
-        try {
-          let sourceText = text;
-          let sourceFilename = filename;
-
-          if (type === 'url') {
-            if (!url) throw new Error('No URL provided.');
-            if (isBlockedVideoUrl(url)) {
-              throw new Error('Video links are not supported in this build. Paste notes or transcript text instead.');
-            }
-            setOverlayProgress(38, 'Fetching page');
-            setMetaStatus('Evaluating source structure...');
-            const payload = await extractUrl({ url });
-            sourceText = payload.text;
-            sourceFilename = payload.title || url;
-          }
-
-          if (!sourceText) throw new Error('No content provided.');
-
-          setOverlayProgress(65, 'Drafting map');
-          extractOverlay.classList.add('eo-mapping');
-          startTrickle();
-          startMetaCycle();
-          const jsonPayload = await generateKnowledgeMap(sourceText);
-          const durationMs = Math.round(performance.now() - extractStartedPerf);
-
-          // INVARIANT: failed or malformed extraction must never mutate
-          // contentStore / concepts / localStorage. Guard runs BEFORE any
-          // state mutation and regardless of UI disabled state.
-          if (!isValidKnowledgeMap(jsonPayload)) {
-            removeOverlay();
-            throw new Error('Extraction returned an invalid map.');
-          }
-
-          jsonPayload.metadata = jsonPayload.metadata || {};
-          jsonPayload.metadata.starting_map_context = startingMapContext;
-          jsonPayload.metadata.map_maturity = 'provisional';
-
-          removeOverlay(true);
-          const concept = {
-            id, name, state: 'growing',
-            createdAt: Date.now(), timerStart: null,
-            contentPreview: sourceText.slice(0, 500),
-            contentType: type,
-            contentFilename: sourceFilename,
-            sourceUrl: type === 'url' ? url : null,
-            startingMapContext,
-            graphData: JSON.stringify(jsonPayload)
-          };
-          contentStore.set(id, sourceText);
-          concepts.push(concept);
-          saveConcepts(concepts);
-          renderGrid(concepts);
-          renderConceptList(concepts);
-          selectConcept(concept.id);
-          closeCreationDialog();
-          closeDrawer();
-        } catch (err) {
-          removeOverlay();
-          const sanitized = sanitizeExtractError(err);
-          console.warn('[extract] raw error (console only):', err);
-          const bannerSlot = document.querySelector('.creation-dialog-banner-slot');
-          if (bannerSlot) {
-            const existing = bannerSlot.querySelector('.creation-banner--error');
-            if (existing) existing.remove();
-            bannerSlot.appendChild(buildErrorBanner(sanitized));
-          }
-          const shellContent = document.querySelector('.creation-dialog-content');
-          shellContent?.querySelectorAll('button, input, textarea').forEach((el) => { el.disabled = false; });
-        }
       },
-      onCancel: () => {
-        closeCreationDialog();
-      }
     });
-    // Focus first input inside dialog after mount
-    const firstInput = dialog.shell.querySelector('input:not([disabled]), textarea:not([disabled])');
-    firstInput?.focus();
   }
 
   function deleteConcept(id, btnEl) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1000,6 +1000,20 @@ const App = (() => {
     return banner;
   }
 
+  // Calm, seed-specific error banner used in error-recovery remount.
+  // Distinct from buildErrorBanner (which prefixes "Extraction stopped.") to
+  // avoid the console-y tone on what may be a transient model-output issue.
+  function buildSeedFailureBanner(message) {
+    const banner = document.createElement('div');
+    banner.className = 'creation-banner creation-banner--error';
+    banner.innerHTML = `
+      <div>
+        ${escHtml(message)}
+      </div>
+    `;
+    return banner;
+  }
+
   function buildGuestActions(loginHref) {
     const row = document.createElement('div');
     row.className = 'creation-guest-actions';
@@ -1376,26 +1390,33 @@ const App = (() => {
 
     const { buildConversationalCreateUI } = await import('./concept-create.js');
 
-    // Shared helper to re-mount the creation dialog with an error banner after
-    // the overlay tears down. The user's sketch is NOT preserved on retry — this
-    // is acceptable for v1. Preserving sketch across error retry is a follow-up.
-    // seed is forwarded so retry preserves the hero-input pre-fill.
-    function remountWithError(err) {
+    // Re-mount the creation dialog at the summary card stage, preserving the
+    // learner's concept, sketchTurns, and source from the failed submit.
+    // Banner names two strategic paths without consoling or naming the provider.
+    function remountWithError(err, preservedState) {
       const dialog2 = mountCreationDialog();
       dialog2.bannerSlot.appendChild(
-        buildErrorBanner(sanitizeExtractError(err))
+        buildSeedFailureBanner(
+          "socratink couldn't draft from this seed. You can try again, or attach source material for a different draft path."
+        )
       );
       buildConversationalCreateUI(dialog2.shellContent, {
-        seed,
+        seed: {
+          name: preservedState?.name || seed?.name || "",
+          sketchTurns: preservedState?.sketchTurns || [],
+          source: preservedState?.source || null,
+          stage: "summary",
+          ctaOverrideCopy: "Try again",
+        },
         onCancel: () => closeCreationDialog(),
         onBeforeSubmit: ({ name: n }) => {
           closeCreationDialog();
           return mountExtractOverlay({ name: n });
         },
         onSubmit: handleSubmit,
-        onSubmitError: ({ overlayHandle, error }) => {
+        onSubmitError: ({ overlayHandle, error, preservedState: ps }) => {
           if (overlayHandle) overlayHandle.removeOverlay(false);
-          remountWithError(error);
+          remountWithError(error, ps);
         },
       });
     }
@@ -1437,9 +1458,9 @@ const App = (() => {
         return mountExtractOverlay({ name });
       },
       onSubmit: handleSubmit,
-      onSubmitError: ({ overlayHandle, error }) => {
+      onSubmitError: ({ overlayHandle, error, preservedState }) => {
         if (overlayHandle) overlayHandle.removeOverlay(false);
-        remountWithError(error);
+        remountWithError(error, preservedState);
       },
     });
   }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1871,6 +1871,9 @@ const App = (() => {
             <span>ready for first attempt</span>
             <span>locked</span>
           </div>
+          ${meta.low_density
+            ? `<p class="map-provisional-low-density">Drafted from a thin sketch. The route is intentionally sparse — your first cold attempt will fill in what the sketch left out.</p>`
+            : ''}
         </div>
       </section>
       <section class="map-zone map-first-room-zone">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -998,65 +998,65 @@ const App = (() => {
     const extractOverlay = document.createElement('div');
     extractOverlay.id = 'extract-overlay';
     extractOverlay.innerHTML = `
-      <canvas class=”eo-particle-canvas”></canvas>
-      <div class=”eo-glow-blob”></div>
-      <header class=”eo-header”>
-        <img src=”/brand/socratink-mark-square.png?v=1” alt=”” class=”eo-brand-mark” aria-hidden=”true”>
-        <h1 class=”eo-brand”>socratink</h1>
+      <canvas class="eo-particle-canvas"></canvas>
+      <div class="eo-glow-blob"></div>
+      <header class="eo-header">
+        <img src="/brand/socratink-mark-square.png?v=1" alt="" class="eo-brand-mark" aria-hidden="true">
+        <h1 class="eo-brand">socratink</h1>
       </header>
-      <div class=”eo-focal”>
-        <div class=”eo-radar”></div>
-        <div class=”eo-ring-outer”></div>
-        <div class=”eo-ring-inner”></div>
-        <svg class=”eo-crystal-svg” xmlns=”http://www.w3.org/2000/svg” viewBox=”54 65 92 110” overflow=”hidden”>
+      <div class="eo-focal">
+        <div class="eo-radar"></div>
+        <div class="eo-ring-outer"></div>
+        <div class="eo-ring-inner"></div>
+        <svg class="eo-crystal-svg" xmlns="http://www.w3.org/2000/svg" viewBox="54 65 92 110" overflow="hidden">
           <defs>
-            <filter id=”eo-glow” x=”-40%” y=”-40%” width=”180%” height=”180%”>
-              <feGaussianBlur stdDeviation=”3” result=”blur”/>
-              <feComposite in=”SourceGraphic” in2=”blur” operator=”over”/>
+            <filter id="eo-glow" x="-40%" y="-40%" width="180%" height="180%">
+              <feGaussianBlur stdDeviation="3" result="blur"/>
+              <feComposite in="SourceGraphic" in2="blur" operator="over"/>
             </filter>
           </defs>
-          <g class=”eo-crystal-grow”>
+          <g class="eo-crystal-grow">
             <!-- glow halo — soft, no drop-shadow interference -->
-            <polygon points=”100,73 121,91 131,119 117,145 100,167 83,145 69,119 79,91” fill=”hsl(270,55%,65%)” opacity=”0.18” filter=”url(#eo-glow)”/>
+            <polygon points="100,73 121,91 131,119 117,145 100,167 83,145 69,119 79,91" fill="hsl(270,55%,65%)" opacity="0.18" filter="url(#eo-glow)"/>
             <!-- lower-left -->
-            <polygon points=”100,119 69,119 83,145 100,167” fill=”hsl(270,42%,52%)”/>
+            <polygon points="100,119 69,119 83,145 100,167" fill="hsl(270,42%,52%)"/>
             <!-- lower-right -->
-            <polygon points=”100,119 100,167 117,145 131,119” fill=”hsl(270,38%,42%)”/>
+            <polygon points="100,119 100,167 117,145 131,119" fill="hsl(270,38%,42%)"/>
             <!-- upper-left -->
-            <polygon points=”100,73 79,91 69,119 100,119” fill=”hsl(270,48%,62%)”/>
+            <polygon points="100,73 79,91 69,119 100,119" fill="hsl(270,48%,62%)"/>
             <!-- upper-right -->
-            <polygon points=”100,73 100,119 131,119 121,91” fill=”hsl(270,42%,52%)”/>
+            <polygon points="100,73 100,119 131,119 121,91" fill="hsl(270,42%,52%)"/>
             <!-- bottom-tip -->
-            <polygon points=”83,145 100,167 117,145” fill=”hsl(270,38%,42%)”/>
+            <polygon points="83,145 100,167 117,145" fill="hsl(270,38%,42%)"/>
             <!-- top — brightest face -->
-            <polygon points=”100,73 79,91 100,119 121,91” fill=”hsl(270,52%,74%)”/>
+            <polygon points="100,73 79,91 100,119 121,91" fill="hsl(270,52%,74%)"/>
             <!-- specular -->
-            <polygon points=”104,77 114,94 112,85” fill=”hsl(270,60%,92%)” opacity=”0.7”/>
+            <polygon points="104,77 114,94 112,85" fill="hsl(270,60%,92%)" opacity="0.7"/>
           </g>
         </svg>
-        <div class=”eo-pill eo-pill-top”>
-          <span class=”material-symbols-outlined eo-pill-icon”>auto_awesome</span>
-          <span class=”eo-status-label”>Analyzing</span>
+        <div class="eo-pill eo-pill-top">
+          <span class="material-symbols-outlined eo-pill-icon">auto_awesome</span>
+          <span class="eo-status-label">Analyzing</span>
         </div>
-        <div class=”eo-pill eo-pill-bottom”>
-          <span class=”material-symbols-outlined eo-pill-icon”>memory</span>
-          <span class=”eo-concept-name”>${escHtml(name)}</span>
+        <div class="eo-pill eo-pill-bottom">
+          <span class="material-symbols-outlined eo-pill-icon">memory</span>
+          <span class="eo-concept-name">${escHtml(name)}</span>
         </div>
       </div>
-      <div class=”eo-meta-status”>
-        <span class=”eo-meta-text”>Parsing source content...</span>
+      <div class="eo-meta-status">
+        <span class="eo-meta-text">Parsing source content...</span>
       </div>
-      <div class=”eo-tip”>
-        <p class=”eo-tip-text”>&ldquo;socratink is drafting your starting map.&rdquo;</p>
+      <div class="eo-tip">
+        <p class="eo-tip-text">&ldquo;socratink is drafting your starting map.&rdquo;</p>
       </div>
-      <footer class=”eo-footer”>
-        <div class=”eo-progress-meta”>
-          <span class=”eo-progress-label”>Drafting</span>
-          <span class=”eo-progress-pct”>20%</span>
+      <footer class="eo-footer">
+        <div class="eo-progress-meta">
+          <span class="eo-progress-label">Drafting</span>
+          <span class="eo-progress-pct">20%</span>
         </div>
-        <div class=”eo-progress-track”>
-          <div class=”eo-progress-bar” style=”width:20%”>
-            <div class=”eo-progress-shimmer”></div>
+        <div class="eo-progress-track">
+          <div class="eo-progress-bar" style="width:20%">
+            <div class="eo-progress-shimmer"></div>
           </div>
         </div>
       </footer>
@@ -1099,7 +1099,7 @@ const App = (() => {
         tipEl.classList.add('eo-tip-exit');
         setTimeout(() => {
           idx = (idx + 1) % OVERLAY_TIPS.length;
-          tipEl.innerHTML = '“' + OVERLAY_TIPS[idx] + '”';
+          tipEl.innerHTML = '"' + OVERLAY_TIPS[idx] + '"';
           tipEl.classList.remove('eo-tip-exit');
         }, 420);
       }, 5500);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -267,7 +267,7 @@ const App = (() => {
   }
 
   function getHeroGuidance(concept) {
-    if (!concept) return 'Name one concept or paste source material. socratink will help you rebuild it from memory. The first room asks for a small cold attempt before any explanation appears.';
+    if (!concept) return 'Name one concept. socratink helps you rebuild it from memory; the first room asks for a small cold attempt before any explanation appears.';
     switch (concept.state) {
       case 'instantiated':
         return concept.graphData
@@ -284,7 +284,7 @@ const App = (() => {
       case 'actualized':
         return 'Spaced evidence is on record. Re-drill later if you want to challenge it.';
       default:
-        return 'Name one concept or paste source material. The first room asks for a small cold attempt before any explanation appears.';
+        return 'Name one concept. The first room asks for a small cold attempt before any explanation appears.';
     }
   }
 
@@ -347,46 +347,18 @@ const App = (() => {
     }
   }
 
-  // Classify empty-state input: short, no newline, no sentence-final punctuation → concept name;
-  // otherwise → pasted passage. `.` `?` `!` are the signal; concept names almost never end in them.
-  function classifyHeroInput(raw) {
-    const text = (raw || '').trim();
-    if (!text) return { kind: 'empty', text: '' };
-    const hasNewline = /\n/.test(text);
-    const hasSentenceFinal = /[.?!]/.test(text);
-    if (text.length < 200 && !hasNewline && !hasSentenceFinal) {
-      return { kind: 'name', text };
-    }
-    return { kind: 'passage', text };
-  }
-
   function runHeroAction(evtOrNothing) {
-    // Empty-state form submit path: a Submit event comes in. Classify and pre-fill the dialog.
+    // Empty-state form submit path: a Submit event comes in. Hero is single-purpose:
+    // capture the concept name. Source material is attached on the modal's
+    // source-material chip if the learner wants it.
     if (evtOrNothing && typeof evtOrNothing.preventDefault === 'function') {
       evtOrNothing.preventDefault();
       const field = document.getElementById('hero-single-input-field');
-      const raw = field ? field.value : '';
-      const classified = classifyHeroInput(raw);
-      if (classified.kind === 'empty') return false;
+      const raw = (field ? field.value : '').trim();
+      if (!raw) return false;
       showDashboard();
       openDrawer();
-
-      // The hero input is the learner's answer to "What do you want to
-      // understand?". Pre-seed the chat so the modal does not ask the
-      // same question again.
-      //   - "name" classification → seed concept; modal opens at turn 2.
-      //   - "passage" classification → seed source; modal opens at turn 1
-      //     for the concept name, then exits to the summary card directly
-      //     (sketch is optional when source is attached).
-      const seed =
-        classified.kind === 'name'
-          ? { name: classified.text }
-          : classified.kind === 'passage'
-            ? { source: { type: 'text', text: classified.text, filename: '' } }
-            : undefined;
-
-      startAddConcept(seed);
-
+      startAddConcept({ name: raw });
       if (field) {
         field.value = '';
         field.style.height = '';
@@ -442,6 +414,17 @@ const App = (() => {
         e.preventDefault();
         form?.requestSubmit?.();
       }
+    });
+    const chips = document.querySelectorAll('[data-hero-example]');
+    chips.forEach((chip) => {
+      chip.addEventListener('click', () => {
+        const value = chip.dataset.heroExample || '';
+        if (!value) return;
+        field.value = value;
+        field.focus();
+        field.setSelectionRange(value.length, value.length);
+        sync();
+      });
     });
     sync();
   }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -425,25 +425,9 @@ const App = (() => {
     if (!(field instanceof HTMLTextAreaElement)) return;
     const form = document.getElementById('hero-single-input');
     const submit = form?.querySelector('.hero-single-input__submit');
-    const fileInput = document.getElementById('hero-single-input-file');
-    const attachBtn = document.getElementById('hero-single-input-attach');
-    const fileNote = document.getElementById('hero-single-input-file-note');
-
-    const defaultFileNote = 'TXT, MD, or PDF · max 2 MB';
-
     const autogrow = () => {
       field.style.height = 'auto';
       field.style.height = Math.min(field.scrollHeight, 240) + 'px';
-    };
-    const setFileNote = (message = defaultFileNote, tone = 'neutral') => {
-      if (!(fileNote instanceof HTMLElement)) return;
-      fileNote.textContent = message;
-      fileNote.dataset.tone = tone;
-    };
-    const formatFileSize = (bytes) => {
-      if (!Number.isFinite(bytes) || bytes <= 0) return '0 KB';
-      if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
     };
     const sync = () => {
       if (submit instanceof HTMLButtonElement) {
@@ -460,37 +444,6 @@ const App = (() => {
       }
     });
     sync();
-    setFileNote();
-
-    if (fileInput instanceof HTMLInputElement && attachBtn instanceof HTMLButtonElement) {
-      attachBtn.addEventListener('click', () => fileInput.click());
-      fileInput.addEventListener('change', () => {
-        const file = fileInput.files?.[0];
-        if (!file) return;
-
-        _readFile(
-          file,
-          (text, filename) => {
-            const nextText = String(text || '').trim();
-            if (!nextText) {
-              setFileNote('No readable text found. Try another file or paste text.', 'error');
-              fileInput.value = '';
-              return;
-            }
-            field.value = nextText;
-            sync();
-            field.focus();
-            setFileNote(`Attached ${filename} · ${formatFileSize(file.size)}`, 'success');
-            fileInput.value = '';
-          },
-          (message) => {
-            const sizeHint = file.size > 2 * 1024 * 1024 ? ` This file is ${formatFileSize(file.size)}.` : '';
-            setFileNote(`${message}${sizeHint}`, 'error');
-            fileInput.value = '';
-          }
-        );
-      });
-    }
   }
 
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -370,10 +370,27 @@ const App = (() => {
       if (classified.kind === 'empty') return false;
       showDashboard();
       openDrawer();
-      // The conversational dialog handles its own input focus; no pre-fill needed.
-      // TODO(v2): When threshold-chat-turn is wired to the backend, pass `classified.text`
-      // as an initial hero-input hint so the chat turn-1 can be pre-answered for the user.
-      startAddConcept();
+
+      // The hero input is the learner's answer to "What do you want to
+      // understand?". Pre-seed the chat so the modal does not ask the
+      // same question again.
+      //   - "name" classification → seed concept; modal opens at turn 2.
+      //   - "passage" classification → seed source; modal opens at turn 1
+      //     for the concept name, then exits to the summary card directly
+      //     (sketch is optional when source is attached).
+      const seed =
+        classified.kind === 'name'
+          ? { name: classified.text }
+          : classified.kind === 'passage'
+            ? { source: { type: 'text', text: classified.text, filename: '' } }
+            : undefined;
+
+      startAddConcept(seed);
+
+      if (field) {
+        field.value = '';
+        field.style.height = '';
+      }
       return false;
     }
 
@@ -1337,7 +1354,7 @@ const App = (() => {
     overlayHandle.removeOverlay(true);
   }
 
-  async function startAddConcept() {
+  async function startAddConcept(seed) {
     window.__creationDialogTrigger = document.activeElement;
     const dialog = mountCreationDialog();
     let isGuest = false;
@@ -1362,12 +1379,14 @@ const App = (() => {
     // Shared helper to re-mount the creation dialog with an error banner after
     // the overlay tears down. The user's sketch is NOT preserved on retry — this
     // is acceptable for v1. Preserving sketch across error retry is a follow-up.
+    // seed is forwarded so retry preserves the hero-input pre-fill.
     function remountWithError(err) {
       const dialog2 = mountCreationDialog();
       dialog2.bannerSlot.appendChild(
         buildErrorBanner(sanitizeExtractError(err))
       );
       buildConversationalCreateUI(dialog2.shellContent, {
+        seed,
         onCancel: () => closeCreationDialog(),
         onBeforeSubmit: ({ name: n }) => {
           closeCreationDialog();
@@ -1409,6 +1428,7 @@ const App = (() => {
     }
 
     buildConversationalCreateUI(dialog.shellContent, {
+      seed,
       onCancel: () => closeCreationDialog(),
       onBeforeSubmit: ({ name }) => {
         // Pre-flight: close the dialog and mount the overlay BEFORE the

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1361,8 +1361,15 @@ const App = (() => {
       if (!isValidKnowledgeMap(provisionalMap)) {
         // The dialog is already closed (onBeforeSubmit closed it). Tear down
         // the overlay and re-mount the dialog with an error banner.
+        // Preserve the learner's sketch and source so the re-mounted summary
+        // card is populated — same effort-preservation as the network-error path.
         if (overlayHandle) overlayHandle.removeOverlay(false);
-        remountWithError(new Error('invalid map'));
+        const preservedState = {
+          name,
+          sketchTurns: startingSketch ? [startingSketch] : [],
+          source,
+        };
+        remountWithError(new Error('invalid map'), preservedState);
         return;
       }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -997,99 +997,99 @@ const App = (() => {
     return row;
   }
 
-  // ── finishConceptCreateWithMap ───────────────────────────────
-  // Called after the knowledge map is already in hand (either from the old
-  // form-based flow or, now, from the conversational flow in concept-create.js).
-  // This helper owns everything that happens AFTER the network call:
-  //   mount extract overlay → brief animation → saveConcept → selectConcept.
+  // ── mountExtractOverlay ─────────────────────────────────────
+  // Mounts the full-viewport extract overlay and starts all animation
+  // cycles. Returns an overlayHandle object with a single method:
+  //   removeOverlay(success) — tears down the overlay.
+  //     success=true  → sets 100% + “Draft ready”, waits 700ms, then fades.
+  //     success=false → immediate fade-out (error path).
   //
-  // NOTE (Option B): In the conversational flow the network call happens inside
-  // concept-create.js (doSubmit) before onSubmit fires. The overlay therefore
-  // shows briefly between dialog close and graph mount rather than during the
-  // network call. A future Option A refactor would stream progress events from
-  // concept-create.js so the overlay could mount before the POST.
+  // The overlay mounts BEFORE the network call so learners see activity
+  // immediately after clicking Build. (Option A refactor — 2026-05-04.)
   //
-  // Parameters:
-  //   id            — pre-generated concept id (generateId())
-  //   name          — concept name string
-  //   knowledgeMap  — already-validated knowledge map object
-  //   startedAtIso  — ISO timestamp of when creation began
-  //   startedPerf   — performance.now() at creation start (unused here but
-  //                   preserved for future duration telemetry)
-  //   startingSketch — the learner's rough map text (stored as
-  //                    starting_map_context in metadata; maps to the old
-  //                    thresholdContext field for persistence shape parity)
-  //   source        — resolved source object { type, text } from concept-create.js
-  function finishConceptCreateWithMap({ id, name, knowledgeMap, startedAtIso, startedPerf, startingSketch, source }) {
-    const startingMapContext = String(startingSketch || '').trim().slice(0, 1200);
+  // Callers must NOT call removeOverlay twice; the DOM element is removed
+  // by the first call's scheduled timeout.
+  function mountExtractOverlay({ name }) {
+    const OVERLAY_TIPS = [
+      'socratink is drafting your starting map.',
+      'Spacing retrieval over time helps short-term recall become more durable.',
+      'socratink is structuring the rooms.',
+      'Answering before the explanation appears gives study something specific to repair.',
+      'socratink is sketching the draft route.',
+      'The graph records evidence from attempts and spaced reconstruction, not exposure.',
+      'Reading is exposure. Reconstruction is evidence.',
+    ];
 
-    // Derive content fields from source (URL already resolved by concept-create.js)
-    const sourceText = (source && source.text) ? source.text : '';
-    const sourceType = (source && source.type) ? source.type : 'text';
-    const sourceFilename = (source && source.filename) ? source.filename : null;
+    const META_STAGES = [
+      'Mapping concept graph...',
+      'Checking for contradictions...',
+      'Synthesizing relationships...',
+      'Drafting provisional route...',
+      'Structuring final map...',
+    ];
 
     const extractOverlay = document.createElement('div');
     extractOverlay.id = 'extract-overlay';
     extractOverlay.innerHTML = `
-      <canvas class="eo-particle-canvas"></canvas>
-      <div class="eo-glow-blob"></div>
-      <header class="eo-header">
-        <img src="/brand/socratink-mark-square.png?v=1" alt="" class="eo-brand-mark" aria-hidden="true">
-        <h1 class="eo-brand">socratink</h1>
+      <canvas class=”eo-particle-canvas”></canvas>
+      <div class=”eo-glow-blob”></div>
+      <header class=”eo-header”>
+        <img src=”/brand/socratink-mark-square.png?v=1” alt=”” class=”eo-brand-mark” aria-hidden=”true”>
+        <h1 class=”eo-brand”>socratink</h1>
       </header>
-      <div class="eo-focal">
-        <div class="eo-radar"></div>
-        <div class="eo-ring-outer"></div>
-        <div class="eo-ring-inner"></div>
-        <svg class="eo-crystal-svg" xmlns="http://www.w3.org/2000/svg" viewBox="54 65 92 110" overflow="hidden">
+      <div class=”eo-focal”>
+        <div class=”eo-radar”></div>
+        <div class=”eo-ring-outer”></div>
+        <div class=”eo-ring-inner”></div>
+        <svg class=”eo-crystal-svg” xmlns=”http://www.w3.org/2000/svg” viewBox=”54 65 92 110” overflow=”hidden”>
           <defs>
-            <filter id="eo-glow" x="-40%" y="-40%" width="180%" height="180%">
-              <feGaussianBlur stdDeviation="3" result="blur"/>
-              <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+            <filter id=”eo-glow” x=”-40%” y=”-40%” width=”180%” height=”180%”>
+              <feGaussianBlur stdDeviation=”3” result=”blur”/>
+              <feComposite in=”SourceGraphic” in2=”blur” operator=”over”/>
             </filter>
           </defs>
-          <g class="eo-crystal-grow">
+          <g class=”eo-crystal-grow”>
             <!-- glow halo — soft, no drop-shadow interference -->
-            <polygon points="100,73 121,91 131,119 117,145 100,167 83,145 69,119 79,91" fill="hsl(270,55%,65%)" opacity="0.18" filter="url(#eo-glow)"/>
+            <polygon points=”100,73 121,91 131,119 117,145 100,167 83,145 69,119 79,91” fill=”hsl(270,55%,65%)” opacity=”0.18” filter=”url(#eo-glow)”/>
             <!-- lower-left -->
-            <polygon points="100,119 69,119 83,145 100,167" fill="hsl(270,42%,52%)"/>
+            <polygon points=”100,119 69,119 83,145 100,167” fill=”hsl(270,42%,52%)”/>
             <!-- lower-right -->
-            <polygon points="100,119 100,167 117,145 131,119" fill="hsl(270,38%,42%)"/>
+            <polygon points=”100,119 100,167 117,145 131,119” fill=”hsl(270,38%,42%)”/>
             <!-- upper-left -->
-            <polygon points="100,73 79,91 69,119 100,119" fill="hsl(270,48%,62%)"/>
+            <polygon points=”100,73 79,91 69,119 100,119” fill=”hsl(270,48%,62%)”/>
             <!-- upper-right -->
-            <polygon points="100,73 100,119 131,119 121,91" fill="hsl(270,42%,52%)"/>
+            <polygon points=”100,73 100,119 131,119 121,91” fill=”hsl(270,42%,52%)”/>
             <!-- bottom-tip -->
-            <polygon points="83,145 100,167 117,145" fill="hsl(270,38%,42%)"/>
+            <polygon points=”83,145 100,167 117,145” fill=”hsl(270,38%,42%)”/>
             <!-- top — brightest face -->
-            <polygon points="100,73 79,91 100,119 121,91" fill="hsl(270,52%,74%)"/>
+            <polygon points=”100,73 79,91 100,119 121,91” fill=”hsl(270,52%,74%)”/>
             <!-- specular -->
-            <polygon points="104,77 114,94 112,85" fill="hsl(270,60%,92%)" opacity="0.7"/>
+            <polygon points=”104,77 114,94 112,85” fill=”hsl(270,60%,92%)” opacity=”0.7”/>
           </g>
         </svg>
-        <div class="eo-pill eo-pill-top">
-          <span class="material-symbols-outlined eo-pill-icon">auto_awesome</span>
-          <span class="eo-status-label">Analyzing</span>
+        <div class=”eo-pill eo-pill-top”>
+          <span class=”material-symbols-outlined eo-pill-icon”>auto_awesome</span>
+          <span class=”eo-status-label”>Analyzing</span>
         </div>
-        <div class="eo-pill eo-pill-bottom">
-          <span class="material-symbols-outlined eo-pill-icon">memory</span>
-          <span class="eo-concept-name">${escHtml(name)}</span>
+        <div class=”eo-pill eo-pill-bottom”>
+          <span class=”material-symbols-outlined eo-pill-icon”>memory</span>
+          <span class=”eo-concept-name”>${escHtml(name)}</span>
         </div>
       </div>
-      <div class="eo-meta-status">
-        <span class="eo-meta-text">Parsing source content...</span>
+      <div class=”eo-meta-status”>
+        <span class=”eo-meta-text”>Parsing source content...</span>
       </div>
-      <div class="eo-tip">
-        <p class="eo-tip-text">&ldquo;Retrieval practice strengthens memory more than passive exposure.&rdquo;</p>
+      <div class=”eo-tip”>
+        <p class=”eo-tip-text”>&ldquo;socratink is drafting your starting map.&rdquo;</p>
       </div>
-      <footer class="eo-footer">
-        <div class="eo-progress-meta">
-          <span class="eo-progress-label">Drafting</span>
-          <span class="eo-progress-pct">20%</span>
+      <footer class=”eo-footer”>
+        <div class=”eo-progress-meta”>
+          <span class=”eo-progress-label”>Drafting</span>
+          <span class=”eo-progress-pct”>20%</span>
         </div>
-        <div class="eo-progress-track">
-          <div class="eo-progress-bar" style="width:20%">
-            <div class="eo-progress-shimmer"></div>
+        <div class=”eo-progress-track”>
+          <div class=”eo-progress-bar” style=”width:20%”>
+            <div class=”eo-progress-shimmer”></div>
           </div>
         </div>
       </footer>
@@ -1107,24 +1107,6 @@ const App = (() => {
       INFLUENCE: 90, MAX_PUSH: 7, EASE: 0.07, OP_EASE: 0.10,
       SETTLE_THRESH: 0.12,
     };
-
-    const OVERLAY_TIPS = [
-      'Retrieval practice strengthens memory more than passive exposure.',
-      'Spacing retrieval over time helps short-term recall become more durable.',
-      'A draft map is a hypothesis. It earns trust only after you reconstruct rooms from memory.',
-      'Answering before the explanation appears gives study something specific to repair.',
-      'The generation effect: producing an answer, even imperfectly, encodes it deeper than passive exposure.',
-      'The graph records evidence from attempts and spaced reconstruction, not exposure.',
-      'Spacing works best when intervals grow: short gaps early, longer gaps later.',
-    ];
-
-    const META_STAGES = [
-      'Mapping concept graph...',
-      'Checking for contradictions...',
-      'Synthesizing relationships...',
-      'Drafting provisional route...',
-      'Structuring final map...',
-    ];
 
     function setMetaStatus(txt) {
       const el = extractOverlay.querySelector('.eo-meta-text');
@@ -1301,36 +1283,58 @@ const App = (() => {
       extractOverlay.classList.add('eo-mapping');
       startTrickle();
       startMetaCycle();
-
-      // Persistence runs inside the rAF callback so the intervals/RAF handles
-      // exist by the time removeOverlay(true) tries to cancel them. Without
-      // this ordering, removeOverlay fires before the rAF callback creates the
-      // timers, leaving them un-cancellable.
-      const jsonPayload = knowledgeMap;
-      jsonPayload.metadata = jsonPayload.metadata || {};
-      jsonPayload.metadata.starting_map_context = startingMapContext;
-      jsonPayload.metadata.map_maturity = 'provisional';
-
-      const concepts = loadConcepts();
-      const concept = {
-        id, name, state: 'growing',
-        createdAt: Date.now(), timerStart: null,
-        contentPreview: sourceText.slice(0, 500),
-        contentType: sourceType,
-        contentFilename: sourceFilename,
-        sourceUrl: source?.url || null,
-        startingMapContext,
-        graphData: JSON.stringify(jsonPayload)
-      };
-      contentStore.set(id, sourceText);
-      concepts.push(concept);
-      saveConcepts(concepts);
-      renderGrid(concepts);
-      renderConceptList(concepts);
-      selectConcept(concept.id);
-      closeDrawer();
-      removeOverlay(true);
     });
+
+    return { removeOverlay };
+  }
+
+  // ── finishConceptCreateAfterOverlay ──────────────────────────
+  // Runs persistence + teardown AFTER the network call resolves.
+  // The extract overlay is already mounted by the caller (via mountExtractOverlay)
+  // before the network call. This function does NOT mount the overlay.
+  //
+  // Parameters:
+  //   id            — pre-generated concept id (generateId())
+  //   name          — concept name string
+  //   knowledgeMap  — already-validated knowledge map object
+  //   startedAtIso  — ISO timestamp of when creation began
+  //   startedPerf   — performance.now() at creation start (preserved for
+  //                   future duration telemetry)
+  //   startingSketch — the learner's rough map text
+  //   source        — resolved source object { type, text } from concept-create.js
+  //   overlayHandle — { removeOverlay } returned by mountExtractOverlay
+  function finishConceptCreateAfterOverlay({ id, name, knowledgeMap, startedAtIso, startedPerf, startingSketch, source, overlayHandle }) {
+    const startingMapContext = String(startingSketch || '').trim().slice(0, 1200);
+
+    // Derive content fields from source (URL already resolved by concept-create.js)
+    const sourceText = (source && source.text) ? source.text : '';
+    const sourceType = (source && source.type) ? source.type : 'text';
+    const sourceFilename = (source && source.filename) ? source.filename : null;
+
+    const jsonPayload = knowledgeMap;
+    jsonPayload.metadata = jsonPayload.metadata || {};
+    jsonPayload.metadata.starting_map_context = startingMapContext;
+    jsonPayload.metadata.map_maturity = 'provisional';
+
+    const concepts = loadConcepts();
+    const concept = {
+      id, name, state: 'growing',
+      createdAt: Date.now(), timerStart: null,
+      contentPreview: sourceText.slice(0, 500),
+      contentType: sourceType,
+      contentFilename: sourceFilename,
+      sourceUrl: source?.url || null,
+      startingMapContext,
+      graphData: JSON.stringify(jsonPayload)
+    };
+    contentStore.set(id, sourceText);
+    concepts.push(concept);
+    saveConcepts(concepts);
+    renderGrid(concepts);
+    renderConceptList(concepts);
+    selectConcept(concept.id);
+    closeDrawer();
+    overlayHandle.removeOverlay(true);
   }
 
   async function startAddConcept() {
@@ -1354,31 +1358,68 @@ const App = (() => {
     }
 
     const { buildConversationalCreateUI } = await import('./concept-create.js');
+
+    // Shared helper to re-mount the creation dialog with an error banner after
+    // the overlay tears down. The user's sketch is NOT preserved on retry — this
+    // is acceptable for v1. Preserving sketch across error retry is a follow-up.
+    function remountWithError(err) {
+      const dialog2 = mountCreationDialog();
+      dialog2.bannerSlot.appendChild(
+        buildErrorBanner(sanitizeExtractError(err))
+      );
+      buildConversationalCreateUI(dialog2.shellContent, {
+        onCancel: () => closeCreationDialog(),
+        onBeforeSubmit: ({ name: n }) => {
+          closeCreationDialog();
+          return mountExtractOverlay({ name: n });
+        },
+        onSubmit: handleSubmit,
+        onSubmitError: ({ overlayHandle, error }) => {
+          if (overlayHandle) overlayHandle.removeOverlay(false);
+          remountWithError(error);
+        },
+      });
+    }
+
+    function handleSubmit({ name, startingSketch, source, provisionalMap, overlayHandle }) {
+      if (!isValidKnowledgeMap(provisionalMap)) {
+        // The dialog is already closed (onBeforeSubmit closed it). Tear down
+        // the overlay and re-mount the dialog with an error banner.
+        if (overlayHandle) overlayHandle.removeOverlay(false);
+        remountWithError(new Error('invalid map'));
+        return;
+      }
+
+      if (loadConcepts().length >= 4) {
+        if (overlayHandle) overlayHandle.removeOverlay(false);
+        renderAddTrigger();
+        return;
+      }
+
+      finishConceptCreateAfterOverlay({
+        id: generateId(),
+        name,
+        knowledgeMap: provisionalMap,
+        startedAtIso: new Date().toISOString(),
+        startedPerf: performance.now(),
+        startingSketch,
+        source,
+        overlayHandle,
+      });
+    }
+
     buildConversationalCreateUI(dialog.shellContent, {
       onCancel: () => closeCreationDialog(),
-      onSubmit: async ({ name, startingSketch, source, provisionalMap }) => {
-        if (!isValidKnowledgeMap(provisionalMap)) {
-          // The dialog has not closed yet; show the error banner inline.
-          dialog.bannerSlot.innerHTML = '';
-          dialog.bannerSlot.appendChild(
-            buildErrorBanner(sanitizeExtractError(new Error('invalid map')))
-          );
-          return;
-        }
-
-        const concepts = loadConcepts();
-        if (concepts.length >= 4) { renderAddTrigger(); return; }
+      onBeforeSubmit: ({ name }) => {
+        // Pre-flight: close the dialog and mount the overlay BEFORE the
+        // network call so there is no silent-wait gap after clicking Build.
         closeCreationDialog();
-
-        finishConceptCreateWithMap({
-          id: generateId(),
-          name,
-          knowledgeMap: provisionalMap,
-          startedAtIso: new Date().toISOString(),
-          startedPerf: performance.now(),
-          startingSketch,
-          source,
-        });
+        return mountExtractOverlay({ name });
+      },
+      onSubmit: handleSubmit,
+      onSubmitError: ({ overlayHandle, error }) => {
+        if (overlayHandle) overlayHandle.removeOverlay(false);
+        remountWithError(error);
       },
     });
   }
@@ -3887,6 +3928,7 @@ const App = (() => {
     deleteConcept,
     startAddConcept,
     renderAddTrigger,
+    mountExtractOverlay,
     extract, drill, drillFail, drillPass, consolidate,
     fastForward,
     hideMapView, setMapMode, toggleCluster,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1301,33 +1301,36 @@ const App = (() => {
       extractOverlay.classList.add('eo-mapping');
       startTrickle();
       startMetaCycle();
+
+      // Persistence runs inside the rAF callback so the intervals/RAF handles
+      // exist by the time removeOverlay(true) tries to cancel them. Without
+      // this ordering, removeOverlay fires before the rAF callback creates the
+      // timers, leaving them un-cancellable.
+      const jsonPayload = knowledgeMap;
+      jsonPayload.metadata = jsonPayload.metadata || {};
+      jsonPayload.metadata.starting_map_context = startingMapContext;
+      jsonPayload.metadata.map_maturity = 'provisional';
+
+      const concepts = loadConcepts();
+      const concept = {
+        id, name, state: 'growing',
+        createdAt: Date.now(), timerStart: null,
+        contentPreview: sourceText.slice(0, 500),
+        contentType: sourceType,
+        contentFilename: sourceFilename,
+        sourceUrl: source?.url || null,
+        startingMapContext,
+        graphData: JSON.stringify(jsonPayload)
+      };
+      contentStore.set(id, sourceText);
+      concepts.push(concept);
+      saveConcepts(concepts);
+      renderGrid(concepts);
+      renderConceptList(concepts);
+      selectConcept(concept.id);
+      closeDrawer();
+      removeOverlay(true);
     });
-
-    // The map is already in hand — stamp metadata then persist immediately.
-    const jsonPayload = knowledgeMap;
-    jsonPayload.metadata = jsonPayload.metadata || {};
-    jsonPayload.metadata.starting_map_context = startingMapContext;
-    jsonPayload.metadata.map_maturity = 'provisional';
-
-    removeOverlay(true);
-    const concepts = loadConcepts();
-    const concept = {
-      id, name, state: 'growing',
-      createdAt: Date.now(), timerStart: null,
-      contentPreview: sourceText.slice(0, 500),
-      contentType: sourceType,
-      contentFilename: sourceFilename,
-      sourceUrl: null,
-      startingMapContext,
-      graphData: JSON.stringify(jsonPayload)
-    };
-    contentStore.set(id, sourceText);
-    concepts.push(concept);
-    saveConcepts(concepts);
-    renderGrid(concepts);
-    renderConceptList(concepts);
-    selectConcept(concept.id);
-    closeDrawer();
   }
 
   async function startAddConcept() {
@@ -1634,7 +1637,6 @@ const App = (() => {
     }
 
     buildContentInputUI(overlay, {
-      showNameField: false,
       showClipboard: false,
       onSubmit: ({ text, type, filename }) => {
         if (!text) return;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,5 @@
 import { Bus } from './bus.js';
-import { generateKnowledgeMap } from './ai_service.js?v=2';
+import { generateKnowledgeMap } from './ai_service.js';
 import {
   getHealth,
   extractUrl,
@@ -1373,12 +1373,6 @@ const App = (() => {
         return;
       }
 
-      if (loadConcepts().length >= 4) {
-        if (overlayHandle) overlayHandle.removeOverlay(false);
-        renderAddTrigger();
-        return;
-      }
-
       finishConceptCreateAfterOverlay({
         id: generateId(),
         name,
@@ -1395,6 +1389,16 @@ const App = (() => {
       seed,
       onCancel: () => closeCreationDialog(),
       onBeforeSubmit: ({ name }) => {
+        if (loadConcepts().length >= 4) {
+          // Library is at the 4-concept cap. Don't pay for an LLM call.
+          // Don't close the dialog. Surface the cap inline so the learner
+          // can either remove a concept or cancel.
+          dialog.bannerSlot.innerHTML = '';
+          dialog.bannerSlot.appendChild(
+            buildSeedFailureBanner('Library is full. Remove a concept first to add another.')
+          );
+          return null;
+        }
         // Pre-flight: close the dialog and mount the overlay BEFORE the
         // network call so there is no silent-wait gap after clicking Build.
         closeCreationDialog();
@@ -3915,7 +3919,6 @@ const App = (() => {
     deleteConcept,
     startAddConcept,
     renderAddTrigger,
-    mountExtractOverlay,
     extract, drill, drillFail, drillPass, consolidate,
     fastForward,
     hideMapView, setMapMode, toggleCluster,

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -187,10 +187,130 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
     }
   }
 
-  // Placeholder until Task 5 ships the real summary renderer.
+  function joinSketch() {
+    return state.sketchTurns.filter((s) => s && s.trim()).join("\n\n");
+  }
+
+  function sketchIsSubstantive() {
+    return isSubstantiveSketch(joinSketch());
+  }
+
+  function ctaCopyForState() {
+    if (state.source && sketchIsSubstantive()) return "Build from my map and source";
+    if (state.source && !sketchIsSubstantive()) return "Build from source";
+    if (!state.source && sketchIsSubstantive()) return "Build from my starting map";
+    // Disabled state — copy still reads "Build from my starting map" so the
+    // CTA does not flicker text on every keystroke; the disabled attribute +
+    // the sketch-chip footer copy carry the strategy framing instead.
+    return "Build from my starting map";
+  }
+
+  function ctaEnabledForState() {
+    const concept = state.concept.trim();
+    if (!concept) return false;
+    if (state.source) return true;
+    return sketchIsSubstantive();
+  }
+
+  function sourceChipDescriptor() {
+    if (!state.source) return null;
+    if (state.source.type === "url") {
+      const len = (state.source.text || "").length.toLocaleString();
+      return `${len} chars from a URL`;
+    }
+    if (state.source.type === "file") {
+      const filename = state.source.filename || "file";
+      const len = (state.source.text || "").length.toLocaleString();
+      return `${filename} · ${len} chars`;
+    }
+    // text
+    const len = (state.source.text || "").length.toLocaleString();
+    return `${len} chars pasted`;
+  }
+
   function renderSummary() {
-    container.innerHTML =
-      '<div class="creation-summary"><p>Summary card pending (Task 5).</p></div>';
+    const concept = state.concept.trim();
+    const sketch = joinSketch();
+    const sketchOk = isSubstantiveSketch(sketch);
+    const sourceDesc = sourceChipDescriptor();
+    const ctaCopy = ctaCopyForState();
+    const ctaEnabled = ctaEnabledForState();
+
+    const breadcrumbLabel =
+      concept ? `↑ chat (collapsed): "${escHtml(concept)}" · sketch captured`
+              : "↑ chat (collapsed): sketch captured";
+
+    const sketchBlockedFooter = !state.source && !sketchOk;
+
+    container.innerHTML = `
+      <div class="creation-summary">
+        <p class="creation-chat-breadcrumb" aria-hidden="true">${breadcrumbLabel}</p>
+
+        <span class="creation-section-eyebrow">STARTING MAP</span>
+
+        <article class="creation-chip" data-chip="concept">
+          <div class="creation-chip-label-row">
+            <span class="creation-chip-label">CONCEPT</span>
+            <button class="creation-chip-action" type="button" data-action="edit-concept">edit</button>
+          </div>
+          <div class="creation-chip-value" data-role="concept-value">${escHtml(concept)}</div>
+        </article>
+
+        <article class="creation-chip" data-chip="sketch">
+          <div class="creation-chip-label-row">
+            <span class="creation-chip-label">YOUR SKETCH</span>
+            <button class="creation-chip-action" type="button" data-action="edit-sketch">edit</button>
+          </div>
+          <div class="creation-chip-value" data-role="sketch-value">${escHtml(sketch)}</div>
+          ${sketchBlockedFooter
+            ? `<p class="creation-chip-footer" data-role="sketch-footer">${escHtml(SKETCH_FOOTER_BLOCKED)}</p>`
+            : ""}
+        </article>
+
+        <article class="creation-chip ${sourceDesc ? "" : "creation-chip-empty"}" data-chip="source">
+          <div class="creation-chip-label-row">
+            <span class="creation-chip-label">SOURCE MATERIAL</span>
+            <button class="creation-chip-action" type="button" data-action="${sourceDesc ? "replace-source" : "add-source"}">
+              ${sourceDesc ? "replace" : "Add source"}
+            </button>
+          </div>
+          <div class="creation-chip-value" data-role="source-value">
+            ${sourceDesc
+              ? escHtml(sourceDesc)
+              : '<span class="creation-chip-empty-text">None added — build will start from your model only</span>'}
+          </div>
+        </article>
+
+        <div class="creation-footer">
+          <button class="creation-cancel" type="button">Cancel</button>
+          <button class="creation-submit creation-build-cta" type="button" ${ctaEnabled ? "" : "disabled"}>
+            ${escHtml(ctaCopy)}
+          </button>
+        </div>
+
+        <p class="creation-dialog-meta">${FOOTER_DEFAULT}</p>
+      </div>
+    `;
+
+    // Wire cancel + submit (the chip edit + source actions land in Tasks 7-8).
+    container.querySelector(".creation-cancel").addEventListener("click", () => onCancel?.());
+    const submitBtn = container.querySelector(".creation-submit");
+    submitBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (submitBtn.disabled) return;
+      doSubmit();
+    });
+
+    emitTelemetry("concept_create.summary.shown", {
+      has_concept: Boolean(concept),
+      has_sketch: Boolean(sketch),
+      sketch_len: sketch.length,
+    });
+  }
+
+  // Stub — real submit ships in Task 9.
+  function doSubmit() {
+    /* implemented in Task 9 */
   }
 
   // Boot the first chat turn.

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -312,6 +312,8 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
       has_sketch: Boolean(sketch),
       sketch_len: sketch.length,
     });
+
+    attachChipEditHandlers();
   }
 
   // Stub — real submit ships in Task 9.
@@ -334,6 +336,98 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
     emitTelemetry("concept_create.build_blocked", {
       reason,
       origin: "client",
+    });
+  }
+
+  function attachChipEditHandlers() {
+    const editConceptBtn = container.querySelector('[data-action="edit-concept"]');
+    const editSketchBtn = container.querySelector('[data-action="edit-sketch"]');
+    if (editConceptBtn) editConceptBtn.addEventListener("click", () => beginEditConcept());
+    if (editSketchBtn) editSketchBtn.addEventListener("click", () => beginEditSketch());
+  }
+
+  function beginEditConcept() {
+    const valueEl = container.querySelector('[data-role="concept-value"]');
+    if (!valueEl) return;
+    const prior = state.concept;
+    valueEl.innerHTML = `
+      <input
+        class="creation-chip-input"
+        type="text"
+        maxlength="200"
+        value="${escHtml(prior)}"
+        aria-label="Concept name">
+    `;
+    const input = valueEl.querySelector(".creation-chip-input");
+    input.focus();
+    input.select();
+
+    function save() {
+      const next = input.value.trim();
+      if (next !== prior) {
+        state.concept = next;
+        emitTelemetry("concept_create.summary.edited", { chip: "concept" });
+      }
+      rerenderSummary();
+    }
+    function cancel() {
+      rerenderSummary();
+    }
+    input.addEventListener("blur", save);
+    input.addEventListener("keydown", (e) => {
+      // stopPropagation: prevent the modal-level Escape handler from closing
+      // the dialog while we're editing a chip in place.
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        e.preventDefault();
+        cancel();
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        save();
+      }
+    });
+  }
+
+  function beginEditSketch() {
+    const valueEl = container.querySelector('[data-role="sketch-value"]');
+    if (!valueEl) return;
+    const prior = joinSketch();
+    valueEl.innerHTML = `
+      <textarea
+        class="creation-chip-textarea"
+        maxlength="10000"
+        rows="4"
+        aria-label="Your sketch">${escHtml(prior)}</textarea>
+    `;
+    const textarea = valueEl.querySelector(".creation-chip-textarea");
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+
+    function save() {
+      const next = textarea.value;
+      if (next !== prior) {
+        // Replace all sketchTurns with the edited value as a single turn.
+        // Subsequent edits are a single-turn sketch from the learner's POV.
+        state.sketchTurns = next.trim() ? [next] : [];
+        emitTelemetry("concept_create.summary.edited", { chip: "sketch" });
+      }
+      rerenderSummary();
+    }
+    function cancel() {
+      rerenderSummary();
+    }
+    textarea.addEventListener("blur", save);
+    textarea.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        e.preventDefault();
+        cancel();
+      }
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        save();
+      }
     });
   }
 

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -305,7 +305,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
           <div class="creation-chip-value" data-role="source-value">
             ${sourceDesc
               ? escHtml(sourceDesc)
-              : '<span class="creation-chip-empty-text">None added — build will start from your model only</span>'}
+              : '<span class="creation-chip-empty-text">None added — socratink will draft from your sketch alone. The graph stays hypothesis until your reconstruction.</span>'}
           </div>
         </article>
 

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -314,6 +314,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
     });
 
     attachChipEditHandlers();
+    attachSourceChipHandlers();
   }
 
   // Stub — real submit ships in Task 9.
@@ -429,6 +430,154 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
         save();
       }
     });
+  }
+
+  function beginEditSource() {
+    const sourceChip = container.querySelector('[data-chip="source"]');
+    if (!sourceChip) return;
+    const valueEl = sourceChip.querySelector('[data-role="source-value"]');
+    valueEl.innerHTML = `
+      <div class="creation-source-panel">
+        <div class="overlay-tabs creation-source-tabs">
+          <button class="overlay-tab active" type="button" data-tab="paste">Text</button>
+          <button class="overlay-tab" type="button" data-tab="url">URL</button>
+          <button class="overlay-tab" type="button" data-tab="upload">File</button>
+        </div>
+        <div class="overlay-panel" data-panel="paste">
+          <textarea class="overlay-textarea" placeholder="Paste source material here." maxlength="500000"></textarea>
+        </div>
+        <div class="overlay-panel" data-panel="url" style="display:none">
+          <input class="overlay-url-input" type="url" placeholder="https://example.com/article">
+          <p class="overlay-dropfeedback overlay-url-feedback"></p>
+        </div>
+        <div class="overlay-panel" data-panel="upload" style="display:none">
+          <div class="overlay-dropzone">
+            Drop a file or click to browse<br>
+            <span style="font-size:11px;opacity:0.65">.txt &nbsp; .md &nbsp; .pdf &nbsp; up to 2MB</span>
+          </div>
+          <input type="file" accept=".txt,.md,.pdf" style="display:none">
+          <p class="overlay-dropfeedback overlay-file-feedback"></p>
+        </div>
+        <div class="creation-source-panel-footer">
+          <button class="creation-source-panel-cancel" type="button">Cancel</button>
+          <button class="creation-source-panel-attach" type="button" disabled>Attach</button>
+        </div>
+      </div>
+    `;
+
+    const tabs = valueEl.querySelectorAll(".overlay-tab");
+    const panels = valueEl.querySelectorAll(".overlay-panel");
+    let activeTab = "paste";
+    let pendingFileText = "";
+    let pendingFileName = "";
+
+    const textarea = valueEl.querySelector(".overlay-textarea");
+    const urlInput = valueEl.querySelector(".overlay-url-input");
+    const dropzone = valueEl.querySelector(".overlay-dropzone");
+    const fileInput = valueEl.querySelector('input[type="file"]');
+    const fileFeedback = valueEl.querySelector(".overlay-file-feedback");
+    const cancelBtn = valueEl.querySelector(".creation-source-panel-cancel");
+    const attachBtn = valueEl.querySelector(".creation-source-panel-attach");
+
+    function panelHasContent() {
+      if (activeTab === "paste") return textarea.value.trim().length > 0;
+      if (activeTab === "url") return urlInput.value.trim().length > 0;
+      return pendingFileText.length > 0;
+    }
+    function refreshAttachEnabled() {
+      attachBtn.disabled = !panelHasContent();
+    }
+
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        activeTab = tab.dataset.tab;
+        tabs.forEach((t) => t.classList.toggle("active", t.dataset.tab === activeTab));
+        panels.forEach((p) => {
+          p.style.display = p.dataset.panel === activeTab ? "" : "none";
+        });
+        refreshAttachEnabled();
+      });
+    });
+
+    textarea.addEventListener("input", refreshAttachEnabled);
+    urlInput.addEventListener("input", refreshAttachEnabled);
+
+    dropzone.addEventListener("click", () => fileInput.click());
+    dropzone.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      dropzone.classList.add("dragover");
+    });
+    dropzone.addEventListener("dragleave", () => dropzone.classList.remove("dragover"));
+    dropzone.addEventListener("drop", (e) => {
+      e.preventDefault();
+      dropzone.classList.remove("dragover");
+      const f = e.dataTransfer.files?.[0];
+      if (f) handleFile(f);
+    });
+    fileInput.addEventListener("change", () => {
+      const f = fileInput.files?.[0];
+      if (f) handleFile(f);
+    });
+
+    function handleFile(file) {
+      // Two-megabyte cap mirrors the form-era constraint.
+      if (file.size > 2 * 1024 * 1024) {
+        fileFeedback.className = "overlay-dropfeedback error";
+        fileFeedback.textContent = "File is over 2MB.";
+        pendingFileText = "";
+        pendingFileName = "";
+        refreshAttachEnabled();
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        pendingFileText = String(reader.result || "");
+        pendingFileName = file.name;
+        fileFeedback.className = "overlay-dropfeedback ok";
+        fileFeedback.textContent = `${file.name} · ${pendingFileText.length.toLocaleString()} chars`;
+        refreshAttachEnabled();
+      };
+      reader.onerror = () => {
+        fileFeedback.className = "overlay-dropfeedback error";
+        fileFeedback.textContent = "Couldn't read that file.";
+        pendingFileText = "";
+        pendingFileName = "";
+        refreshAttachEnabled();
+      };
+      reader.readAsText(file);
+    }
+
+    cancelBtn.addEventListener("click", () => rerenderSummary());
+
+    attachBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (attachBtn.disabled) return;
+      if (activeTab === "paste") {
+        const text = textarea.value.trim();
+        if (!text) return;
+        state.source = { type: "text", text };
+      } else if (activeTab === "url") {
+        // The Plan A backend expects URL fetching to go through /api/extract-url
+        // (separate endpoint). For now we capture the URL on the client; Task 9
+        // routes URL submits through that endpoint. The chip stores the URL
+        // and the fetched text once the URL endpoint succeeds.
+        const url = urlInput.value.trim();
+        if (!url) return;
+        state.source = { type: "url", url, text: "", filename: "" };
+      } else {
+        if (!pendingFileText) return;
+        state.source = { type: "file", text: pendingFileText, filename: pendingFileName };
+      }
+      emitTelemetry("concept_create.source.added", { type: state.source.type });
+      rerenderSummary();
+    });
+  }
+
+  function attachSourceChipHandlers() {
+    const addBtn = container.querySelector('[data-action="add-source"]');
+    const replaceBtn = container.querySelector('[data-action="replace-source"]');
+    if (addBtn) addBtn.addEventListener("click", () => beginEditSource());
+    if (replaceBtn) replaceBtn.addEventListener("click", () => beginEditSource());
   }
 
   // Boot the first chat turn.

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -45,17 +45,25 @@ const SKETCH_FOOTER_BLOCKED =
 export function buildConversationalCreateUI(container, { onSubmit, onCancel, onBeforeSubmit, onSubmitError, seed }) {
   const initialName = (seed && typeof seed.name === "string" ? seed.name.trim() : "");
   const initialSource = seed && seed.source ? seed.source : null;
-  // If we have a name, skip turn 1 (the hero already captured the answer).
-  // If we have only source, start at turn 1 (concept name still needed).
-  const initialStage = initialName ? STAGE.CHAT_TURN_2 : STAGE.CHAT_TURN_1;
+  const initialSketchTurns = (seed && Array.isArray(seed.sketchTurns)) ? seed.sketchTurns.slice() : [];
+  // If seed.stage === "summary" (explicit), or we have both name and sketchTurns,
+  // land at the summary card directly. Otherwise fall through to the chat turns.
+  const initialStage = (seed && seed.stage === "summary")
+    ? STAGE.SUMMARY
+    : (initialName && initialSketchTurns.length > 0)
+      ? STAGE.SUMMARY
+      : initialName
+        ? STAGE.CHAT_TURN_2
+        : STAGE.CHAT_TURN_1;
 
   const state = {
     stage: initialStage,
     concept: initialName,
-    sketchTurns: [],          // verbatim learner replies; concatenated into chip value
-    source: initialSource,    // { type, text?, url?, filename? } once attached
+    sketchTurns: initialSketchTurns, // verbatim learner replies; concatenated into chip value
+    source: initialSource,           // { type, text?, url?, filename? } once attached
     usedFallback: false,
     submitting: false,
+    ctaOverride: (seed && typeof seed.ctaOverrideCopy === "string") ? seed.ctaOverrideCopy : null,
   };
 
   function destroy() {
@@ -212,6 +220,10 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
   }
 
   function ctaCopyForState() {
+    // ctaOverride is set in error-recovery mode (e.g. "Try again"). Once the
+    // user attaches source, the override yields to the normal truth-table so
+    // the CTA accurately names the new build path.
+    if (state.ctaOverride && !state.source) return state.ctaOverride;
     if (state.source && sketchIsSubstantive()) return "Build from my map and source";
     if (state.source && !sketchIsSubstantive()) return "Build from source";
     if (!state.source && sketchIsSubstantive()) return "Build from my starting map";
@@ -371,7 +383,16 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
         };
       } catch (err) {
         state.submitting = false;
-        onSubmitError?.({ overlayHandle, error: err });
+        emitTelemetry("concept_create.build_failed", {
+          stage: "submit",
+          error_kind: "url_fetch",
+        });
+        const preservedState = {
+          name: state.concept,
+          sketchTurns: state.sketchTurns.slice(),
+          source: state.source,
+        };
+        onSubmitError?.({ overlayHandle, error: err, preservedState });
         return;
       }
     }
@@ -400,6 +421,11 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
       });
     } catch (err) {
       state.submitting = false;
+      const preservedState = {
+        name: state.concept,
+        sketchTurns: state.sketchTurns.slice(),
+        source: state.source,
+      };
       if (err && err.status === 422 && err.body) {
         const code = err.body.error;
         // Emit telemetry before routing to onSubmitError. The dialog is
@@ -411,9 +437,22 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
             reason: code,
             origin: "server",
           });
+        } else {
+          emitTelemetry("concept_create.build_failed", {
+            stage: "submit",
+            error_kind: "422_unhandled",
+          });
         }
+      } else {
+        const errorKind = (err && err.status >= 500)
+          ? "5xx_network"
+          : "other";
+        emitTelemetry("concept_create.build_failed", {
+          stage: "submit",
+          error_kind: errorKind,
+        });
       }
-      onSubmitError?.({ overlayHandle, error: err });
+      onSubmitError?.({ overlayHandle, error: err, preservedState });
     }
   }
 
@@ -682,8 +721,12 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     if (replaceBtn) replaceBtn.addEventListener("click", () => beginEditSource());
   }
 
-  // Boot the first chat turn.
-  renderChat();
+  // Boot at the resolved initial stage.
+  if (initialStage === STAGE.SUMMARY) {
+    renderSummary();
+  } else {
+    renderChat();
+  }
 
   return { destroy };
 }

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -287,8 +287,6 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
             ${escHtml(ctaCopy)}
           </button>
         </div>
-
-        <p class="creation-dialog-meta">${FOOTER_DEFAULT}</p>
       </div>
     `;
 
@@ -383,10 +381,18 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
         const code = err.body.error;
         const message = err.body.message || "Submission rejected.";
         if (code === "missing_concept") {
+          emitTelemetry("concept_create.build_blocked", {
+            reason: code,
+            origin: "server",
+          });
           showSubmitError("concept", message);
           return;
         }
         if (code === "thin_sketch_no_source") {
+          emitTelemetry("concept_create.build_blocked", {
+            reason: code,
+            origin: "server",
+          });
           showSubmitError("sketch", message);
           return;
         }

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -44,7 +44,7 @@ const SKETCH_FOOTER_BLOCKED =
   "A few words about how you think it works will give socratink something to draft from. " +
   "Or attach source material — either path opens the build.";
 
-export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
+export function buildConversationalCreateUI(container, { onSubmit, onCancel, onBeforeSubmit, onSubmitError }) {
   const state = {
     stage: STAGE.CHAT_TURN_1,
     concept: "",
@@ -327,6 +327,13 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
       has_sketch: Boolean(sketch),
     });
 
+    // Pre-flight: signal the caller to close the dialog and mount the extract
+    // overlay BEFORE any network call. The caller returns an overlayHandle that
+    // the caller uses to tear down the overlay on success or error. If
+    // onBeforeSubmit is omitted, overlayHandle is undefined — callers that omit
+    // it must not expect overlay teardown from the network-error path.
+    const overlayHandle = onBeforeSubmit?.({ name: concept });
+
     let resolvedSource = state.source;
 
     // URL source path: hop through /api/extract-url first to materialise text.
@@ -348,10 +355,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
         };
       } catch (err) {
         state.submitting = false;
-        showSubmitError(
-          "source",
-          err && err.message ? err.message : "Couldn't fetch that URL."
-        );
+        onSubmitError?.({ overlayHandle, error: err });
         return;
       }
     }
@@ -369,81 +373,32 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
       });
       state.submitting = false;
       // Hand off to the caller; one of provisional_map / knowledge_map is set.
+      // overlayHandle is forwarded so the caller can tear the overlay down after
+      // persistence (finishConceptCreateAfterOverlay calls removeOverlay(true)).
       onSubmit?.({
         name: concept,
         startingSketch: sketch,
         source: resolvedSource,
         provisionalMap: data.provisional_map || data.knowledge_map || null,
+        overlayHandle,
       });
     } catch (err) {
       state.submitting = false;
       if (err && err.status === 422 && err.body) {
         const code = err.body.error;
-        const message = err.body.message || "Submission rejected.";
-        if (code === "missing_concept") {
+        // Emit telemetry before routing to onSubmitError. The dialog is
+        // already closed (onBeforeSubmit closed it), so chip-level footers
+        // have nowhere to render — 422s now surface via the re-mounted dialog
+        // error banner in the caller.
+        if (code === "missing_concept" || code === "thin_sketch_no_source") {
           emitTelemetry("concept_create.build_blocked", {
             reason: code,
             origin: "server",
           });
-          showSubmitError("concept", message);
-          return;
-        }
-        if (code === "thin_sketch_no_source") {
-          emitTelemetry("concept_create.build_blocked", {
-            reason: code,
-            origin: "server",
-          });
-          showSubmitError("sketch", message);
-          return;
         }
       }
-      showSubmitError(
-        "submit",
-        (err && err.message) || "Couldn't submit. Try again."
-      );
+      onSubmitError?.({ overlayHandle, error: err });
     }
-  }
-
-  function showSubmitError(target, message) {
-    rerenderSummary();
-    if (target === "concept") {
-      const valueEl = container.querySelector('[data-role="concept-value"]');
-      if (valueEl) {
-        valueEl.insertAdjacentHTML(
-          "afterend",
-          `<p class="creation-chip-footer">${escHtml(message)}</p>`
-        );
-      }
-      return;
-    }
-    if (target === "sketch") {
-      const sketchChip = container.querySelector('[data-chip="sketch"]');
-      if (!sketchChip) return;
-      const existing = sketchChip.querySelector(".creation-chip-footer");
-      if (existing) existing.textContent = message;
-      else
-        sketchChip.insertAdjacentHTML(
-          "beforeend",
-          `<p class="creation-chip-footer">${escHtml(message)}</p>`
-        );
-      return;
-    }
-    if (target === "source") {
-      const sourceChip = container.querySelector('[data-chip="source"]');
-      if (!sourceChip) return;
-      sourceChip.insertAdjacentHTML(
-        "beforeend",
-        `<p class="creation-chip-footer">${escHtml(message)}</p>`
-      );
-      return;
-    }
-    // Generic fallback: append a banner below the summary.
-    const summary = container.querySelector(".creation-summary");
-    if (!summary) return;
-    summary.insertAdjacentHTML(
-      "beforeend",
-      `<p class="creation-chip-footer">${escHtml(message)}</p>`
-    );
   }
 
   function rerenderSummary() {

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -30,13 +30,11 @@ const STAGE = Object.freeze({
 const CHAT_COPY = Object.freeze({
   TURN_1: "What do you want to understand?",
   TURN_2: "Sketch what you think it does — rough is fine. What parts come to mind?",
-  // The fallback is generic-but-honest for v1: "inputs and outputs" is the
-  // input-output frame most causal concepts share, derived in spirit from the
-  // spec's analogical-fallback rule. Concept-derived analogy generation is a
+  // The fallback is concept-agnostic: one example works for processes, state
+  // quantities, and abstract nouns. Concept-derived analogy generation is a
   // documented Plan B follow-up — see plan §"Out of scope".
   FALLBACK:
-    "Try this: think of something familiar that takes inputs and produces outputs. " +
-    "What inputs does this concept take, and what does it produce?",
+    "Try this: give one example. Anywhere this concept shows up in something you've read or experienced — a small detail will do.",
 });
 
 const FOOTER_DEFAULT = "Study content stays locked until the cold attempt.";
@@ -96,6 +94,9 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
 
     container.innerHTML = `
       <div class="creation-chat" data-stage="${escHtml(state.stage)}">
+        ${state.concept
+          ? `<p class="creation-chat-anchor"><span class="creation-chat-anchor-label">CONCEPT</span><span class="creation-chat-anchor-name">${escHtml(state.concept)}</span></p>`
+          : ""}
         <p class="creation-chat-question" id="creation-chat-question">${escHtml(question)}</p>
         <textarea
           class="creation-chat-composer"

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -495,11 +495,18 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
         panels.forEach((p) => {
           p.style.display = p.dataset.panel === activeTab ? "" : "none";
         });
+        valueEl.querySelectorAll(".overlay-dropfeedback").forEach((f) => {
+          f.textContent = "";
+          f.className = "overlay-dropfeedback";
+        });
         refreshAttachEnabled();
       });
     });
 
     textarea.addEventListener("input", refreshAttachEnabled);
+    // URL validation is server-side: Task 9 hops through /api/extract-url, which
+    // applies source_intake's allow-list (private-IP block, video-host block, scheme
+    // checks). The client only enables Attach when the field is non-empty.
     urlInput.addEventListener("input", refreshAttachEnabled);
 
     dropzone.addEventListener("click", () => fileInput.click());

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -342,7 +342,6 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
         resolvedSource = {
           type: "text",
           text: String(fetched.text || ""),
-          // Keep the original URL on the client for telemetry / display only.
           // Backend payload uses type: "text" so the dispatcher takes the
           // existing extract_knowledge_map path on this submit.
         };

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -297,7 +297,13 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
     const submitBtn = container.querySelector(".creation-submit");
     submitBtn.addEventListener("mousedown", (e) => {
       e.preventDefault();
-      if (submitBtn.disabled) return;
+      if (submitBtn.disabled) {
+        const reason = !state.concept.trim()
+          ? "missing_concept"
+          : "thin_sketch_no_source";
+        handleDisabledClickAttempt(reason);
+        return;
+      }
       doSubmit();
     });
 
@@ -311,6 +317,24 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
   // Stub — real submit ships in Task 9.
   function doSubmit() {
     /* implemented in Task 9 */
+  }
+
+  function rerenderSummary() {
+    // Cheap full re-render — chip state is small, DOM is shallow, no
+    // animation interrupted by re-render in v1. If perf bites later,
+    // swap to surgical updates per chip.
+    renderSummary();
+  }
+
+  // Wire the disabled-CTA telemetry. The CTA's disabled attribute prevents
+  // the click in normal use, but if an integration test or assistive tech
+  // somehow triggers an activation we want telemetry to log the block.
+  // (Server-side validation is the authority either way.)
+  function handleDisabledClickAttempt(reason) {
+    emitTelemetry("concept_create.build_blocked", {
+      reason,
+      origin: "client",
+    });
   }
 
   // Boot the first chat turn.

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -342,8 +342,11 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
         resolvedSource = {
           type: "text",
           text: String(fetched.text || ""),
-          // Backend payload uses type: "text" so the dispatcher takes the
-          // existing extract_knowledge_map path on this submit.
+          // Preserve the original URL on the resolved source so app.js can
+          // store sourceUrl on the concept record. Backend payload uses
+          // type: "text" so the dispatcher takes the existing
+          // extract_knowledge_map path on this submit.
+          url: resolvedSource.url,
         };
       } catch (err) {
         state.submitting = false;

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -317,9 +317,125 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
     attachSourceChipHandlers();
   }
 
-  // Stub — real submit ships in Task 9.
-  function doSubmit() {
-    /* implemented in Task 9 */
+  async function doSubmit() {
+    if (state.submitting) return;
+    state.submitting = true;
+
+    const concept = state.concept.trim();
+    const sketch = joinSketch();
+
+    emitTelemetry("concept_create.build_clicked", {
+      has_source: Boolean(state.source),
+      has_sketch: Boolean(sketch),
+    });
+
+    let resolvedSource = state.source;
+
+    // URL source path: hop through /api/extract-url first to materialise text.
+    // The /api/extract dispatcher rejects URL sources directly (see main.py
+    // _resolve_extract_path: 'URL sources go through /api/extract-url.').
+    if (resolvedSource && resolvedSource.type === "url" && !resolvedSource.text) {
+      try {
+        const { extractUrl } = await import("./api-client.js");
+        const fetched = await extractUrl({ url: resolvedSource.url });
+        // /api/extract-url returns {text, title, url} per source_intake.
+        resolvedSource = {
+          type: "text",
+          text: String(fetched.text || ""),
+          // Keep the original URL on the client for telemetry / display only.
+          // Backend payload uses type: "text" so the dispatcher takes the
+          // existing extract_knowledge_map path on this submit.
+        };
+      } catch (err) {
+        state.submitting = false;
+        showSubmitError(
+          "source",
+          err && err.message ? err.message : "Couldn't fetch that URL."
+        );
+        return;
+      }
+    }
+
+    try {
+      const { submitConceptCreate } = await import("./ai_service.js");
+      const apiKey =
+        (typeof localStorage !== "undefined" && localStorage.getItem("gemini_key")) ||
+        undefined;
+      const data = await submitConceptCreate({
+        name: concept,
+        startingSketch: sketch,
+        source: resolvedSource,
+        apiKey,
+      });
+      state.submitting = false;
+      // Hand off to the caller; one of provisional_map / knowledge_map is set.
+      onSubmit?.({
+        name: concept,
+        startingSketch: sketch,
+        source: resolvedSource,
+        provisionalMap: data.provisional_map || data.knowledge_map || null,
+      });
+    } catch (err) {
+      state.submitting = false;
+      if (err && err.status === 422 && err.body) {
+        const code = err.body.error;
+        const message = err.body.message || "Submission rejected.";
+        if (code === "missing_concept") {
+          showSubmitError("concept", message);
+          return;
+        }
+        if (code === "thin_sketch_no_source") {
+          showSubmitError("sketch", message);
+          return;
+        }
+      }
+      showSubmitError(
+        "submit",
+        (err && err.message) || "Couldn't submit. Try again."
+      );
+    }
+  }
+
+  function showSubmitError(target, message) {
+    rerenderSummary();
+    if (target === "concept") {
+      const valueEl = container.querySelector('[data-role="concept-value"]');
+      if (valueEl) {
+        valueEl.insertAdjacentHTML(
+          "afterend",
+          `<p class="creation-chip-footer">${escHtml(message)}</p>`
+        );
+      }
+      return;
+    }
+    if (target === "sketch") {
+      const sketchChip = container.querySelector('[data-chip="sketch"]');
+      if (!sketchChip) return;
+      const existing = sketchChip.querySelector(".creation-chip-footer");
+      if (existing) existing.textContent = message;
+      else
+        sketchChip.insertAdjacentHTML(
+          "beforeend",
+          `<p class="creation-chip-footer">${escHtml(message)}</p>`
+        );
+      return;
+    }
+    if (target === "source") {
+      const sourceChip = container.querySelector('[data-chip="source"]');
+      if (!sourceChip) return;
+      sourceChip.insertAdjacentHTML(
+        "beforeend",
+        `<p class="creation-chip-footer">${escHtml(message)}</p>`
+      );
+      return;
+    }
+    // Generic fallback: append a banner below the summary.
+    const summary = container.querySelector(".creation-summary");
+    if (!summary) return;
+    summary.insertAdjacentHTML(
+      "beforeend",
+      `<p class="creation-chip-footer">${escHtml(message)}</p>`
+    );
   }
 
   function rerenderSummary() {

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -1,0 +1,67 @@
+// public/js/concept-create.js
+//
+// Conversational concept creation — Stage A (chat) → Stage B (summary card).
+// Replaces the form-based showNameField branch of buildContentInputUI.
+// Spec: docs/superpowers/specs/2026-05-02-conversational-concept-creation-design.md
+// Plan: docs/superpowers/plans/2026-05-04-conversational-concept-creation-frontend.md
+//
+// Public API: buildConversationalCreateUI(container, { onSubmit, onCancel }).
+// Returns { destroy() } so callers can clean up on dialog close.
+//
+// This module owns ZERO graph rendering and ZERO API key reading. It receives
+// onSubmit({ name, startingSketch, source }) and the caller posts to the
+// backend — same separation of concerns the form-based flow used.
+
+import { isSubstantiveSketch } from "./sketch-validation.js";
+import { emitTelemetry } from "./telemetry.js";
+
+const STAGE = Object.freeze({
+  CHAT_TURN_1: "chat:turn-1",
+  CHAT_TURN_2: "chat:turn-2",
+  CHAT_FALLBACK: "chat:fallback",
+  SUMMARY: "summary",
+});
+
+// Hardcoded chat copy for v1. The shape is locked by the spec; the literal
+// strings derive verbatim from the threshold-chat system prompt example
+// (app_prompts/threshold-chat-system-v1.txt) so no voice drift can sneak in
+// while the frontend still hardcodes them. A future plan wires these to a
+// /api/threshold-chat-turn endpoint and removes the hardcode.
+const CHAT_COPY = Object.freeze({
+  TURN_1: "What do you want to understand?",
+  TURN_2: "Sketch what you think it does — rough is fine. What parts come to mind?",
+  // The fallback is generic-but-honest for v1: "inputs and outputs" is the
+  // input-output frame most causal concepts share, derived in spirit from the
+  // spec's analogical-fallback rule. Concept-derived analogy generation is a
+  // documented Plan B follow-up — see plan §"Out of scope".
+  FALLBACK:
+    "Try this: think of something familiar that takes inputs and produces outputs. " +
+    "What inputs does this concept take, and what does it produce?",
+});
+
+const FOOTER_DEFAULT = "Study content stays locked until the cold attempt.";
+const SKETCH_FOOTER_BLOCKED =
+  "A few words about how you think it works will give socratink something to draft from. " +
+  "Or attach source material — either path opens the build.";
+
+export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
+  const state = {
+    stage: STAGE.CHAT_TURN_1,
+    concept: "",
+    sketchTurns: [],          // verbatim learner replies; concatenated into chip value
+    source: null,              // { type, text?, url?, filename? } once attached
+    usedFallback: false,
+    submitting: false,
+  };
+
+  function destroy() {
+    container.innerHTML = "";
+  }
+
+  // Subsequent tasks fill in renderChat / renderSummary / submit logic and
+  // call them from here. For now, stub with a placeholder so the module is
+  // importable without errors.
+  container.innerHTML = "";
+
+  return { destroy };
+}

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -37,7 +37,6 @@ const CHAT_COPY = Object.freeze({
     "Try this: give one example. Anywhere this concept shows up in something you've read or experienced — a small detail will do.",
 });
 
-const FOOTER_DEFAULT = "Study content stays locked until the cold attempt.";
 const SKETCH_FOOTER_BLOCKED =
   "A few words about how you think it works will give socratink something to draft from. " +
   "Or attach source material — either path opens the build.";
@@ -64,6 +63,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     usedFallback: false,
     submitting: false,
     ctaOverride: (seed && typeof seed.ctaOverrideCopy === "string") ? seed.ctaOverrideCopy : null,
+    summaryShownEmitted: false,      // gates concept_create.summary.shown to fire once per arrival
   };
 
   function destroy() {
@@ -140,7 +140,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     });
 
     cancelBtn.addEventListener("click", () => onCancel?.());
-    submitBtn.addEventListener("mousedown", (e) => {
+    submitBtn.addEventListener("click", (e) => {
       e.preventDefault();
       if (submitBtn.disabled) return;
       submitChatTurn(composer.value.trim());
@@ -243,6 +243,8 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
   function sourceChipDescriptor() {
     if (!state.source) return null;
     if (state.source.type === "url") {
+      // TODO(v2): URL descriptor renders "0 chars from a URL" before the
+      // URL hop materialises text. Show the URL itself or "fetching..." here.
       const len = (state.source.text || "").length.toLocaleString();
       return `${len} chars from a URL`;
     }
@@ -321,7 +323,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     // Wire cancel + submit (the chip edit + source actions land in Tasks 7-8).
     container.querySelector(".creation-cancel").addEventListener("click", () => onCancel?.());
     const submitBtn = container.querySelector(".creation-submit");
-    submitBtn.addEventListener("mousedown", (e) => {
+    submitBtn.addEventListener("click", (e) => {
       e.preventDefault();
       if (submitBtn.disabled) {
         const reason = !state.concept.trim()
@@ -333,11 +335,14 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
       doSubmit();
     });
 
-    emitTelemetry("concept_create.summary.shown", {
-      has_concept: Boolean(concept),
-      has_sketch: Boolean(sketch),
-      sketch_len: sketch.length,
-    });
+    if (!state.summaryShownEmitted) {
+      emitTelemetry("concept_create.summary.shown", {
+        has_concept: Boolean(concept),
+        has_sketch: Boolean(sketch),
+        sketch_len: sketch.length,
+      });
+      state.summaryShownEmitted = true;
+    }
 
     attachChipEditHandlers();
     attachSourceChipHandlers();
@@ -690,7 +695,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
 
     cancelBtn.addEventListener("click", () => rerenderSummary());
 
-    attachBtn.addEventListener("mousedown", (e) => {
+    attachBtn.addEventListener("click", (e) => {
       e.preventDefault();
       if (attachBtn.disabled) return;
       if (activeTab === "paste") {

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -44,12 +44,18 @@ const SKETCH_FOOTER_BLOCKED =
   "A few words about how you think it works will give socratink something to draft from. " +
   "Or attach source material — either path opens the build.";
 
-export function buildConversationalCreateUI(container, { onSubmit, onCancel, onBeforeSubmit, onSubmitError }) {
+export function buildConversationalCreateUI(container, { onSubmit, onCancel, onBeforeSubmit, onSubmitError, seed }) {
+  const initialName = (seed && typeof seed.name === "string" ? seed.name.trim() : "");
+  const initialSource = seed && seed.source ? seed.source : null;
+  // If we have a name, skip turn 1 (the hero already captured the answer).
+  // If we have only source, start at turn 1 (concept name still needed).
+  const initialStage = initialName ? STAGE.CHAT_TURN_2 : STAGE.CHAT_TURN_1;
+
   const state = {
-    stage: STAGE.CHAT_TURN_1,
-    concept: "",
+    stage: initialStage,
+    concept: initialName,
     sketchTurns: [],          // verbatim learner replies; concatenated into chip value
-    source: null,              // { type, text?, url?, filename? } once attached
+    source: initialSource,    // { type, text?, url?, filename? } once attached
     usedFallback: false,
     submitting: false,
   };
@@ -150,6 +156,15 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
         reply_len: reply.length,
         used_fallback: false,
       });
+      // If a passage was pre-attached as source via the hero input, the
+      // source is the seed — skip turn 2 (sketch optional) and exit to
+      // the summary card directly. The learner can still edit the sketch
+      // chip later if they want.
+      if (state.source) {
+        state.stage = STAGE.SUMMARY;
+        renderSummary();
+        return;
+      }
       state.stage = STAGE.CHAT_TURN_2;
       renderChat();
       return;

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -58,10 +58,143 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel }) {
     container.innerHTML = "";
   }
 
-  // Subsequent tasks fill in renderChat / renderSummary / submit logic and
-  // call them from here. For now, stub with a placeholder so the module is
-  // importable without errors.
-  container.innerHTML = "";
+  // Helper: minimal escape for inline text (we only inject sanitized strings,
+  // but defensive-by-default — these never escape into innerHTML untrusted).
+  function escHtml(s) {
+    return String(s ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function questionForStage(stage) {
+    if (stage === STAGE.CHAT_TURN_1) return CHAT_COPY.TURN_1;
+    if (stage === STAGE.CHAT_TURN_2) return CHAT_COPY.TURN_2;
+    if (stage === STAGE.CHAT_FALLBACK) return CHAT_COPY.FALLBACK;
+    return "";
+  }
+
+  function turnNumberForStage(stage) {
+    if (stage === STAGE.CHAT_TURN_1) return 1;
+    if (stage === STAGE.CHAT_TURN_2) return 2;
+    if (stage === STAGE.CHAT_FALLBACK) return "fallback";
+    return null;
+  }
+
+  function renderChat() {
+    const turn = turnNumberForStage(state.stage);
+    const question = questionForStage(state.stage);
+    const hasPrior = state.sketchTurns.length > 0 || state.concept !== "";
+
+    container.innerHTML = `
+      <div class="creation-chat" data-stage="${escHtml(state.stage)}">
+        <p class="creation-chat-question" id="creation-chat-question">${escHtml(question)}</p>
+        <textarea
+          class="creation-chat-composer"
+          id="creation-chat-composer"
+          aria-labelledby="creation-chat-question"
+          maxlength="2000"
+          rows="3"
+          placeholder=""></textarea>
+        <div class="creation-footer">
+          <button class="creation-cancel" type="button">Cancel</button>
+          <button class="creation-submit" type="button" disabled>Continue</button>
+        </div>
+      </div>
+    `;
+
+    const composer = container.querySelector(".creation-chat-composer");
+    const cancelBtn = container.querySelector(".creation-cancel");
+    const submitBtn = container.querySelector(".creation-submit");
+
+    composer.focus();
+    composer.addEventListener("input", () => {
+      submitBtn.disabled = composer.value.trim().length === 0;
+    });
+    composer.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !submitBtn.disabled) {
+        e.preventDefault();
+        submitChatTurn(composer.value.trim());
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel?.();
+      }
+    });
+
+    cancelBtn.addEventListener("click", () => onCancel?.());
+    submitBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      if (submitBtn.disabled) return;
+      submitChatTurn(composer.value.trim());
+    });
+
+    emitTelemetry("concept_create.chat.turn_started", {
+      turn,
+      has_prior_reply: hasPrior,
+    });
+  }
+
+  function submitChatTurn(reply) {
+    if (!reply) return;
+    const turn = turnNumberForStage(state.stage);
+
+    if (state.stage === STAGE.CHAT_TURN_1) {
+      // Turn 1 reply is the concept name (verbatim for v1; canonicalisation
+      // is a documented follow-up). The learner can edit the chip later.
+      state.concept = reply;
+      emitTelemetry("concept_create.chat.turn_replied", {
+        turn,
+        reply_len: reply.length,
+        used_fallback: false,
+      });
+      state.stage = STAGE.CHAT_TURN_2;
+      renderChat();
+      return;
+    }
+
+    if (state.stage === STAGE.CHAT_TURN_2) {
+      state.sketchTurns.push(reply);
+      const isThin = !isSubstantiveSketch(reply);
+      emitTelemetry("concept_create.chat.turn_replied", {
+        turn,
+        reply_len: reply.length,
+        used_fallback: false,
+      });
+      if (isThin) {
+        state.stage = STAGE.CHAT_FALLBACK;
+        state.usedFallback = true;
+        renderChat();
+        return;
+      }
+      state.stage = STAGE.SUMMARY;
+      renderSummary();
+      return;
+    }
+
+    if (state.stage === STAGE.CHAT_FALLBACK) {
+      state.sketchTurns.push(reply);
+      emitTelemetry("concept_create.chat.turn_replied", {
+        turn,
+        reply_len: reply.length,
+        used_fallback: true,
+      });
+      state.stage = STAGE.SUMMARY;
+      renderSummary();
+      return;
+    }
+  }
+
+  // Placeholder until Task 5 ships the real summary renderer.
+  function renderSummary() {
+    container.innerHTML =
+      '<div class="creation-summary"><p>Summary card pending (Task 5).</p></div>';
+  }
+
+  // Boot the first chat turn.
+  renderChat();
 
   return { destroy };
 }

--- a/public/js/concept-create.js
+++ b/public/js/concept-create.js
@@ -366,6 +366,11 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     // onBeforeSubmit is omitted, overlayHandle is undefined — callers that omit
     // it must not expect overlay teardown from the network-error path.
     const overlayHandle = onBeforeSubmit?.({ name: concept });
+    if (overlayHandle === null) {
+      // Caller rejected the submit (e.g., library at cap). Don't proceed.
+      state.submitting = false;
+      return;
+    }
 
     let resolvedSource = state.source;
 
@@ -502,7 +507,10 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     input.focus();
     input.select();
 
+    let saved = false;
     function save() {
+      if (saved) return;
+      saved = true;
       const next = input.value.trim();
       if (next !== prior) {
         state.concept = next;
@@ -511,6 +519,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
       rerenderSummary();
     }
     function cancel() {
+      saved = true;  // suppress save on the imminent blur
       rerenderSummary();
     }
     input.addEventListener("blur", save);
@@ -544,7 +553,10 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
     textarea.focus();
     textarea.setSelectionRange(textarea.value.length, textarea.value.length);
 
+    let saved = false;
     function save() {
+      if (saved) return;
+      saved = true;
       const next = textarea.value;
       if (next !== prior) {
         // Replace all sketchTurns with the edited value as a single turn.
@@ -555,6 +567,7 @@ export function buildConversationalCreateUI(container, { onSubmit, onCancel, onB
       rerenderSummary();
     }
     function cancel() {
+      saved = true;  // suppress save on the imminent blur
       rerenderSummary();
     }
     textarea.addEventListener("blur", save);

--- a/public/js/sketch-validation.js
+++ b/public/js/sketch-validation.js
@@ -1,0 +1,73 @@
+// public/js/sketch-validation.js
+//
+// Substantiveness heuristic — JS port of models/sketch_validation.py.
+// Verified against tests/fixtures/sketch_validation_parity.json by
+// tests/test_frontend_sketch_validation.py. A divergence is a
+// release-blocker per spec §5.3.
+//
+// Why /u everywhere: Python's \w is Unicode by default; JS's is ASCII-only.
+// Without /u, the same input ("café résumé naïve …") would tokenize differently
+// in the two languages and the parity fixture's unicode rows would silently
+// fail. See models/sketch_validation.py "JS PORT NOTE" docstring.
+
+export const MIN_SUBSTANTIVE_TOKENS = 8;
+
+const DONT_KNOW_PATTERNS = [
+  "idk",
+  "i dont know",
+  "i don't know",
+  "no idea",
+  "no clue",
+  "dunno",
+  "not sure",
+];
+
+const STOPWORDS = new Set(
+  (
+    "a an the and or but if of for in on at to from by with as is are was were " +
+    "be been being do does did has have had this that these those it its"
+  ).split(/\s+/)
+);
+
+const PUNCT_RE = /[^\p{L}\p{N}_\s]/gu;
+const WHITESPACE_RE = /\s+/gu;
+const REPEATED_CHAR_RE = /^(.)\1{4,}$/u;
+
+function normalize(text) {
+  let t = text.trim().toLowerCase();
+  t = t.replace(PUNCT_RE, " ");
+  t = t.replace(WHITESPACE_RE, " ");
+  return t.trim();
+}
+
+function isDontKnow(normalized) {
+  if (!normalized) return true;
+  if (REPEATED_CHAR_RE.test(normalized)) return true;
+  for (const pattern of DONT_KNOW_PATTERNS) {
+    if (normalized === pattern) return true;
+    if (normalized.startsWith(pattern + " ")) {
+      const extra = normalized.slice(pattern.length + 1).split(/\s+/u).filter(Boolean);
+      if (extra.length <= 3) return true;
+    }
+  }
+  return false;
+}
+
+function countSubstantiveTokens(normalized) {
+  const tokens = normalized.split(/\s+/u).filter((t) => t && t.length >= 2);
+  let count = 0;
+  for (const t of tokens) {
+    if (!STOPWORDS.has(t)) count += 1;
+  }
+  return count;
+}
+
+export function isSubstantiveSketch(text) {
+  if (text === null || text === undefined) return false;
+  if (typeof text !== "string") return false;
+  const normalized = normalize(text);
+  if (!normalized) return false;
+  if (isDontKnow(normalized)) return false;
+  if (countSubstantiveTokens(normalized) < MIN_SUBSTANTIVE_TOKENS) return false;
+  return true;
+}

--- a/public/js/telemetry.js
+++ b/public/js/telemetry.js
@@ -1,0 +1,28 @@
+// public/js/telemetry.js
+//
+// Frontend telemetry emit point for the conversational concept-creation flow.
+// Spec §5.4 lists the events. The events are observable in three places:
+//
+//   1. Browser console (`console.info('telemetry', { event, ...extra })`)
+//   2. Bus listeners (`Bus.on('telemetry', fn)`) — for in-app debug overlays
+//   3. Future: a /api/telemetry endpoint. Not wired in v1 — the helper takes
+//      one shape so adding the network post is a one-line change later.
+//
+// Server-side telemetry (concept_create.lc.queried, .build_blocked, .ai_call,
+// etc.) flows through Python's structured logger from main.py — that path is
+// already shipped in Plan A. Client events use `origin: 'client'` so the
+// dashboards can detect client/server validation drift.
+
+import { Bus } from "./bus.js";
+
+export function emitTelemetry(event, extra = {}) {
+  if (typeof event !== "string" || !event) return;
+  const payload = { event, ...extra };
+  try {
+    Bus.emit("telemetry", payload);
+  } catch (err) {
+    /* Bus is best-effort. Never let telemetry break the UI. */
+  }
+  // eslint-disable-next-line no-console
+  console.info("telemetry", payload);
+}

--- a/tests/_helpers/run_sketch_parity.mjs
+++ b/tests/_helpers/run_sketch_parity.mjs
@@ -1,0 +1,22 @@
+// tests/_helpers/run_sketch_parity.mjs
+// Loads the shared parity fixture, runs the JS implementation, prints JSON rows.
+// No deps — uses Node's built-in fs and URL handling.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { isSubstantiveSketch } from "../../public/js/sketch-validation.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(__dirname, "..", "fixtures", "sketch_validation_parity.json");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+const rows = fixture.entries.map((entry, idx) => ({
+  idx,
+  text: entry.text,
+  expected: entry.expected_substantive,
+  actual: isSubstantiveSketch(entry.text),
+}));
+
+process.stdout.write(JSON.stringify(rows));

--- a/tests/test_frontend_sketch_validation.py
+++ b/tests/test_frontend_sketch_validation.py
@@ -1,0 +1,49 @@
+"""JS parity test for is_substantive_sketch.
+
+Loads the shared fixture (used by both Python tests and this JS harness),
+shells out to a small node runner, and asserts byte-for-byte verdict parity.
+A divergence is a release-blocker per spec §5.3 / handoff §2.
+
+Skipped when `node` is unavailable (mirrors tests/test_frontend_syntax.py).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "sketch_validation_parity.json"
+RUNNER = REPO_ROOT / "tests" / "_helpers" / "run_sketch_parity.mjs"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_js_sketch_validation_matches_python_for_every_fixture_entry() -> None:
+    assert FIXTURE.exists(), f"fixture missing: {FIXTURE}"
+    assert RUNNER.exists(), f"node runner missing: {RUNNER}"
+
+    result = subprocess.run(
+        ["node", str(RUNNER)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"node runner failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    rows = json.loads(result.stdout)
+    assert isinstance(rows, list) and rows, "runner produced no rows"
+
+    mismatches = [r for r in rows if r["expected"] != r["actual"]]
+    if mismatches:
+        msg = "\n".join(
+            f"  idx={r['idx']} text={r['text']!r} expected={r['expected']} actual={r['actual']}"
+            for r in mismatches
+        )
+        pytest.fail(
+            f"JS sketch_validation diverges from Python on {len(mismatches)}/{len(rows)} entries:\n{msg}"
+        )


### PR DESCRIPTION
## Summary

Replaces the form-based concept-creation modal with a 2-turn conversational chat → summary-card flow. Wires to the source-optional Plan A backend (already on dev). Adds calm-aligned design polish across the threshold capture surface and recovery paths.

**Foundational principle this branch enforces** (saved to memory `feedback_screen_foundation_principles.md`): every screen must (1) preserve the learner's effort, (2) tell the truth about evidence, (3) ask for the minimum next reconstruction needed.

## What ships
- New conversational threshold capture: 2-turn chat (turn 1 captures concept, turn 2 captures sketch) with optional analogical fallback
- Summary card with 3 chips (concept / sketch / source-material) and a state-dependent CTA truth table
- JS port of `is_substantive_sketch` with 28+ entry parity fixture (release-blocker contract with the Python backend)
- Recovery hatch on submit failure: dialog re-mounts at summary stage with chips preserved + truthful banner copy + `Try again` CTA
- Source-less honesty copy: source chip empty state names the hypothesis trade-off
- Hero refactor: dropped attach-file button, dropped invisible dual-mode classification, added curated example chips, removed reassure line, vertical-centered on tall desktops, textarea ambient bloom, chip hover micro-lift
- Particle-field constellation feathers via CSS mask-image (no more hard horizon)
- Dark-mode sidebar: neutral graphite (was lavender-tinted)
- Low-density calibration line on sparse provisional graphs
- Concept anchor on chat surface (`CONCEPT · entropy` lavender eyebrow)
- Universal fallback copy ("Try this: give one example…") replacing hardcoded I/O framing
- Extract overlay mounts BEFORE the `/api/extract` network call (Option A) — covers the 5-15s wait with branded thinking state instead of silent dialog
- Pre-network library-capacity check (no LLM cost when at cap)
- Keyboard activation on Submit/Build/Attach (was mousedown-only)
- Telemetry: `concept_create.*` events per spec §5.4 (chat turns, summary shown/edited, source added, build clicked/blocked/failed)

## Backend
Untouched on this branch. Plan A already on dev at `086e617`.

## Test plan
- [x] 522/522 backend suite passes (`pytest tests/ --ignore=tests/e2e -q`)
- [x] 16/16 frontend module-syntax tests pass
- [x] JS sketch-validation parity test passes (28+ unicode entries vs Python source)
- [x] No-mistakes gate cycle: 4 rounds, final risk = low
- [x] CodeRabbit review: 5 actionable + 3 nitpicks reviewed; 6 fixes shipped, 1 skipped (legacy code outside scope), 1 verified-already-correct
- [x] Banned-pattern sweep clean (no emoji, exclamation marks, gradient text, side-stripe borders, glassmorphism)
- [x] Visual smoke walked in playwright at 1440×900: empty hero, filled hero, recovery banner, vertical centering, textarea bloom, chip lift

## Findings logged for follow-up
- URL chip "0 chars from a URL" pre-fetch descriptor (TODO comment in code)
- URL re-fetch on retry (extra network call, not user-visible)
- Console-noisy telemetry helper (currently per-emit `console.info` — fine for v1, gate behind env later)
- Fetch-failure classification could be sharper

## Plan C / future
- Reconcile DESIGN.md §3 Screen 1 to reflect conversational threshold capture
- Real `/api/threshold-chat-turn` endpoint (chat copy currently hardcoded mirror of `app_prompts/threshold-chat-system-v1.txt`)
- Concept-derived analogy generation (currently universal "give one example" fallback)
- Frontend telemetry network post (currently `console.info` + `Bus.emit` only)