### PR TITLE
fix: improve ig-highlight contrast in light mode

### DIFF
--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -192,3 +192,449 @@ body.antigravity-theme .ignition-view__inner {
   z-index: 1;
   margin: auto 0;
 }
+
+/* ══════════════════════════════════════════════════════════════
+   ANTIGRAVITY — Ignition View Enhanced Aesthetics
+   Additive layer; does not remove any existing functionality.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Background: layered depth with animated aurora bloom ──── */
+body.antigravity-theme #ignition-view {
+  background-color: #F2F0F5;
+  background-image:
+    radial-gradient(ellipse 72% 56% at 50% 28%, rgba(144, 103, 198, 0.10) 0%, transparent 68%),
+    radial-gradient(ellipse 44% 36% at 20% 80%, rgba(141, 134, 201, 0.07) 0%, transparent 60%),
+    radial-gradient(ellipse 40% 32% at 82% 72%, rgba(77, 186, 138, 0.05) 0%, transparent 56%);
+  animation: ag-bg-breathe 12s ease-in-out infinite alternate;
+}
+
+@keyframes ag-bg-breathe {
+  0%   { background-size: 100% 100%, 100% 100%, 100% 100%; }
+  100% { background-size: 110% 110%, 105% 105%, 108% 108%; }
+}
+
+html[data-theme="dark"] body.antigravity-theme #ignition-view {
+  background-color: #18181b;
+  background-image:
+    radial-gradient(ellipse 70% 54% at 50% 26%, rgba(158, 139, 255, 0.12) 0%, transparent 68%),
+    radial-gradient(ellipse 42% 34% at 18% 78%, rgba(141, 134, 201, 0.09) 0%, transparent 60%),
+    radial-gradient(ellipse 38% 30% at 84% 74%, rgba(60, 221, 199, 0.07) 0%, transparent 56%);
+}
+
+/* ── Ignition title: larger, tighter, more expressive ──────── */
+body.antigravity-theme .ignition-title {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: clamp(2.2rem, 4vw + 1rem, 3.6rem);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+  color: var(--text-main);
+  text-wrap: balance;
+  text-shadow:
+    0 2px 0 rgba(255,255,255,0.60),
+    0 6px 32px rgba(144, 103, 198, 0.13);
+  position: relative;
+}
+
+html[data-theme="dark"] body.antigravity-theme .ignition-title {
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.06),
+    0 6px 32px rgba(158, 139, 255, 0.22);
+}
+
+/* Title: animated gradient shimmer on the key word */
+body.antigravity-theme .ignition-title .ig-highlight {
+  background: linear-gradient(
+    135deg,
+    var(--accent-color) 0%,
+    var(--accent-mint) 52%,
+    var(--accent-color) 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: ag-title-shimmer 4s ease-in-out infinite;
+  display: inline;
+}
+
+@keyframes ag-title-shimmer {
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+html[data-motion="reduced"] body.antigravity-theme .ignition-title .ig-highlight,
+html[data-motion="reduced"] body.antigravity-theme #ignition-view {
+  animation: none !important;
+}
+
+/* ── Eyebrow: badge-style treatment ─────────────────────────── */
+body.antigravity-theme .ignition-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  background: rgba(144, 103, 198, 0.10);
+  border: 1px solid rgba(144, 103, 198, 0.22);
+  color: var(--accent-color);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 20px;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+body.antigravity-theme .ignition-eyebrow::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-color);
+  box-shadow: 0 0 6px var(--accent-color);
+  flex-shrink: 0;
+  animation: ag-dot-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes ag-dot-pulse {
+  0%, 100% { opacity: 1;   transform: scale(1); }
+  50%       { opacity: 0.5; transform: scale(0.7); }
+}
+
+html[data-theme="dark"] body.antigravity-theme .ignition-eyebrow {
+  background: rgba(158, 139, 255, 0.12);
+  border-color: rgba(158, 139, 255, 0.24);
+}
+
+/* ── Ignition inner: tighter vertical rhythm ─────────────────── */
+body.antigravity-theme .ignition-view__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0;
+  padding: clamp(20px, 4vh, 52px) clamp(20px, 5vw, 64px);
+  max-width: 720px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Hero form: premium glassmorphism card ───────────────────── */
+body.antigravity-theme .hero-single-input {
+  background: rgba(255, 255, 255, 0.56) !important;
+  backdrop-filter: blur(20px) saturate(160%) !important;
+  -webkit-backdrop-filter: blur(20px) saturate(160%) !important;
+  border: 1px solid rgba(255, 255, 255, 0.72) !important;
+  border-radius: 28px !important;
+  box-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.85) inset,
+    0 -1px 0 rgba(144, 103, 198, 0.08) inset,
+    0 20px 60px rgba(144, 103, 198, 0.12),
+    0 6px 18px rgba(36, 32, 56, 0.07) !important;
+  padding: 28px 28px 22px !important;
+  transition:
+    transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    box-shadow 0.4s ease,
+    border-color 0.3s ease !important;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Glass sheen sweep */
+body.antigravity-theme .hero-single-input::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.28) 0%,
+    rgba(255, 255, 255, 0.0) 60%
+  );
+  pointer-events: none;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+body.antigravity-theme .hero-single-input:focus-within {
+  transform: translateY(-5px) !important;
+  border-color: rgba(144, 103, 198, 0.36) !important;
+  box-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.85) inset,
+    0 -1px 0 rgba(144, 103, 198, 0.12) inset,
+    0 28px 72px rgba(144, 103, 198, 0.20),
+    0 8px 24px rgba(36, 32, 56, 0.10),
+    0 0 0 1.5px rgba(144, 103, 198, 0.28) !important;
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-single-input {
+  background: rgba(30, 28, 40, 0.62) !important;
+  border-color: rgba(158, 139, 255, 0.14) !important;
+  box-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.06) inset,
+    0 20px 60px rgba(0, 0, 0, 0.32),
+    0 6px 18px rgba(0, 0, 0, 0.22) !important;
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-single-input:focus-within {
+  border-color: rgba(158, 139, 255, 0.30) !important;
+  box-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.06) inset,
+    0 28px 72px rgba(0, 0, 0, 0.44),
+    0 0 0 1.5px rgba(158, 139, 255, 0.26) !important;
+}
+
+/* ── Textarea field: refined ─────────────────────────────────── */
+body.antigravity-theme .hero-single-input__field {
+  background: rgba(255, 255, 255, 0.62) !important;
+  border-color: rgba(144, 103, 198, 0.16) !important;
+  border-radius: 16px !important;
+  font-size: 17px !important;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: #242038;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.80) inset,
+    0 2px 8px rgba(36, 32, 56, 0.04) !important;
+  padding: 14px 16px !important;
+  position: relative;
+  z-index: 1;
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-single-input__field {
+  background: rgba(255, 255, 255, 0.05) !important;
+  border-color: rgba(158, 139, 255, 0.16) !important;
+  color: #FFFFFF !important;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.06) inset,
+    0 2px 8px rgba(0, 0, 0, 0.16) !important;
+}
+
+body.antigravity-theme .hero-single-input__field::placeholder {
+  color: rgba(36, 32, 56, 0.38) !important;
+}
+html[data-theme="dark"] body.antigravity-theme .hero-single-input__field::placeholder {
+  color: rgba(255, 255, 255, 0.28) !important;
+}
+
+/* ── Submit button: elevated gradient pill ───────────────────── */
+body.antigravity-theme .hero-single-input__submit {
+  background: linear-gradient(
+    135deg,
+    var(--accent-color) 0%,
+    #7a59aa 48%,
+    var(--accent-mint) 100%
+  ) !important;
+  background-size: 200% 100% !important;
+  border: none !important;
+  border-radius: 16px !important;
+  color: #FFFFFF !important;
+  font-weight: 700;
+  min-height: 48px !important;
+  padding: 12px 22px 12px 26px !important;
+  box-shadow:
+    0 10px 28px rgba(144, 103, 198, 0.32),
+    0 3px 10px rgba(36, 32, 56, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28) !important;
+  transition:
+    transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    box-shadow 0.3s ease,
+    background-position 0.4s ease !important;
+  position: relative;
+  z-index: 1;
+}
+
+body.antigravity-theme .hero-single-input__submit:hover:not(:disabled) {
+  transform: translateY(-3px) !important;
+  background-position: 100% 0 !important;
+  box-shadow:
+    0 16px 36px rgba(144, 103, 198, 0.42),
+    0 6px 16px rgba(36, 32, 56, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.36) !important;
+}
+
+body.antigravity-theme .hero-single-input__submit:active:not(:disabled) {
+  transform: translateY(-1px) scale(0.98) !important;
+}
+
+body.antigravity-theme .hero-single-input__submit:disabled {
+  background: rgba(36, 32, 56, 0.07) !important;
+  color: rgba(36, 32, 56, 0.30) !important;
+  box-shadow: none !important;
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-single-input__submit:disabled {
+  background: rgba(255, 255, 255, 0.08) !important;
+  color: rgba(255, 255, 255, 0.28) !important;
+  box-shadow: none !important;
+}
+
+/* ── Submit icon circle ──────────────────────────────────────── */
+body.antigravity-theme .hero-single-input__submit-icon {
+  background: rgba(255, 255, 255, 0.22) !important;
+  border-radius: 50% !important;
+}
+
+/* ── Source attach button ─────────────────────────────────────── */
+body.antigravity-theme .hero-source-attach {
+  align-self: flex-start;
+  color: var(--accent-color) !important;
+  background: rgba(144, 103, 198, 0.08) !important;
+  border: 1px solid rgba(144, 103, 198, 0.18) !important;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  transition: background 0.2s, border-color 0.2s, transform 0.2s;
+  min-height: unset;
+  width: auto;
+  flex: none;
+  box-shadow: none !important;
+  position: relative;
+  z-index: 1;
+}
+
+body.antigravity-theme .hero-source-attach:hover {
+  background: rgba(144, 103, 198, 0.14) !important;
+  border-color: rgba(144, 103, 198, 0.30) !important;
+  transform: translateY(-1px);
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-source-attach {
+  color: rgba(158, 139, 255, 0.88) !important;
+  background: rgba(158, 139, 255, 0.10) !important;
+  border-color: rgba(158, 139, 255, 0.20) !important;
+}
+
+/* ── Floating orb: ambient glow nodes around the form ────────── */
+body.antigravity-theme #ignition-view::before,
+body.antigravity-theme #ignition-view::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+body.antigravity-theme #ignition-view::before {
+  width: 480px;
+  height: 480px;
+  top: -80px;
+  left: -120px;
+  background: radial-gradient(circle, rgba(144, 103, 198, 0.08) 0%, transparent 68%);
+  filter: blur(32px);
+  animation: ag-orb-drift-a 16s ease-in-out infinite alternate;
+}
+
+body.antigravity-theme #ignition-view::after {
+  width: 360px;
+  height: 360px;
+  bottom: -60px;
+  right: -80px;
+  background: radial-gradient(circle, rgba(77, 186, 138, 0.07) 0%, transparent 64%);
+  filter: blur(28px);
+  animation: ag-orb-drift-b 18s ease-in-out infinite alternate;
+}
+
+html[data-theme="dark"] body.antigravity-theme #ignition-view::before {
+  background: radial-gradient(circle, rgba(158, 139, 255, 0.10) 0%, transparent 68%);
+}
+html[data-theme="dark"] body.antigravity-theme #ignition-view::after {
+  background: radial-gradient(circle, rgba(60, 221, 199, 0.08) 0%, transparent 64%);
+}
+
+@keyframes ag-orb-drift-a {
+  0%   { transform: translate(0,   0)   scale(1); }
+  100% { transform: translate(60px, 40px) scale(1.12); }
+}
+@keyframes ag-orb-drift-b {
+  0%   { transform: translate(0,   0)   scale(1); }
+  100% { transform: translate(-50px, -30px) scale(1.08); }
+}
+
+html[data-motion="reduced"] body.antigravity-theme #ignition-view::before,
+html[data-motion="reduced"] body.antigravity-theme #ignition-view::after,
+html[data-motion="reduced"] body.antigravity-theme #ignition-view {
+  animation: none !important;
+}
+
+/* ── Cap gate: styled ─────────────────────────────────────────── */
+body.antigravity-theme .ignition-cap-gate {
+  background: rgba(255, 255, 255, 0.50);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(144, 103, 198, 0.18);
+  border-radius: 18px;
+  padding: 20px 28px;
+  text-align: center;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(144, 103, 198, 0.10);
+}
+
+html[data-theme="dark"] body.antigravity-theme .ignition-cap-gate {
+  background: rgba(30, 28, 40, 0.58);
+  border-color: rgba(158, 139, 255, 0.16);
+}
+
+body.antigravity-theme .ignition-cap-gate__message {
+  color: var(--text-main);
+  font-size: 15px;
+  font-weight: 500;
+  margin-bottom: 14px;
+  opacity: 0.85;
+}
+
+body.antigravity-theme .ignition-cap-gate__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 22px;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-mint));
+  color: #FFFFFF;
+  border: none;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(144, 103, 198, 0.28);
+  transition: transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.25s ease;
+  width: auto;
+  flex: none;
+  min-height: unset;
+}
+
+body.antigravity-theme .ignition-cap-gate__cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(144, 103, 198, 0.38);
+}
+
+/* ── Door error text ────────────────────────────────────────── */
+body.antigravity-theme .hero-door-error {
+  color: var(--danger, #e05c6b) !important;
+  font-size: 13px;
+  font-weight: 500;
+  margin: -4px 0;
+}
+
+/* ── Mobile adjustments ─────────────────────────────────────── */
+@media (max-width: 720px) {
+  body.antigravity-theme .ignition-title {
+    font-size: clamp(1.8rem, 7vw, 2.6rem);
+    letter-spacing: -0.025em;
+  }
+
+  body.antigravity-theme .hero-single-input {
+    border-radius: 22px !important;
+    padding: 20px 18px 16px !important;
+  }
+
+  body.antigravity-theme #ignition-view::before,
+  body.antigravity-theme #ignition-view::after {
+    display: none;
+  }
+}

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -246,9 +246,10 @@ html[data-theme="dark"] body.antigravity-theme .ignition-title {
 body.antigravity-theme .ignition-title .ig-highlight {
   background: linear-gradient(
     135deg,
-    var(--accent-color) 0%,
-    var(--accent-mint) 52%,
-    var(--accent-color) 100%
+    #6b3fa0 0%,
+    #9067c6 42%,
+    #3d7abd 76%,
+    #6b3fa0 100%
   );
   background-size: 200% 100%;
   -webkit-background-clip: text;
@@ -256,6 +257,22 @@ body.antigravity-theme .ignition-title .ig-highlight {
   -webkit-text-fill-color: transparent;
   animation: ag-title-shimmer 4s ease-in-out infinite;
   display: inline;
+  filter: drop-shadow(0 1px 0 rgba(107, 63, 160, 0.18));
+}
+
+html[data-theme="dark"] body.antigravity-theme .ignition-title .ig-highlight {
+  background: linear-gradient(
+    135deg,
+    #c8a8f7 0%,
+    #a97ef4 42%,
+    #7dd4f8 76%,
+    #c8a8f7 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 1px 0 rgba(200, 168, 247, 0.22));
 }
 
 @keyframes ag-title-shimmer {

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -494,7 +494,7 @@ body.antigravity-theme .hero-single-input__submit-icon {
   border-radius: 50% !important;
 }
 
-/* ── Source attach button ─────────────────────────────────────── */
+/* ── Source attach button ──���──────────────────────────────────── */
 body.antigravity-theme .hero-source-attach {
   align-self: flex-start;
   color: var(--accent-color) !important;
@@ -652,6 +652,1223 @@ body.antigravity-theme .hero-door-error {
 
   body.antigravity-theme #ignition-view::before,
   body.antigravity-theme #ignition-view::after {
+    display: none;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANTIGRAVITY — Dashboard / Launch Pad / Library / Settings
+   Additive aesthetic layer. All rules are scoped to
+   body.antigravity-theme so the base app remains intact.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Shared helpers ─────────────────────────────────────────── */
+body.antigravity-theme {
+  --ag-glass-bg: rgba(255, 255, 255, 0.55);
+  --ag-glass-border: rgba(255, 255, 255, 0.70);
+  --ag-glass-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.85) inset,
+    0 18px 50px rgba(36, 32, 56, 0.08),
+    0 4px 14px rgba(36, 32, 56, 0.05);
+  --ag-glass-blur: blur(18px) saturate(160%);
+  --ag-violet: #9067C6;
+  --ag-mint:   #4DBA8A;
+  --ag-ink:    #242038;
+}
+
+html[data-theme="dark"] body.antigravity-theme {
+  --ag-glass-bg: rgba(30, 28, 40, 0.62);
+  --ag-glass-border: rgba(158, 139, 255, 0.16);
+  --ag-glass-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 18px 50px rgba(0, 0, 0, 0.32),
+    0 4px 14px rgba(0, 0, 0, 0.20);
+  --ag-violet: #9E8BFF;
+  --ag-mint:   #3CDDC7;
+  --ag-ink:    #FFFFFF;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   1. DASHBOARD (DESK) — hero card
+   ══════════════════════════════════════════════════════════════ */
+
+body.antigravity-theme .hero-card.intro-page {
+  position: relative;
+  background:
+    radial-gradient(ellipse 60% 48% at 18% 22%, rgba(144, 103, 198, 0.10) 0%, transparent 64%),
+    radial-gradient(ellipse 48% 38% at 82% 78%, rgba(77, 186, 138, 0.07) 0%, transparent 60%);
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-card.intro-page {
+  background:
+    radial-gradient(ellipse 60% 48% at 18% 22%, rgba(158, 139, 255, 0.12) 0%, transparent 64%),
+    radial-gradient(ellipse 48% 38% at 82% 78%, rgba(60, 221, 199, 0.08) 0%, transparent 60%);
+}
+
+/* Eyebrow badge */
+body.antigravity-theme .hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(144, 103, 198, 0.10);
+  border: 1px solid rgba(144, 103, 198, 0.22);
+  color: var(--ag-violet);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+body.antigravity-theme .hero-eyebrow::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--ag-violet);
+  box-shadow: 0 0 6px var(--ag-violet);
+  animation: ag-dot-pulse 2.4s ease-in-out infinite;
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-eyebrow {
+  background: rgba(158, 139, 255, 0.12);
+  border-color: rgba(158, 139, 255, 0.24);
+}
+
+/* Hero title — bold, fluid, tight */
+body.antigravity-theme .hero-title {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: clamp(2rem, 3.4vw + 0.6rem, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.032em;
+  line-height: 1.08;
+  color: var(--text-main);
+  text-wrap: balance;
+  margin-top: 12px;
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.55),
+    0 6px 28px rgba(144, 103, 198, 0.12);
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-title {
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.05),
+    0 6px 28px rgba(158, 139, 255, 0.20);
+}
+
+/* Hero guidance copy */
+body.antigravity-theme .desc.hero-guidance,
+body.antigravity-theme .hero-guidance {
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1.55;
+  max-width: 36ch;
+  font-weight: 500;
+  margin-top: 10px;
+  text-wrap: pretty;
+}
+
+/* State chip */
+body.antigravity-theme .hero-state-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: rgba(36, 32, 56, 0.06);
+  border: 1px solid rgba(36, 32, 56, 0.10);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: lowercase;
+  color: var(--text-muted);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+html[data-theme="dark"] body.antigravity-theme .hero-state-chip {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+/* Primary "New concept" CTA */
+body.antigravity-theme .hero-primary-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 22px 12px 24px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--ag-violet) 0%, #7a59aa 50%, var(--ag-mint) 100%);
+  background-size: 200% 100%;
+  color: #FFFFFF;
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  box-shadow:
+    0 10px 28px rgba(144, 103, 198, 0.32),
+    0 3px 10px rgba(36, 32, 56, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  transition:
+    transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    box-shadow 0.3s ease,
+    background-position 0.4s ease;
+  margin-top: 22px;
+}
+
+body.antigravity-theme .hero-primary-action:hover {
+  transform: translateY(-3px);
+  background-position: 100% 0;
+  box-shadow:
+    0 16px 36px rgba(144, 103, 198, 0.42),
+    0 6px 16px rgba(36, 32, 56, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.36);
+}
+
+body.antigravity-theme .hero-primary-action:active {
+  transform: translateY(-1px) scale(0.98);
+}
+
+body.antigravity-theme .hero-primary-action__arrow {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 0.3s ease;
+}
+
+body.antigravity-theme .hero-primary-action:hover .hero-primary-action__arrow {
+  transform: translateX(3px);
+}
+
+/* Timer display — quiet but elegant */
+body.antigravity-theme #timer-display {
+  font-family: 'Outfit', 'Inter', sans-serif;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-muted);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  margin-top: 18px;
+  opacity: 0.7;
+}
+
+/* Crystal grid container — soft halo behind the board */
+body.antigravity-theme #grid-container {
+  position: relative;
+}
+
+body.antigravity-theme #grid-container::before {
+  content: "";
+  position: absolute;
+  inset: 6% 8%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(144, 103, 198, 0.16) 0%, transparent 60%);
+  filter: blur(40px);
+  z-index: 0;
+  pointer-events: none;
+  animation: ag-grid-halo 8s ease-in-out infinite alternate;
+}
+
+html[data-theme="dark"] body.antigravity-theme #grid-container::before {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(158, 139, 255, 0.20) 0%, transparent 60%);
+}
+
+@keyframes ag-grid-halo {
+  0%   { opacity: 0.65; transform: scale(1); }
+  100% { opacity: 1;    transform: scale(1.08); }
+}
+
+body.antigravity-theme #grid-svg {
+  position: relative;
+  z-index: 1;
+  filter: drop-shadow(0 8px 24px rgba(36, 32, 56, 0.10));
+}
+
+html[data-theme="dark"] body.antigravity-theme #grid-svg {
+  filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.40));
+}
+
+html[data-motion="reduced"] body.antigravity-theme #grid-container::before {
+  animation: none !important;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   2. LAUNCH PAD — threshold capture
+   ══════════════════════════════════════════════════════════════ */
+
+body.antigravity-theme #launch-pad-view {
+  background-color: #F2F0F5;
+  background-image:
+    radial-gradient(ellipse 70% 54% at 50% 26%, rgba(144, 103, 198, 0.10) 0%, transparent 68%),
+    radial-gradient(ellipse 42% 34% at 18% 78%, rgba(141, 134, 201, 0.07) 0%, transparent 60%),
+    radial-gradient(ellipse 38% 30% at 84% 74%, rgba(77, 186, 138, 0.05) 0%, transparent 56%);
+  position: relative;
+}
+
+html[data-theme="dark"] body.antigravity-theme #launch-pad-view {
+  background-color: #18181b;
+  background-image:
+    radial-gradient(ellipse 70% 54% at 50% 26%, rgba(158, 139, 255, 0.12) 0%, transparent 68%),
+    radial-gradient(ellipse 42% 34% at 18% 78%, rgba(141, 134, 201, 0.09) 0%, transparent 60%),
+    radial-gradient(ellipse 38% 30% at 84% 74%, rgba(60, 221, 199, 0.07) 0%, transparent 56%);
+}
+
+/* Ambient orbs */
+body.antigravity-theme #launch-pad-view::before,
+body.antigravity-theme #launch-pad-view::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+body.antigravity-theme #launch-pad-view::before {
+  width: 460px;
+  height: 460px;
+  top: -80px;
+  left: -120px;
+  background: radial-gradient(circle, rgba(144, 103, 198, 0.08) 0%, transparent 68%);
+  filter: blur(32px);
+  animation: ag-orb-drift-a 16s ease-in-out infinite alternate;
+}
+
+body.antigravity-theme #launch-pad-view::after {
+  width: 340px;
+  height: 340px;
+  bottom: -60px;
+  right: -80px;
+  background: radial-gradient(circle, rgba(77, 186, 138, 0.07) 0%, transparent 64%);
+  filter: blur(28px);
+  animation: ag-orb-drift-b 18s ease-in-out infinite alternate;
+}
+
+html[data-theme="dark"] body.antigravity-theme #launch-pad-view::before {
+  background: radial-gradient(circle, rgba(158, 139, 255, 0.10) 0%, transparent 68%);
+}
+html[data-theme="dark"] body.antigravity-theme #launch-pad-view::after {
+  background: radial-gradient(circle, rgba(60, 221, 199, 0.08) 0%, transparent 64%);
+}
+
+html[data-motion="reduced"] body.antigravity-theme #launch-pad-view::before,
+html[data-motion="reduced"] body.antigravity-theme #launch-pad-view::after {
+  animation: none !important;
+}
+
+body.antigravity-theme .launch-pad-view__inner {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  width: 100%;
+  margin: auto;
+  padding: clamp(20px, 4vh, 52px) clamp(20px, 5vw, 64px);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: center;
+}
+
+/* Concept name above title */
+body.antigravity-theme .launch-pad-concept-name {
+  display: inline-flex;
+  align-self: center;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: rgba(144, 103, 198, 0.10);
+  border: 1px solid rgba(144, 103, 198, 0.22);
+  border-radius: 999px;
+  color: var(--ag-violet);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  margin-bottom: 18px;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+body.antigravity-theme .launch-pad-concept-name::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ag-violet);
+  box-shadow: 0 0 6px var(--ag-violet);
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-concept-name {
+  background: rgba(158, 139, 255, 0.12);
+  border-color: rgba(158, 139, 255, 0.24);
+}
+
+/* Launch Pad title */
+body.antigravity-theme .launch-pad-title {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: clamp(1.9rem, 3.6vw + 0.6rem, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.032em;
+  line-height: 1.10;
+  color: var(--text-main);
+  text-wrap: balance;
+  margin: 0 0 12px;
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.55),
+    0 6px 28px rgba(144, 103, 198, 0.12);
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-title {
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.05),
+    0 6px 28px rgba(158, 139, 255, 0.20);
+}
+
+body.antigravity-theme .launch-pad-helper {
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1.55;
+  margin: 0 auto 24px;
+  max-width: 48ch;
+  text-wrap: pretty;
+}
+
+/* Form card */
+body.antigravity-theme .launch-pad-form {
+  background: var(--ag-glass-bg);
+  backdrop-filter: var(--ag-glass-blur);
+  -webkit-backdrop-filter: var(--ag-glass-blur);
+  border: 1px solid var(--ag-glass-border);
+  border-radius: 26px;
+  box-shadow: var(--ag-glass-shadow);
+  padding: 26px;
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    box-shadow 0.4s ease,
+    border-color 0.3s ease;
+}
+
+body.antigravity-theme .launch-pad-form::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.26) 0%, transparent 60%);
+  pointer-events: none;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+body.antigravity-theme .launch-pad-form:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(144, 103, 198, 0.32);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.85) inset,
+    0 26px 64px rgba(144, 103, 198, 0.18),
+    0 0 0 1.5px rgba(144, 103, 198, 0.26);
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-form:focus-within {
+  border-color: rgba(158, 139, 255, 0.30);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 26px 64px rgba(0, 0, 0, 0.40),
+    0 0 0 1.5px rgba(158, 139, 255, 0.26);
+}
+
+body.antigravity-theme .launch-pad-input {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid rgba(144, 103, 198, 0.16);
+  border-radius: 16px;
+  padding: 14px 16px;
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--ag-ink);
+  resize: vertical;
+  min-height: 140px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.80) inset,
+    0 2px 8px rgba(36, 32, 56, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.antigravity-theme .launch-pad-input:focus {
+  outline: none;
+  border-color: rgba(144, 103, 198, 0.40);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.80) inset,
+    0 0 0 3px rgba(144, 103, 198, 0.12);
+}
+
+body.antigravity-theme .launch-pad-input::placeholder {
+  color: rgba(36, 32, 56, 0.36);
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-input {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(158, 139, 255, 0.16);
+  color: #FFFFFF;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 2px 8px rgba(0, 0, 0, 0.16);
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-input::placeholder {
+  color: rgba(255, 255, 255, 0.28);
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-input:focus {
+  border-color: rgba(158, 139, 255, 0.40);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 0 0 3px rgba(158, 139, 255, 0.18);
+}
+
+body.antigravity-theme .launch-pad-validation {
+  position: relative;
+  z-index: 1;
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 10px 2px 0;
+  min-height: 1em;
+  text-align: left;
+}
+
+body.antigravity-theme .launch-pad-form__row {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 18px;
+}
+
+body.antigravity-theme .launch-pad-submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 22px 12px 24px;
+  border: none;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--ag-violet) 0%, #7a59aa 50%, var(--ag-mint) 100%);
+  background-size: 200% 100%;
+  color: #FFFFFF;
+  font-weight: 700;
+  font-size: 15px;
+  cursor: pointer;
+  box-shadow:
+    0 10px 28px rgba(144, 103, 198, 0.32),
+    0 3px 10px rgba(36, 32, 56, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  transition:
+    transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    box-shadow 0.3s ease,
+    background-position 0.4s ease;
+}
+
+body.antigravity-theme .launch-pad-submit:hover:not(:disabled) {
+  transform: translateY(-3px);
+  background-position: 100% 0;
+  box-shadow:
+    0 16px 36px rgba(144, 103, 198, 0.42),
+    0 6px 16px rgba(36, 32, 56, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.36);
+}
+
+body.antigravity-theme .launch-pad-submit:active:not(:disabled) {
+  transform: translateY(-1px) scale(0.98);
+}
+
+body.antigravity-theme .launch-pad-submit:disabled {
+  background: rgba(36, 32, 56, 0.07);
+  color: rgba(36, 32, 56, 0.32);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+html[data-theme="dark"] body.antigravity-theme .launch-pad-submit:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.30);
+}
+
+body.antigravity-theme .launch-pad-submit svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 0.3s ease;
+}
+
+body.antigravity-theme .launch-pad-submit:hover:not(:disabled) svg {
+  transform: translateX(3px);
+}
+
+body.antigravity-theme .launch-pad-footer {
+  position: relative;
+  z-index: 1;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  margin: 16px 0 0;
+  letter-spacing: 0.02em;
+  opacity: 0.72;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   3. LIBRARY VIEW
+   ══════════════════════════════════════════════════════════════ */
+
+body.antigravity-theme #library-view {
+  background-color: #F2F0F5;
+  background-image:
+    radial-gradient(ellipse 60% 46% at 22% 18%, rgba(144, 103, 198, 0.08) 0%, transparent 64%),
+    radial-gradient(ellipse 50% 38% at 80% 84%, rgba(77, 186, 138, 0.06) 0%, transparent 60%);
+}
+
+html[data-theme="dark"] body.antigravity-theme #library-view {
+  background-color: #18181b;
+  background-image:
+    radial-gradient(ellipse 60% 46% at 22% 18%, rgba(158, 139, 255, 0.10) 0%, transparent 64%),
+    radial-gradient(ellipse 50% 38% at 80% 84%, rgba(60, 221, 199, 0.07) 0%, transparent 60%);
+}
+
+body.antigravity-theme .library-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(144, 103, 198, 0.10);
+  border: 1px solid rgba(144, 103, 198, 0.22);
+  color: var(--ag-violet);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+body.antigravity-theme .library-kicker::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--ag-violet);
+  box-shadow: 0 0 6px var(--ag-violet);
+}
+
+html[data-theme="dark"] body.antigravity-theme .library-kicker {
+  background: rgba(158, 139, 255, 0.12);
+  border-color: rgba(158, 139, 255, 0.24);
+}
+
+body.antigravity-theme .library-section-title {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: clamp(1.5rem, 2.2vw + 0.4rem, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.028em;
+  line-height: 1.15;
+  color: var(--text-main);
+  margin: 0 0 8px;
+}
+
+body.antigravity-theme .library-section-copy {
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0 0 24px;
+  max-width: 60ch;
+}
+
+body.antigravity-theme .library-vault-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+body.antigravity-theme .library-card.library-card-vault {
+  background: var(--ag-glass-bg);
+  backdrop-filter: var(--ag-glass-blur);
+  -webkit-backdrop-filter: var(--ag-glass-blur);
+  border: 1px solid var(--ag-glass-border);
+  border-radius: 22px;
+  padding: 22px 22px 18px;
+  box-shadow: var(--ag-glass-shadow);
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.35s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    box-shadow 0.35s ease,
+    border-color 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+body.antigravity-theme .library-card.library-card-vault::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.22) 0%, transparent 56%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+body.antigravity-theme .library-card.library-card-vault:hover {
+  transform: translateY(-5px);
+  border-color: rgba(144, 103, 198, 0.32);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.85) inset,
+    0 24px 56px rgba(144, 103, 198, 0.18),
+    0 6px 18px rgba(36, 32, 56, 0.10);
+}
+
+body.antigravity-theme .library-card.library-card-vault:active {
+  transform: translateY(-2px) scale(0.99);
+}
+
+html[data-theme="dark"] body.antigravity-theme .library-card.library-card-vault:hover {
+  border-color: rgba(158, 139, 255, 0.32);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 24px 56px rgba(0, 0, 0, 0.40),
+    0 6px 18px rgba(0, 0, 0, 0.24);
+}
+
+body.antigravity-theme .library-card-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+body.antigravity-theme .library-card-kicker {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ag-violet);
+  margin-bottom: 4px;
+  opacity: 0.85;
+}
+
+body.antigravity-theme .library-card-name {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.018em;
+  color: var(--text-main);
+  line-height: 1.25;
+  display: block;
+}
+
+body.antigravity-theme .library-card-state {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  border-radius: 999px;
+  background: rgba(36, 32, 56, 0.06);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+html[data-theme="dark"] body.antigravity-theme .library-card-state {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+body.antigravity-theme .library-card-summary {
+  position: relative;
+  z-index: 1;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-muted);
+  margin: 0;
+  text-wrap: pretty;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+body.antigravity-theme .library-card-meta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+body.antigravity-theme .library-card-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: 999px;
+  background: rgba(144, 103, 198, 0.08);
+  border: 1px solid rgba(144, 103, 198, 0.16);
+  color: var(--ag-violet);
+}
+
+html[data-theme="dark"] body.antigravity-theme .library-card-pill {
+  background: rgba(158, 139, 255, 0.10);
+  border-color: rgba(158, 139, 255, 0.20);
+}
+
+body.antigravity-theme .library-card-cta {
+  position: relative;
+  z-index: 1;
+  align-self: flex-start;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  color: var(--ag-violet);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  transition: gap 0.25s ease, color 0.2s ease;
+}
+
+body.antigravity-theme .library-card-cta::after {
+  content: "→";
+  font-size: 14px;
+  transition: transform 0.25s ease;
+}
+
+body.antigravity-theme .library-card.library-card-vault:hover .library-card-cta {
+  gap: 10px;
+}
+
+body.antigravity-theme .library-card.library-card-vault:hover .library-card-cta::after {
+  transform: translateX(2px);
+}
+
+body.antigravity-theme .library-empty {
+  background: var(--ag-glass-bg);
+  backdrop-filter: var(--ag-glass-blur);
+  -webkit-backdrop-filter: var(--ag-glass-blur);
+  border: 1px dashed rgba(144, 103, 198, 0.28);
+  border-radius: 18px;
+  padding: 22px;
+  color: var(--text-muted);
+  font-size: 14px;
+  text-align: center;
+}
+
+body.antigravity-theme .library-empty a {
+  color: var(--ag-violet);
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(144, 103, 198, 0.32);
+}
+
+body.antigravity-theme .library-empty a:hover {
+  border-bottom-color: var(--ag-violet);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   4. SETTINGS VIEW
+   ══════════════════════════════════════════════════════════════ */
+
+body.antigravity-theme #settings-view {
+  background-color: #F2F0F5;
+  background-image:
+    radial-gradient(ellipse 60% 44% at 50% 14%, rgba(144, 103, 198, 0.08) 0%, transparent 64%);
+}
+
+html[data-theme="dark"] body.antigravity-theme #settings-view {
+  background-color: #18181b;
+  background-image:
+    radial-gradient(ellipse 60% 44% at 50% 14%, rgba(158, 139, 255, 0.10) 0%, transparent 64%);
+}
+
+body.antigravity-theme .settings-shell {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: clamp(20px, 4vh, 40px) clamp(20px, 5vw, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+body.antigravity-theme .settings-page-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(144, 103, 198, 0.10);
+  border: 1px solid rgba(144, 103, 198, 0.22);
+  color: var(--ag-violet);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+  width: fit-content;
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-page-kicker {
+  background: rgba(158, 139, 255, 0.12);
+  border-color: rgba(158, 139, 255, 0.24);
+}
+
+body.antigravity-theme .settings-page-kicker .crystal-glyph {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: linear-gradient(135deg, var(--ag-violet), var(--ag-mint));
+  transform: rotate(45deg);
+  box-shadow: 0 0 6px rgba(144, 103, 198, 0.6);
+}
+
+body.antigravity-theme .settings-page-title {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: clamp(1.8rem, 2.8vw + 0.4rem, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -0.030em;
+  line-height: 1.12;
+  color: var(--text-main);
+  margin: 0 0 8px;
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.55),
+    0 6px 28px rgba(144, 103, 198, 0.10);
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-page-title {
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.05),
+    0 6px 28px rgba(158, 139, 255, 0.18);
+}
+
+body.antigravity-theme .settings-page-copy {
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 50ch;
+}
+
+body.antigravity-theme .settings-identity-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  background: var(--ag-glass-bg);
+  backdrop-filter: var(--ag-glass-blur);
+  -webkit-backdrop-filter: var(--ag-glass-blur);
+  border: 1px solid var(--ag-glass-border);
+  border-radius: 18px;
+  box-shadow: var(--ag-glass-shadow);
+}
+
+body.antigravity-theme .settings-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ag-violet), var(--ag-mint));
+  flex: none;
+  box-shadow: 0 4px 12px rgba(144, 103, 198, 0.30);
+}
+
+body.antigravity-theme .settings-avatar.is-guest {
+  background: rgba(36, 32, 56, 0.08);
+  box-shadow: none;
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-avatar.is-guest {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+body.antigravity-theme .settings-identity-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+body.antigravity-theme .settings-identity-email {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--text-main);
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body.antigravity-theme .settings-identity-meta {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+body.antigravity-theme .settings-identity-action {
+  flex: none;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(144, 103, 198, 0.10);
+  border: 1px solid rgba(144, 103, 198, 0.22);
+  color: var(--ag-violet);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, transform 0.2s;
+}
+
+body.antigravity-theme .settings-identity-action:hover {
+  background: rgba(144, 103, 198, 0.16);
+  border-color: rgba(144, 103, 198, 0.32);
+  transform: translateY(-1px);
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-identity-action {
+  background: rgba(158, 139, 255, 0.12);
+  border-color: rgba(158, 139, 255, 0.22);
+}
+
+body.antigravity-theme .settings-display {
+  background: var(--ag-glass-bg);
+  backdrop-filter: var(--ag-glass-blur);
+  -webkit-backdrop-filter: var(--ag-glass-blur);
+  border: 1px solid var(--ag-glass-border);
+  border-radius: 22px;
+  padding: 24px 24px 8px;
+  box-shadow: var(--ag-glass-shadow);
+}
+
+body.antigravity-theme .settings-section-heading {
+  font-family: 'Outfit', 'Manrope', 'Inter', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 14px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(36, 32, 56, 0.06);
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-section-heading {
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+body.antigravity-theme .settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(36, 32, 56, 0.06);
+}
+
+body.antigravity-theme .settings-row:last-child {
+  border-bottom: none;
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-row {
+  border-bottom-color: rgba(255, 255, 255, 0.05);
+}
+
+body.antigravity-theme .settings-row-label {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--text-main);
+  letter-spacing: -0.01em;
+  margin-bottom: 2px;
+}
+
+body.antigravity-theme .settings-row-meta {
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.005em;
+  line-height: 1.4;
+}
+
+body.antigravity-theme .settings-pill-group {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px;
+  background: rgba(36, 32, 56, 0.05);
+  border-radius: 999px;
+  border: 1px solid rgba(36, 32, 56, 0.06);
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-pill-group {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+body.antigravity-theme .settings-pill {
+  background: transparent;
+  border: none;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  border-radius: 999px;
+  cursor: pointer;
+  letter-spacing: -0.005em;
+  transition: background 0.2s, color 0.2s;
+}
+
+body.antigravity-theme .settings-pill[aria-checked="true"] {
+  background: linear-gradient(135deg, var(--ag-violet), #7a59aa);
+  color: #FFFFFF;
+  box-shadow: 0 4px 12px rgba(144, 103, 198, 0.30);
+}
+
+body.antigravity-theme .settings-pill:hover:not([aria-checked="true"]) {
+  color: var(--text-main);
+  background: rgba(144, 103, 198, 0.08);
+}
+
+body.antigravity-theme .settings-toggle {
+  position: relative;
+  flex: none;
+  width: 44px;
+  height: 26px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(36, 32, 56, 0.14);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.25s ease;
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-toggle {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+body.antigravity-theme .settings-toggle::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #FFFFFF;
+  box-shadow:
+    0 2px 6px rgba(36, 32, 56, 0.25),
+    0 1px 0 rgba(36, 32, 56, 0.10) inset;
+  transition: left 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+body.antigravity-theme .settings-toggle[aria-checked="true"] {
+  background: linear-gradient(135deg, var(--ag-violet), var(--ag-mint));
+  box-shadow: 0 4px 12px rgba(144, 103, 198, 0.32);
+}
+
+body.antigravity-theme .settings-toggle[aria-checked="true"]::after {
+  left: 21px;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   5. SIDEBAR & BOTTOM NAV — quiet refinements
+   ══════════════════════════════════════════════════════════════ */
+
+body.antigravity-theme .sidebar-nav-item {
+  border-radius: 12px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  transition: background 0.2s, color 0.2s, transform 0.15s;
+}
+
+body.antigravity-theme .sidebar-nav-item:hover {
+  background: rgba(144, 103, 198, 0.08);
+  color: var(--ag-violet);
+}
+
+body.antigravity-theme .sidebar-nav-item.active {
+  background: linear-gradient(135deg, rgba(144, 103, 198, 0.14), rgba(77, 186, 138, 0.10));
+  color: var(--ag-violet);
+  box-shadow: inset 0 0 0 1px rgba(144, 103, 198, 0.20);
+}
+
+html[data-theme="dark"] body.antigravity-theme .sidebar-nav-item:hover {
+  background: rgba(158, 139, 255, 0.10);
+}
+
+html[data-theme="dark"] body.antigravity-theme .sidebar-nav-item.active {
+  background: linear-gradient(135deg, rgba(158, 139, 255, 0.16), rgba(60, 221, 199, 0.10));
+  box-shadow: inset 0 0 0 1px rgba(158, 139, 255, 0.22);
+}
+
+body.antigravity-theme .bottom-nav-item.active {
+  color: var(--ag-violet);
+}
+
+body.antigravity-theme .bottom-nav-item.active .material-symbols-outlined {
+  filter: drop-shadow(0 0 6px rgba(144, 103, 198, 0.40));
+}
+
+html[data-theme="dark"] body.antigravity-theme .bottom-nav-item.active .material-symbols-outlined {
+  filter: drop-shadow(0 0 6px rgba(158, 139, 255, 0.50));
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Mobile adjustments for new view enhancements
+   ══════════════════════════════════════════════════════════════ */
+@media (max-width: 720px) {
+  body.antigravity-theme .hero-title,
+  body.antigravity-theme .launch-pad-title,
+  body.antigravity-theme .settings-page-title {
+    font-size: clamp(1.7rem, 6.5vw, 2.2rem);
+    letter-spacing: -0.025em;
+  }
+
+  body.antigravity-theme .library-vault-grid {
+    grid-template-columns: 1fr;
+  }
+
+  body.antigravity-theme .library-card.library-card-vault {
+    border-radius: 18px;
+    padding: 18px 18px 16px;
+  }
+
+  body.antigravity-theme .launch-pad-form {
+    border-radius: 22px;
+    padding: 20px;
+  }
+
+  body.antigravity-theme .settings-display,
+  body.antigravity-theme .settings-identity-row {
+    border-radius: 18px;
+  }
+
+  body.antigravity-theme .settings-row {
+    flex-wrap: wrap;
+  }
+
+  body.antigravity-theme #launch-pad-view::before,
+  body.antigravity-theme #launch-pad-view::after {
     display: none;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -280,7 +280,7 @@
         <canvas id="intro-particle-canvas"></canvas>
       </div>
       <div class="ignition-view__inner">
-        <h1 class="ignition-title" id="ignition-title">What do you want to understand?</h1>
+        <h1 class="ignition-title" id="ignition-title">What do you want to <span class="ig-highlight">understand</span>?</h1>
 
         <!-- Library-cap gate. Hidden by default; shown by renderIgnitionGate() at board capacity. -->
         <div class="ignition-cap-gate" id="ignition-cap-gate" hidden>

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
   <link rel="stylesheet" href="styles.css?v=84">
-  <link rel="stylesheet" href="antigravity.css?v=3">
+  <link rel="stylesheet" href="antigravity.css?v=4">
 </head>
 
 <body>


### PR DESCRIPTION
## Fix: "understand" highlight visibility in light mode

The previous gradient used `--accent-mint` (a light teal/cyan) as a midpoint, which faded into the cream light-mode background.

### Changes to `public/antigravity.css`
- **Light mode** gradient replaced with deeper, high-contrast stops: deep violet `#6b3fa0` → brand violet `#9067c6` → rich blue `#3d7abd`, ensuring the word is always legible against `#F2F0F5`
- **Dark mode** gets a separate lighter-value gradient (`#c8a8f7` → `#a97ef4` → `#7dd4f8`) so the shimmer pops against dark backgrounds without being overly bright
- Added a subtle `drop-shadow` filter to each mode for a soft glow halo that reinforces legibility