### PR TITLE
docs(product): add competitive novelty matrix to guide feature investment

### DIFF
--- a/docs/product/competitive-novelty.md
+++ b/docs/product/competitive-novelty.md
@@ -1,0 +1,416 @@
+# Competitive Novelty — Mechanism-by-Mechanism
+
+This document scores Socratink's mechanisms against the 2025–2026 study-tool
+landscape and translates each row into a feature-investment implication. It is
+not a binding spec — it is a decision frame for "where should the next unit of
+build effort go?".
+
+If you want the binding product contract, read
+[spec.md](spec.md) and
+[evidence-weighted-map.md](evidence-weighted-map.md). Those win on conflict.
+This doc is downstream: it interprets those doctrines through the lens of
+"what's already commodity in the market vs. what's actually defensible."
+
+Last refreshed: 2026-05-12. Refresh trigger: any major competitor (NotebookLM,
+RemNote, Anki, Khanmigo, Quizlet) ships a feature that touches one of the rows
+below.
+
+---
+
+## TL;DR
+
+- **Five mechanisms are genuinely novel** in the 2026 market: the three-phase
+  loop with hard separation, the evidence-weighted graph doctrine, the
+  multi-step causal-reconstruction rubric, the in-session buffer-flush
+  requirement, and Trajectory Contrast as a metacognitive surface. Repair Reps
+  and the sparse-AI contract are strong supporting differentiators.
+- **Four mechanisms are commodity**: source extraction → graph, knowledge-graph
+  visualization, spaced-repetition scheduling math, and AI flashcard
+  generation. Every serious tool ships these. Don't out-build them; ship
+  table-stakes and route effort elsewhere.
+- **The anti-illusion-of-competence positioning is brand-only** unless the five
+  novel mechanisms above are visibly load-bearing in the UX. The phrase is
+  already being used as marketing copy by other tools (e.g. StudyCards AI)
+  whose underlying primitive is still recognition flashcards.
+- **Race condition**: NotebookLM added flashcards + quizzes + "mastery
+  tracking" in late 2025 / early 2026. They have distribution and the source
+  → output pipeline. They do not yet have proof events, rubric-judged free
+  recall, or a doctrine that distinguishes exposure from evidence. Closing
+  that gap is where Socratink's window lives.
+
+---
+
+## How to read the matrix
+
+For each mechanism:
+
+- **Novelty (1–5)**: 5 = no shipped competitor implements this; 1 = every
+  serious competitor ships it. Scored against the mechanism, not the framing.
+- **Defensibility (Low / Med / High)**: How hard is it for a competitor to
+  copy *the actual mechanism* (not the marketing) within 12 months? "High"
+  usually means the mechanism adds friction the competitor's business model
+  won't tolerate, or requires a doctrine they've already foreclosed.
+- **Implication**: Invest / Commodity-table-stakes / Brand-only / Don't
+  reinvent. This is the feature-budget signal.
+
+"Closest analog" names the most similar shipped product feature, not the most
+similar marketing claim.
+
+---
+
+## The matrix
+
+### 1. Three-phase loop with hard separation
+
+**Mechanism**: Cold Attempt → Targeted Study → Spaced Re-Drill, with no skip
+allowed. Only a spaced re-drill can stamp `solidified`. Study and Repair Reps
+explicitly cannot mutate graph truth. (See `spec.md` §2, §3, and §6 "Moat
+Constraint".)
+
+**Closest analog**: None. Anki/FSRS collapse "exposure," "study," and "proof"
+into a single review event judged by self-reported confidence. NotebookLM has
+flashcards + quizzes + early mastery tracking but no enforced phase ordering.
+RemNote tags cards but treats every review as the same kind of event.
+
+**Novelty**: 5/5. **Defensibility**: High — competitors whose business model
+depends on engagement-per-session won't add friction that delays the dopamine
+hit.
+
+**Implication**: **Invest.** This is the load-bearing mechanism. Investments
+that improve the *feel* of the loop (phase clarity in the side panel, the
+ADHD-beat delay in `spec.md` §2 Phase 2, the buffer-flush nudge) compound.
+Investments that blur phases (e.g., "let users skip to study," "preview the
+mechanism before cold attempt") destroy the moat in exchange for a comfort
+metric.
+
+---
+
+### 2. Evidence-weighted graph doctrine
+
+**Mechanism**: The graph shows what Socratink has *evidence for*, not what the
+learner *knows*. Topology is a hypothesis until reconstruction earns trust.
+(See `evidence-weighted-map.md` §1 and §4.)
+
+**Closest analog**: None as doctrine. Heptabase, Logseq, Obsidian, and
+RemNote render *content* graphs (notes/links). NotebookLM's "mastery tracking"
+explicitly claims mastery from flashcard reviews — the exact failure mode this
+doctrine forbids. Khanmigo has Socratic stance but no persisted graph.
+
+**Novelty**: 5/5 on doctrine, 3/5 on rendering (graph rendering itself is
+commodity). **Defensibility**: Medium. The doctrine is copyable in marketing
+copy in an afternoon; copying it in execution requires giving up on every
+exposure-as-progress dopamine pattern competitors rely on, which most won't do.
+
+**Implication**: **Invest** in surfaces that make the doctrine *visible* to
+the learner — the four state badges, the hypothesis-vs-verified split in the
+graph layer, the result-state UX in `spec.md` §4 (no celebration on `drilled`,
+strongest celebration on `solidified`). **Don't invest** in dressing up
+topology — that's the commodity layer.
+
+---
+
+### 3. Multi-step causal-reconstruction rubric
+
+**Mechanism**: Re-drill demands (a) initiating condition, (b) causal
+transition, (c) resulting state. LLM judges against this rubric, not against
+keyword overlap. (See `spec.md` §2 Phase 3.)
+
+**Closest analog**: None at this granularity. Anki/Quizlet are binary
+right/wrong on self-grade. NotebookLM's quizzes are multiple-choice or
+short-answer with no causal-structure rubric. Khanmigo's Socratic dialogue
+elicits but does not classify against a fixed reconstruction shape.
+
+**Novelty**: 5/5. **Defensibility**: Medium. Other tools can build this — the
+prompt + eval pipeline isn't trade-secret material. But the rubric is the
+artifact that converts "free recall feels hard" into "free recall produces a
+classifiable evidence event," which is what makes node-state assignment
+defensible. Whoever ships this with the best eval wins.
+
+**Implication**: **Invest** in rubric quality and offline eval. The
+extraction-evals/rubric work in `docs/design/handoffs/2026-05-02-extraction-evals-and-rubric.md`
+is the right axis. Underinvesting here turns proof events into noisy labels
+and silently weakens every downstream claim the graph makes.
+
+---
+
+### 4. In-session buffer-flush requirement
+
+**Mechanism**: A re-drill is only valid after 10–15 min (5 min minimum) of
+*interleaved work on other nodes*. Time alone doesn't qualify. (See `spec.md`
+§2 Phase 3 "Buffer Flush" and §5 Traversal "Interleaving Recommendation".)
+
+**Closest analog**: None. Standard SRS — Anki, FSRS, RemNote, Quizlet — uses
+calendar spacing with no in-session interleaving requirement. The cognitive
+science on interleaving as a discriminative-contrast mechanism is well known
+([Springer review, 2021](https://link.springer.com/article/10.1007/s10648-021-09613-w)),
+but implementations stop at "shuffle deck order," not "block credit until the
+working-memory buffer is demonstrably flushed."
+
+**Novelty**: 5/5. **Defensibility**: High — same friction-aversion logic as
+row 1.
+
+**Implication**: **Invest** in the routing engine in `ai_service.py` that
+recommends *which other node* to attempt during the buffer window. The
+quality of those recommendations is the difference between buffer-flush
+feeling magnetic vs. feeling like homework. A poor recommender turns the
+defensible mechanism into a churn driver.
+
+---
+
+### 5. Trajectory Contrast (post-re-drill)
+
+**Mechanism**: After a re-drill, surface the contrast between the learner's
+prior cold attempt and the current reconstruction, framed as evidence about
+their own metacognitive predictions. (See `spec.md` §1 Metacognitive UX table
+and §4 Post-Re-Drill panel.)
+
+**Closest analog**: None. Competitors show *outcome metrics* (streaks, decks
+completed, ease factor). Trajectory Contrast shows *belief updating* — "your
+prediction about how much you knew was wrong, here is the gap." Khanmigo
+gestures at this in dialogue but does not persist or visualize it.
+
+**Novelty**: 4/5. **Defensibility**: High — only meaningful if rows 1 and 3
+are present. A copycat without the loop has nothing to contrast against.
+
+**Implication**: **Invest.** This is the surface where the "anti-illusion"
+promise becomes felt experience rather than marketing. If the learner doesn't
+*see* their fluency illusion get punctured, the doctrine is invisible.
+
+---
+
+### 6. Repair Reps
+
+**Mechanism**: Optional typed causal micro-practice after study completion or
+non-solid re-drill. Strict structured-output validation. **No scores, no
+graph mutation, no interleaving credit, no mastery unlock.** (See `spec.md`
+§4 panel mode 7.)
+
+**Closest analog**: None at this contract. Anki/RemNote re-show the same
+card (recognition repeat). Khanmigo will re-explain, but doesn't structure a
+practice event that explicitly cannot mutate truth. NotebookLM has no
+analogous primitive.
+
+**Novelty**: 4/5. **Defensibility**: Medium. The mechanism is small enough to
+copy, but the *contract* (no graph mutation) is the part that respects the
+evidence-weighted doctrine — and competitors copying the surface usually skip
+the contract because granting credit increases retention metrics short-term.
+
+**Implication**: **Invest** in repair-reps prompt quality and validation
+strictness. Validate that any new copy or UX never implies repair reps moved
+graph state — the contract is the moat.
+
+---
+
+### 7. Sparse AI contract
+
+**Mechanism**: "AI must talk less than the learner. Sparse, gap-identifying
+feedback only." (See `spec.md` §6.)
+
+**Closest analog**: Khanmigo's "never gives the direct answer" is the closest
+philosophical match. Mainstream LLM tutors (ChatGPT, Gemini, NotebookLM chat)
+default to verbose explanation. Most "AI study buddy" products optimize for
+helpfulness-as-explanation, which is the failure mode this contract forbids.
+
+**Novelty**: 4/5 (the *contract* — the philosophy isn't unique). **Defensibility**:
+Medium. Khanmigo could match. Hard to defend because it's a prompting
+discipline, not a moat.
+
+**Implication**: **Invest** in prompt discipline (`app_prompts/`) and offline
+eval that explicitly penalizes verbosity. Felt by the learner immediately —
+violations break the loop's metacognitive stance in one turn.
+
+---
+
+### 8. Generative commitment threshold
+
+**Mechanism**: Cold attempt requires 3+ words and rejects "idk". (See `spec.md`
+§2 Phase 1.)
+
+**Closest analog**: None visible. Free-text-input apps don't gate on
+substantiveness; flashcard apps gate on self-rated buttons (Again / Hard /
+Good / Easy).
+
+**Novelty**: 3/5 (mechanism is simple). **Defensibility**: Low — easy to copy.
+
+**Implication**: **Commodity-adjacent / table-stakes.** Keep it correct and
+zero-schema-detection robust. Don't over-invest — its value is in not letting
+the learner skip the loop, not in being a defensible moat itself.
+
+---
+
+### 9. Source extraction → knowledge graph
+
+**Mechanism**: Upload source → AI extracts concepts → renders as graph
+(`/api/extract`, `/api/extract-url`).
+
+**Closest analog**: NotebookLM, RemNote AI, Wisdolia, StudyFetch, Recallify,
+StudyCards AI all do source-grounded extraction. NotebookLM specifically
+extracts to study guides + flashcards + quizzes from uploaded sources.
+
+**Novelty**: 1/5. **Defensibility**: Low. Gemini/GPT-class extraction is
+commodity; the "AI flashcards from your PDF" category is saturated.
+
+**Implication**: **Don't out-build.** Maintain table-stakes extraction
+quality. Don't differentiate Socratink on extraction polish — differentiate
+on *what the loop does with the extracted map*.
+
+---
+
+### 10. Knowledge-graph visualization
+
+**Mechanism**: Render concepts and relationships as an inspectable graph.
+
+**Closest analog**: Heptabase (visual canvas), Obsidian Graph View, Logseq,
+RemNote, InfraNodus, Atlas. The PKM / second-brain category has shipped
+graph-view as table stakes for years.
+
+**Novelty**: 1/5. **Defensibility**: Low.
+
+**Implication**: **Commodity.** Sufficient quality is enough — the
+*evidence-weighted overlay* (state badges, hypothesis-vs-verified) is what
+makes Socratink's graph different, not the layout. Don't chase prettier
+layouts at the expense of the overlay.
+
+---
+
+### 11. Spaced-repetition scheduling math
+
+**Mechanism**: Deciding *when* to re-show a card.
+
+**Closest analog**: Anki + FSRS-6 — three-component model (stability,
+difficulty, retrievability), 17 trainable weights, trained on ~700M reviews.
+Open-source SOTA. RemNote ships both SM-2 and FSRS. Quizlet has its own
+adaptive plans.
+
+**Novelty**: 1/5. **Defensibility**: Low — open-source SOTA exists.
+
+**Implication**: **Don't reinvent.** Use FSRS or a deliberately simpler
+heuristic and document the choice. The proof event (rows 1, 3, 4) is
+Socratink's differentiator, not the cadence math. Spending engineering
+budget on a custom scheduler would be importing a battle the team can't win
+to defend a flank that doesn't matter.
+
+---
+
+### 12. Anti-illusion-of-competence positioning
+
+**Mechanism**: Marketing and product framing.
+
+**Closest analog**: StudyCards AI uses the exact phrase as marketing copy.
+The Feynman Technique is being repackaged as anti-illusion in 2026 dev
+content. Academic literature flagging the problem in AI-mediated learning
+is now established
+([RSIS Int'l, 2025](https://ideas.repec.org/a/bjc/journl/v12y2025i5p1725-1738.html);
+[PubMed, 2025](https://pubmed.ncbi.nlm.nih.gov/41212201/)). The *concern*
+is mainstream; the *implementation* (rows 1–5) is not.
+
+**Novelty**: 4/5 on implementation, 1/5 on the phrase. **Defensibility**:
+High on execution, low on copy.
+
+**Implication**: **Brand-only moat unless rows 1–5 ship visibly.** Lean
+into the phrase only when the product can demonstrate the mechanism in 60
+seconds of use. Otherwise it reads as the same marketing every other AI
+flashcard app is shipping.
+
+---
+
+## Aggregate read
+
+Two scores, weighted by load-bearing-ness for the doctrine:
+
+- **Mechanism novelty (rows 1–7, the load-bearing layer)**: ~4.4 / 5. The
+  mechanisms that make Socratink Socratink are genuinely missing from the
+  market in 2026.
+- **Surface novelty (rows 8–12, the table-stakes/positioning layer)**: ~1.6 / 5.
+  Everything Socratink renders or claims at the surface has competitive
+  analogs.
+
+The headline: Socratink is **highly novel where it matters and unremarkable
+where it doesn't**. That's the right shape — but only if feature investment
+matches the same shape. The failure mode is letting commodity work (prettier
+graphs, custom scheduler, more import formats) crowd out the load-bearing
+work (rubric eval, buffer-flush UX, trajectory contrast).
+
+---
+
+## Strategic implications for feature roadmap
+
+Direct, decision-shaped:
+
+1. **Default-allocate engineering budget to rows 1–7.** When a backlog item
+   touches one of those rows, it gets prioritization weight. When it touches
+   rows 8–12, it has to clear a higher bar than "would be nice."
+2. **Treat extraction and graph layout as table-stakes.** Reach the bar,
+   don't push past it. A 5%-better extraction gain rarely changes a learner's
+   loop outcome; a 5%-better re-drill rubric does.
+3. **Eval the moat, not the surface.** The offline-eval investment should
+   weight rubric judgment, sparse-AI compliance, and routing quality — not
+   extraction precision/recall on a fixture.
+4. **Don't compete on scheduling math.** Use FSRS or a simpler heuristic.
+   Document it. Move on.
+5. **Brand investments must follow mechanism investments.** The
+   anti-illusion claim is only credible after rows 1–5 are felt within the
+   first session.
+
+---
+
+## Race conditions and watchlist
+
+Things that, if they ship, change the matrix:
+
+- **NotebookLM ships rubric-judged free recall** (not multiple choice). Their
+  flashcards + quizzes + mastery tracking already cover the surface; a
+  rubric-judged proof event would close half of row 3. Probability: medium
+  within 12 months given their iteration cadence
+  ([NotebookLM April 2026 update](https://pasqualepillitteri.it/en/news/1391/notebooklm-april-2026-update-auto-label-flashcards),
+  [Workspace Updates, Sept 2025](https://workspaceupdates.googleblog.com/2025/09/flashcards-quizzes-reports-notebook-lm-google-education.html)).
+  Mitigation: ship Trajectory Contrast and the buffer-flush experience
+  *before* this happens — those rows are harder to bolt on after the fact.
+- **Khanmigo persists a per-learner graph** with state. Closes part of row 2
+  for the K-12 segment. Probability: low-medium. Mitigation: defend on the
+  evidence-weighted doctrine and on extraction-from-arbitrary-source (Khan
+  is curriculum-bound).
+- **RemNote ships in-session interleaving.** Closes row 4. Probability: low —
+  RemNote is rooted in Anki SM-2/FSRS scheduling and adding session
+  constraints would conflict with their existing model. Mitigation: ship the
+  buffer-flush nudge with a quality recommender so the experience is
+  load-bearing.
+- **A new entrant ships the loop.** This is the real risk. Probability:
+  unknowable. Mitigation: ship the loop's *felt* quality, document the
+  doctrine publicly, and accumulate distribution faster than the matrix
+  decays.
+
+---
+
+## What this doc is *not*
+
+- Not a single "novelty score." A scalar would hide the actionable signal,
+  which is per-mechanism.
+- Not a roadmap. It's the input layer to a roadmap.
+- Not a marketing claim. Don't quote rows in copy without re-checking the
+  matrix — competitor ship dates move.
+- Not authoritative on doctrine. `spec.md` and `evidence-weighted-map.md`
+  win on conflict.
+
+---
+
+## Sources
+
+Market state as of 2026-05-12:
+
+- [NotebookLM flashcards, quizzes, mastery tracking (Google Workspace Updates, Sept 2025)](https://workspaceupdates.googleblog.com/2025/09/flashcards-quizzes-reports-notebook-lm-google-education.html)
+- [NotebookLM April 2026 update (Pillitteri)](https://pasqualepillitteri.it/en/news/1391/notebooklm-april-2026-update-auto-label-flashcards)
+- [NotebookLM quizzes/flashcards 2026 analysis (Blockchain.News)](https://blockchain.news/ainews/google-notebooklm-quizzes-and-flashcards-upgrade-7-next-formats-to-build-now-2026-analysis)
+- [RemNote spaced repetition (FSRS + SM-2)](https://help.remnote.com/en/articles/9337171-understanding-spaced-repetition)
+- [RemNote 2026 review (ToolsVerse)](https://thetoolsverse.com/tools/remnote)
+- [Anki FSRS 2026 setup guide (SlideToAnki)](https://slidetoanki.com/blog/how-to-use-fsrs-anki-guide)
+- [FSRS technical explanation (Expertium)](https://expertium.github.io/Algorithm.html)
+- [Anki (Wikipedia)](https://en.wikipedia.org/wiki/Anki_(software))
+- [Khanmigo overview](https://www.khanmigo.ai/)
+- [Quizlet AI / Khanmigo / Wisdolia 2026 comparison (Pillitteri)](https://pasqualepillitteri.it/en/news/745/best-ai-apps-for-studying-2026-kiwi-chatgpt-notebooklm)
+- [Heptabase / Logseq / Obsidian PKM tools 2026 (Buildin)](https://buildin.ai/blog/best-second-brain-apps-2026)
+- [Spacing & interleaving systematic review (Springer, 2021)](https://link.springer.com/article/10.1007/s10648-021-09613-w)
+- [Illusion of competence in AI dependency (RSIS Int'l, 2025)](https://ideas.repec.org/a/bjc/journl/v12y2025i5p1725-1738.html)
+- [The illusion of learning (PubMed, 2025)](https://pubmed.ncbi.nlm.nih.gov/41212201/)
+- [Illusion of competence concept (Project Illuminated)](https://pressbooks.pub/illuminated/chapter/illusion-of-competence/)
+- [StudyCards AI on illusion of competence (marketing)](https://studycardsai.com/blog/illusions-of-competence-ai-flashcards)


### PR DESCRIPTION
Mechanism-by-mechanism scoring of Socratink against the 2026 study-tool
landscape (NotebookLM, RemNote, Anki/FSRS, Khanmigo, Quizlet, Heptabase,
etc.) with per-row implications for feature work — invest, table-stakes,
brand-only, or don't reinvent.

Headline: load-bearing mechanisms (three-phase loop, evidence-weighted
graph doctrine, causal-reconstruction rubric, in-session buffer flush,
trajectory contrast, repair reps, sparse-AI contract) are genuinely novel
in the market; surface layer (extraction, graph viz, SRS scheduling math,
AI flashcards) is commodity. Roadmap should match that shape.

Includes race-condition watchlist anchored to recent NotebookLM ship dates
so the doc earns its refresh cadence.