### PR TITLE
fix: improve repair-state concept view and gate checks

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,1 +1,8 @@
 agent: codex
+
+commands:
+  test: "bash scripts/no-mistakes-test.sh"
+  lint: "bash scripts/no-mistakes-lint.sh"
+
+ignore_patterns:
+  - "agents/superpowers/**"

--- a/agents/founder/WORKFLOWS/01-git-integration.md
+++ b/agents/founder/WORKFLOWS/01-git-integration.md
@@ -45,6 +45,8 @@ scripts/no-mistakes-finish-dev.sh       # after no-mistakes finishes
 scripts/git-worktree-cleanup.sh         # list stale worktrees
 scripts/git-worktree-cleanup.sh --json  # stable machine-readable worktree list
 scripts/git-worktree-cleanup.sh --remove-clean --apply
+scripts/no-mistakes-lint.sh             # reproduce configured no-mistakes lint command
+scripts/no-mistakes-test.sh             # reproduce configured no-mistakes test command
 scripts/git-founder-help.sh             # founder-facing command map
 scripts/git-founder-help.sh doctor      # read-only helper readiness check
 ```
@@ -70,6 +72,9 @@ scripts/git-founder-help.sh doctor      # read-only helper readiness check
 - when stale worktrees create session confusion, use `scripts/git-worktree-cleanup.sh` to list candidates and remove only clean registered worktrees with `--remove <path> --apply`
 - use the `--json` forms only for agents/scripts that need stable fields; founder-facing terminal usage should stay prose-first unless structured output is explicitly useful
 - use `scripts/git-founder-help.sh doctor` when shell shortcuts, hook installation, helper executability, or `no-mistakes` availability is suspect
+- `.no-mistakes.yaml` delegates gate `lint` and `test` to repo-owned wrappers and ignores `agents/superpowers/**`
+- `scripts/no-mistakes-lint.sh` bootstraps Python, sources test-safe auth/env defaults, runs `scripts/doctor.sh`, and runs `git diff --check` from the merge-base of `COMPARE_BRANCH` or `origin/dev`
+- `scripts/no-mistakes-test.sh` bootstraps Python, sources the same test-safe auth/env defaults, installs Node/Chromium coverage prerequisites, defaults `COMPARE_BRANCH` to `origin/dev` when available, and runs `scripts/check-coverage.sh`
 - push intent is revalidated on ack
 - raw `git push` is blocked without authorization artifact
 

--- a/docs/product/spec.md
+++ b/docs/product/spec.md
@@ -139,9 +139,12 @@ the concept page renders a post-reveal comparison on the same surface before
 expanding the full route margin. This comparison may show the learner's draft,
 the same-entry study note, and named gaps when recorded. It must not show
 score/tier/band, diagnose the learner, reveal future entries, or count as graph
-truth. The only comparison-exit action is `Keep working`, which writes
+truth. The normal comparison-exit action is `Keep working`, which writes
 UI-only acknowledgement state so return/reload can restore the expanded
-workspace; it does not append training evidence or imply progress.
+workspace; it does not append training evidence or imply progress. In the repair
+branch only, saving a repair record may also expand the workspace: the completed
+repair state hides the composer/helper/save controls and offers `Try from memory
+again`, without treating the repair as graph truth or progress.
 
 ---
 

--- a/docs/qa/gestalt-hybrid-launch-qa-prompt.md
+++ b/docs/qa/gestalt-hybrid-launch-qa-prompt.md
@@ -90,7 +90,10 @@ and the owner explicitly asks the agent to fix it.
 >    - The learner is not scored or diagnosed.
 >    - The `Keep working` action appears.
 > 10. Save a repair in the learner's own words.
-> 11. Click `Keep working`.
+> 11. Verify the completed-repair state:
+>     - The repair textarea is no longer visible.
+>     - The `Save repair` button is no longer visible.
+>     - The `Try from memory again` action appears.
 > 12. Verify the route expands, but remains truthful:
 >     - Current contract: future route entries are visible but inert until the
 >       learner reconstructs/repairs enough evidence to move.

--- a/docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md
+++ b/docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md
@@ -195,7 +195,7 @@ Before the first Cold attempt exists for the active source-less concept entry, q
 
 Route controls and the 2-column Route Margin Canvas are post-compare affordances, not merely post-attempt affordances. After the attempt is saved but before explicit study reveal, the learner remains in the one-column saved-draft study gate; route previews and route navigation must not let them skip reveal.
 
-Once study is explicitly revealed for that entry, render the immediate post-reveal comparison first. The layout may expand into the Route Margin Canvas only after the learner clicks `Keep working`, or later returns to an entry that already has a real recorded attempt, `study_revealed_at`, and persistent UI-only comparison acknowledgement. An unrevealed saved draft restores the one-column saved-draft study gate.
+Once study is explicitly revealed for that entry, render the immediate post-reveal comparison first. The layout may expand into the Route Margin Canvas after the learner clicks `Keep working`, after a repair record exists for the repair branch, or later returns to an entry that already has a real recorded attempt, `study_revealed_at`, and persistent UI-only comparison acknowledgement. An unrevealed saved draft restores the one-column saved-draft study gate.
 
 Legacy `primed`/`study` records with `attempts: []` preserve compatibility only and must not count as evidence for route-control unlock. They also must not be routed to the Cold attempt surface if `study_revealed_at` already exists, because the learner is no longer truly pre-study.
 
@@ -207,7 +207,7 @@ After the learner submits their first draft in Stage 1:
 3. After explicit reveal, show the study note/comparison on the same concept surface.
 4. Keep the learner in context; do not introduce a separate "Enter Concept Board" destination.
 5. Keep route markers inert through the immediate post-reveal comparison.
-6. Expand route-margin affordances from the same surface only when the learner clicks `Keep working`, or when the learner later returns with recorded attempt evidence, `study_revealed_at`, and persistent UI-only comparison acknowledgement.
+6. Expand route-margin affordances from the same surface when the learner clicks `Keep working`, when a repair record exists for the repair branch, or when the learner later returns with recorded attempt evidence, `study_revealed_at`, and persistent UI-only comparison acknowledgement.
 
 No session-level learning flag is needed. A persistent UI-only comparison acknowledgment is allowed only to preserve render continuity across reload/back navigation; it is not learning evidence. If the relevant training evidence exists and the comparison is no longer the immediate render target, returning to the concept restores the expanded route-margin workspace. If training evidence is reset, the cover/work surface naturally returns and the UI-only acknowledgment must be cleared or ignored.
 
@@ -233,15 +233,15 @@ The post-reveal comparison state must not show:
 
 Repair UI may appear in this state only when the derived entry `next_action` is `repair` after `study_revealed_at`. Missing-piece comparison is not itself a repair composer.
 
-Route affordances do not dismiss the immediate post-reveal comparison. If route markers are visible during comparison, they remain subordinate and inert. Full Route Margin Canvas expansion happens only when the learner clicks `Keep working`, or later returns to an entry with a real recorded attempt, `study_revealed_at`, and persistent UI-only comparison acknowledgement.
+Route affordances do not dismiss the immediate post-reveal comparison. If route markers are visible during comparison, they remain subordinate and inert. Full Route Margin Canvas expansion happens when the learner clicks `Keep working`, when a repair record exists for the repair branch, or later returns to an entry with a real recorded attempt, `study_revealed_at`, and persistent UI-only comparison acknowledgement.
 
-The learner leaves the immediate post-reveal comparison through one low-drama action: `Keep working`.
+The learner normally leaves the immediate post-reveal comparison through one low-drama action: `Keep working`. In the repair branch, saving a repair record is the only additional exit; it hides the composer/helper/save controls and keeps `Try from memory again` available.
 
 `Keep working` expands the same concept surface into the Route Margin Canvas. It is not a navigation gate, not a new destination, and not evidence of completion, mastery, progress, or route success.
 
 During the immediate post-reveal comparison state, route markers may be visible only as subordinate, noninteractive orientation. Do not render them as buttons, links, tabbable controls, or `data-entry-id` navigation targets in this state. Clicking a route marker must not be an alternate way to dismiss the comparison.
 
-After `Keep working`, the Route Margin Canvas may render normal route controls. Only traversal-allowed entries may be interactive; locked/future entries remain inert. The expanded workspace continues to derive all copy and actions from the training record and per-entry `next_action`.
+After expansion via `Keep working` or a repair record, the Route Margin Canvas may render normal route controls. Only traversal-allowed entries may be interactive; locked/future entries remain inert. The expanded workspace continues to derive all copy and actions from the training record and per-entry `next_action`.
 
 If the active entry derives `next_action === "repair"` after `study_revealed_at`, the post-reveal comparison must keep repair clearly available and strategy-framed. Before a repair is saved, show the repair composer. After a repair record exists, hide the composer/helper/save controls and offer `Try from memory again`. `Keep working` may expand the workspace, but it must not hide or demote the repair obligation behind generic navigation.
 
@@ -254,7 +254,7 @@ Forbidden copy: `Enter Concept Board`, `Continue the route`, `Complete`, `Done`,
 | Load -> Cold attempt surface | Source-less concept opens on active entry | `source_mode === "source_less"`; active record has zero real attempts and no `study_revealed_at` | concept name, learner Launch attempt as Starting sketch, provenance, one scaffold prompt, textarea, inert markers | `core_thesis`, mechanisms, study notes, statuses, nearby entries, clickable markers | none | no marker is tabbable/clickable; no `core_thesis` visible as sketch |
 | Cold submit -> Saved-draft gate | recordable drill result from inline attempt | latest real attempt persisted with exact `user_text`; no `study_revealed_at` | exact draft, neutral bridge, `Reveal notes and compare` | gaps, note, score/tier/band, route/status chrome, repair UI | append attempt only | reload restores saved gate, not workspace |
 | Saved gate -> Post-reveal comparison | learner clicks `Reveal notes and compare` | real attempt exists; `study_revealed_at` written | exact draft, same-entry study note, neutral compare copy, gaps only if present | "no missing piece", scores, future notes, route clicks, completion/progress | persist `study_revealed_at`; pass render-only `justRevealedEntryId` | immediate screen is comparison, not route canvas |
-| Comparison -> Expanded workspace | learner clicks `Keep working` | real attempt + `study_revealed_at`; comparison acknowledged in persistent UI-only state | Route Margin Canvas, traversal-gated route controls, repair primary if `next_action === "repair"` | route marker as alternate exit, `Continue the route`, mastery/progress copy | no training mutation; write/invalidate UI-only acknowledgement | before click markers inert; after click allowed controls work; reload/back restores workspace |
+| Comparison -> Expanded workspace | learner clicks `Keep working`, or saves a repair in the repair branch | real attempt + `study_revealed_at`; comparison acknowledged in persistent UI-only state or repair record exists | Route Margin Canvas, traversal-gated route controls, repair primary if `next_action === "repair"`, `Try from memory again` after repair record | route marker as alternate exit, `Continue the route`, mastery/progress copy, repair composer after a repair record exists | `Keep working`: no training mutation, write/invalidate UI-only acknowledgement; repair save: append repair only | before click/save markers inert; after click/save allowed controls work; reload/back restores workspace |
 | Legacy revealed/no-attempt -> Compatibility workspace | legacy source-less record has `study_revealed_at` but zero attempts | study boundary already crossed; no real attempt evidence | existing study surface without cold-attempt framing | cold attempt claim, route progress, mastery, route unlock from study alone | none | does not ask for a "cold" attempt after study reveal |
 | Expanded -> Repair / re-drill | save repair or later reconstruction | repair requires `study_revealed_at`; re-drill derives from spacing/evidence | repair composer before first repair, study reference, `Try from memory again` after repair record, later spaced attempt | `solidified` from study/repair, scores during active work, repair composer after a repair record exists | append repair or spaced attempt | only spaced strong reconstruction can derive `solidified` |
 
@@ -265,7 +265,7 @@ Before production edits, use `/prototype` with the UI branch:
 - Keep the question narrow: "Does the full state chain preserve the minimum remarkable loop without dashboard creep?"
 - Simulate the full chain: `Cold attempt -> saved-draft study gate -> Reveal notes and compare -> immediate comparison -> Keep working -> Route Margin Canvas`.
 - Include both branches: a no-gap attempt with no "no missing piece" verdict, and a gap/repair attempt where **Missing piece** is visible and repair remains clearly available.
-- Verify route markers are inert until `Keep working`, and that `Keep working` is the only comparison-exit action.
+- Verify route markers are inert until `Keep working` or repair save, and that repair save is the only comparison-exit exception.
 - Capture the verdict in a sibling `*.NOTES.md` before deleting or absorbing the prototype.
 
 When ready to implement, use `/codebaseGoalPlanner` to produce one reviewable `/goal` prompt for the bounded production slice. Do not let it expand the product scope; constrain it to the files and validation in this handoff.
@@ -293,7 +293,7 @@ Port the `.concept-page-b2__overview*` styles from the worktree's `public/css/co
 - **Do NOT show route previews during the saved-draft study gate.** After attempt save and before explicit reveal, keep the learner's draft as the object of attention.
 - **Do NOT skip the post-reveal comparison state.** Recording `study_revealed_at` must not immediately dump the learner into the full Route Margin Canvas.
 - **Do NOT render "no missing piece" as a verdict.** Absence of recorded gaps is not a mastery, correctness, or graph-truth claim.
-- **Do NOT let route marker clicks dismiss post-reveal comparison.** The only comparison-exit action is `Keep working`.
+- **Do NOT let route marker clicks dismiss post-reveal comparison.** The normal comparison-exit action is `Keep working`; repair save is the only exception.
 - **Do NOT use progress/completion copy for the comparison exit.** `Keep working` is allowed; `Continue the route`, `Complete`, `Done`, `Mastered`, and `Progress made` are not.
 - **Do NOT create a separate active-entry state variable.** Expanded route controls must reuse the existing `setActiveEntry()` path. Quiet pre-attempt/comparison markers are not route controls and must not use the route-item class, `data-entry-id`, or delegated route selectors.
 - **Do NOT use `extra="forbid"` on the Pydantic models.** This repo intentionally avoids that for Gemini-bound schemas.
@@ -305,7 +305,7 @@ Port the `.concept-page-b2__overview*` styles from the worktree's `public/css/co
 ## 5. Verification Plan
 
 1. **Unit tests:** Model validation, prompt contract assertions, pure renderer output.
-2. **Browser tests:** Cover/work surface appears before first attempt, pre-attempt route markers are visible but not clickable/focusable and cannot reveal future entry prompts, inline cold attempt persists through the drill evaluator path, the saved-draft study gate shows the learner's draft without route previews before study reveal, post-reveal comparison appears on the same surface only after explicit reveal without score/tier/band/no-gap verdicts, route markers cannot dismiss comparison, `Keep working` expands the workspace, reload/back preserves that expansion via UI-only acknowledgement, and route controls navigate to entries without a separate board gate only after real attempt evidence plus `study_revealed_at` plus comparison acknowledgement exists.
+2. **Browser tests:** Cover/work surface appears before first attempt, pre-attempt route markers are visible but not clickable/focusable and cannot reveal future entry prompts, inline cold attempt persists through the drill evaluator path, the saved-draft study gate shows the learner's draft without route previews before study reveal, post-reveal comparison appears on the same surface only after explicit reveal without score/tier/band/no-gap verdicts, route markers cannot dismiss comparison, `Keep working` expands the workspace, repair save expands only into completed-repair state, reload/back preserves that expansion via UI-only acknowledgement or repair record, and route controls navigate to entries without a separate board gate only after real attempt evidence plus `study_revealed_at` plus comparison acknowledgement or repair record exists.
 3. **Coverage gate:** `./scripts/check-coverage.sh` must pass (diff-level 100%).
 4. **Manual inspection:**
    - Create a source-less concept → see cover/work surface with the active cold-attempt writing task visible.
@@ -336,7 +336,7 @@ A follow-up customer/persona critique accepted the immediate writing box but rej
 - the cover is a work surface, not passive orientation
 - the cold-attempt writing task is primary
 - generated route/scaffold is restrained before the attempt
-- the route-margin board expands from the same concept surface only after explicit compare/reveal and `Keep working`
+- the route-margin board expands from the same concept surface only after explicit compare/reveal and `Keep working`, or after a repair record exists for the repair branch
 - no separate overview prompt/schema unless absolutely required
 
 ### Vault Context Check
@@ -347,7 +347,7 @@ High-signal vault findings that reinforce this handoff:
 - **Training evidence surface binding:** visible state surfaces must derive learner-facing truth from `socratink:training:v1:<conceptId>`, not legacy shell state. This supports keeping comparison acknowledgement UI-only and keeping graph truth tied to attempts, repair, and spaced re-drill evidence.
 - **Finished-loop demo:** first-session clarity depends on showing what the learner supplies, what Socratink transforms, and what evidence returns to the map. This supports the self-contained loop shape: learner draft -> targeted comparison -> continued route work, without an "Enter Concept Board" dashboard step.
 - **Tiny Repair Rep floor:** Repair Reps are optional typed micro-practice after a visible gap; they never unlock graph progress, spacing credit, scores, completion, mastery, or `solidified`. This supports showing repair only after study reveal when `next_action === "repair"`, while keeping repair separate from the comparison itself.
-- **Surface leverage map:** Provisional map / Route Margin work must make structure inspectable without implying knowledge, mastery, completion, or diagnostic certainty. This supports inert pre-attempt markers and traversal-gated route controls only after `Keep working`.
+- **Surface leverage map:** Provisional map / Route Margin work must make structure inspectable without implying knowledge, mastery, completion, or diagnostic certainty. This supports inert pre-attempt markers and traversal-gated route controls only after `Keep working` or a repair record.
 
 No new runtime feature is promoted from the vault check. The accepted move is contract tightening only: preserve the minimum loop, keep Repair Reps graph-neutral, and verify the visible surfaces against training-derived evidence.
 

--- a/docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md
+++ b/docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md
@@ -54,7 +54,7 @@ Stage 3: EXPANDED WORKSPACE (ongoing concept work after comparison is acknowledg
 
 ### On `dev` HEAD (the implementation target)
 
-- **2-column layout** in `renderActiveEntryHtml()` → wraps output in `.concept-page-b2__gestalt` with `grid-template-columns: minmax(150px, 220px) minmax(0, 1fr)`.
+- **Route-aware layout** in `renderActiveEntryHtml()` → wraps output in `.concept-page-b2__gestalt` with the 2-column Route Margin Canvas by default, and adds `.concept-page-b2__gestalt--single-column` when saved-draft and post-reveal comparison states hide route/nearby UI.
 - **Route Margin sidebar** rendered by `renderRouteMarginHtml()` in `concept-page-view.js`.
 - **Constellation graph toggle** in `concept-constellation-view.js`, wired via `#concept-view-switch` in `app.js`.
 - **`renderConceptPageB2()`** in `app.js` (line ~2356) is the top-level mount function. It calls `renderActiveEntryHtml()` and sets `mountEl.innerHTML`.
@@ -243,7 +243,7 @@ During the immediate post-reveal comparison state, route markers may be visible 
 
 After `Keep working`, the Route Margin Canvas may render normal route controls. Only traversal-allowed entries may be interactive; locked/future entries remain inert. The expanded workspace continues to derive all copy and actions from the training record and per-entry `next_action`.
 
-If the active entry derives `next_action === "repair"` after `study_revealed_at`, the post-reveal comparison must keep repair clearly available and strategy-framed. `Keep working` may expand the workspace, but it must not hide or demote the repair obligation behind generic navigation.
+If the active entry derives `next_action === "repair"` after `study_revealed_at`, the post-reveal comparison must keep repair clearly available and strategy-framed. Before a repair is saved, show the repair composer. After a repair record exists, hide the composer/helper/save controls and offer `Try from memory again`. `Keep working` may expand the workspace, but it must not hide or demote the repair obligation behind generic navigation.
 
 Forbidden copy: `Enter Concept Board`, `Continue the route`, `Complete`, `Done`, `Mastered`, `Progress made`, or any label implying that reading the study note changed graph truth.
 
@@ -256,7 +256,7 @@ Forbidden copy: `Enter Concept Board`, `Continue the route`, `Complete`, `Done`,
 | Saved gate -> Post-reveal comparison | learner clicks `Reveal notes and compare` | real attempt exists; `study_revealed_at` written | exact draft, same-entry study note, neutral compare copy, gaps only if present | "no missing piece", scores, future notes, route clicks, completion/progress | persist `study_revealed_at`; pass render-only `justRevealedEntryId` | immediate screen is comparison, not route canvas |
 | Comparison -> Expanded workspace | learner clicks `Keep working` | real attempt + `study_revealed_at`; comparison acknowledged in persistent UI-only state | Route Margin Canvas, traversal-gated route controls, repair primary if `next_action === "repair"` | route marker as alternate exit, `Continue the route`, mastery/progress copy | no training mutation; write/invalidate UI-only acknowledgement | before click markers inert; after click allowed controls work; reload/back restores workspace |
 | Legacy revealed/no-attempt -> Compatibility workspace | legacy source-less record has `study_revealed_at` but zero attempts | study boundary already crossed; no real attempt evidence | existing study surface without cold-attempt framing | cold attempt claim, route progress, mastery, route unlock from study alone | none | does not ask for a "cold" attempt after study reveal |
-| Expanded -> Repair / re-drill | save repair or later reconstruction | repair requires `study_revealed_at`; re-drill derives from spacing/evidence | repair composer, study reference, later spaced attempt | `solidified` from study/repair, scores during active work | append repair or spaced attempt | only spaced strong reconstruction can derive `solidified` |
+| Expanded -> Repair / re-drill | save repair or later reconstruction | repair requires `study_revealed_at`; re-drill derives from spacing/evidence | repair composer before first repair, study reference, `Try from memory again` after repair record, later spaced attempt | `solidified` from study/repair, scores during active work, repair composer after a repair record exists | append repair or spaced attempt | only spaced strong reconstruction can derive `solidified` |
 
 ### 3f. Prototype and Goal Workflow
 

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -432,6 +432,9 @@
     0 18px 44px rgba(var(--ink-900-rgb), 0.08),
     inset 0 1px 0 rgba(255, 255, 255, 0.62);
 }
+.concept-page-b2__gestalt--single-column {
+  grid-template-columns: minmax(0, 1fr);
+}
 [data-theme="dark"] .concept-page-b2__gestalt {
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.055), rgba(144, 103, 198, 0.08)),

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=118'     layer(components);
+@import '../styles.css?v=119'     layer(components);
 @import '../antigravity.css?v=28' layer(legacy);
 @import 'paper.css?v=11'          layer(paper);

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=120">
+  <link rel="stylesheet" href="/css/index.css?v=121">
   <link rel="stylesheet" href="css/drill-chamber.css?v=5">
 </head>
 

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -792,8 +792,10 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     `
     : '';
 
+  const gestaltClass = `concept-page-b2__gestalt${hidesRouteAndNearby ? ' concept-page-b2__gestalt--single-column' : ''}`;
+
   return `
-    <section class="concept-page-b2__gestalt" aria-label="Concept gestalt canvas">
+    <section class="${gestaltClass}" aria-label="Concept gestalt canvas">
       ${hidesRouteAndNearby ? '' : renderRouteMarginHtml(backbone, activeIdx, training, {
         ...options,
         interactive: !showsOnlyQuietRoute,

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -484,20 +484,14 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId) {
     : '';
   const gapCount = gaps.length;
   const gapCountText = `${gapCount} missing ${gapCount === 1 ? 'link' : 'links'} to repair`;
-  return `
-    <section class="concept-page-b2__repair" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link">
-      <span class="eyebrow concept-page-b2__repair-eyebrow">Put it in your words</span>
-      <h3>Write the missing link</h3>
-      <p class="concept-page-b2__repair-summary">${escHtml(gapCountText)}</p>
-      <p class="concept-page-b2__repair-helper">Save this repair before you try from memory again.</p>
-      <ul class="concept-page-b2__repair-gaps">
-        ${gaps.map((gap, index) => `
-          <li>
-            <strong>${escHtml(repairGapTitle(gap, index))}</strong>
-            <span>${escHtml(repairGapCorrection(gap))}</span>
-          </li>
-        `).join('')}
-      </ul>
+
+  const helperHtml = repairs.length
+    ? ''
+    : `<p class="concept-page-b2__repair-helper">Save this repair before you try from memory again.</p>`;
+
+  const inputFormHtml = repairs.length
+    ? ''
+    : `
       <textarea
         class="concept-page-b2__repair-input"
         data-repair-entry-id="${escHtml(entryId)}"
@@ -508,6 +502,23 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId) {
       ></textarea>
       <p class="concept-page-b2__repair-error" data-repair-error hidden>Write the missing link before saving.</p>
       <button class="concept-page-b2__repair-save" type="button" data-repair-entry-id="${escHtml(entryId)}">Save repair</button>
+    `;
+
+  return `
+    <section class="concept-page-b2__repair" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link">
+      <span class="eyebrow concept-page-b2__repair-eyebrow">Put it in your words</span>
+      <h3>Write the missing link</h3>
+      <p class="concept-page-b2__repair-summary">${escHtml(gapCountText)}</p>
+      ${helperHtml}
+      <ul class="concept-page-b2__repair-gaps">
+        ${gaps.map((gap, index) => `
+          <li>
+            <strong>${escHtml(repairGapTitle(gap, index))}</strong>
+            <span>${escHtml(repairGapCorrection(gap))}</span>
+          </li>
+        `).join('')}
+      </ul>
+      ${inputFormHtml}
       ${nextAttemptButton}
     </section>
   `;

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,4 +6,4 @@
 @import './css/board-first.css?v=4';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';
-@import './css/concept-page.css?v=22';
+@import './css/concept-page.css?v=23';

--- a/scripts/no-mistakes-env.sh
+++ b/scripts/no-mistakes-env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+_no_mistakes_generate_session_key() {
+  local python_bin="${PYTHON_BIN:-python}"
+  if ! command -v "$python_bin" >/dev/null 2>&1; then
+    python_bin="python3"
+  fi
+  "$python_bin" -c 'import os, base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+}
+
+export AUTH_ENABLED="${AUTH_ENABLED:-true}"
+export SUPABASE_URL="${SUPABASE_URL:-https://example.supabase.co}"
+export SUPABASE_PUBLISHABLE_KEY="${SUPABASE_PUBLISHABLE_KEY:-dummy-publishable-key}"
+export SUPABASE_JWT_SECRET="${SUPABASE_JWT_SECRET:-dummy-jwt-secret}"
+export APP_BASE_URL="${APP_BASE_URL:-http://localhost:8000}"
+export SOCRATINK_BASE_URL="${SOCRATINK_BASE_URL:-http://localhost:8000}"
+export SOCRATINK_DEV_AUTOGUEST="${SOCRATINK_DEV_AUTOGUEST:-0}"
+export SOCRATINK_E2E_LOCAL_GUEST="${SOCRATINK_E2E_LOCAL_GUEST:-1}"
+export GEMINI_API_KEY="${GEMINI_API_KEY:-dummy-for-tests}"
+export GITHUB_ACTIONS="${GITHUB_ACTIONS:-true}"
+
+if [ -z "${SESSION_COOKIE_KEY:-}" ]; then
+  export SESSION_COOKIE_KEY="$(_no_mistakes_generate_session_key)"
+else
+  export SESSION_COOKIE_KEY
+fi

--- a/scripts/no-mistakes-lint.sh
+++ b/scripts/no-mistakes-lint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+resolve_no_mistakes_compare_ref() {
+  if [ -n "${COMPARE_BRANCH:-}" ]; then
+    if git rev-parse --verify --quiet "$COMPARE_BRANCH" >/dev/null; then
+      printf '%s\n' "$COMPARE_BRANCH"
+      return 0
+    fi
+    printf 'no-mistakes-lint.sh: COMPARE_BRANCH is not a valid git ref: %s\n' "$COMPARE_BRANCH" >&2
+    return 1
+  fi
+
+  if git rev-parse --verify --quiet origin/dev >/dev/null; then
+    printf '%s\n' "origin/dev"
+    return 0
+  fi
+
+  printf 'no-mistakes-lint.sh: no valid compare ref (tried COMPARE_BRANCH, origin/dev)\n' >&2
+  return 1
+}
+
+resolve_no_mistakes_diff_base() {
+  local compare_ref
+  compare_ref="$(resolve_no_mistakes_compare_ref)"
+  git merge-base "$compare_ref" HEAD
+}
+
+run_no_mistakes_diff_check() {
+  local diff_base="$1"
+  git diff --check "$diff_base" HEAD
+}
+
+main() {
+  set -euo pipefail
+
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  cd "$repo_root"
+
+  bash scripts/bootstrap-python.sh
+  source scripts/no-mistakes-env.sh
+
+  bash scripts/doctor.sh
+
+  local diff_base
+  diff_base="$(resolve_no_mistakes_diff_base)"
+  run_no_mistakes_diff_check "$diff_base"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/no-mistakes-test.sh
+++ b/scripts/no-mistakes-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+bash scripts/bootstrap-python.sh
+source scripts/no-mistakes-env.sh
+
+npm ci
+.venv/bin/playwright install chromium
+
+if [ -z "${COMPARE_BRANCH:-}" ] && git rev-parse --verify --quiet origin/dev >/dev/null; then
+  export COMPARE_BRANCH="origin/dev"
+fi
+
+bash scripts/check-coverage.sh

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -2133,6 +2133,9 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(!repairedHtml.includes('Write it again'));
         assert.ok(repairedHtml.includes('concept-page-b2__repair'));
         assert.ok(repairedHtml.includes('Try from memory again'));
+        assert.ok(!repairedHtml.includes('concept-page-b2__repair-input'));
+        assert.ok(!repairedHtml.includes('concept-page-b2__repair-save'));
+        assert.ok(!repairedHtml.includes('Save this repair before you try from memory again.'));
 
         const stripHtml = renderConceptStripHtml(backbone, backbone[1], 1, training);
         assert.ok(stripHtml.includes('class="concept-strip"'));

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1365,6 +1365,7 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(!savedHtml.includes('Missing piece'));
         assert.ok(!savedHtml.includes('threshold as the opening condition'));
         assert.ok(!savedHtml.includes('concept-page-b2__route'));
+        assert.ok(savedHtml.includes('concept-page-b2__gestalt--single-column'));
         assert.ok(!savedHtml.includes('concept-page-b2__nearby'));
 
         const cleanRevealedTraining = {
@@ -1400,6 +1401,7 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(compareHtml.includes('data-active-entry-action="keep-working"'));
         assert.ok(!compareHtml.includes('No missing piece recorded for this draft.'));
         assert.ok(!compareHtml.includes('concept-page-b2__route-item'));
+        assert.ok(compareHtml.includes('concept-page-b2__gestalt--single-column'));
         assert.ok(!compareHtml.includes('data-entry-id="spread"'));
         assert.ok(!compareHtml.includes('concept-page-b2__nearby'));
 

--- a/tests/test_no_mistakes_config.py
+++ b/tests/test_no_mistakes_config.py
@@ -1,0 +1,146 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG = REPO_ROOT / ".no-mistakes.yaml"
+ENV_SCRIPT = REPO_ROOT / "scripts" / "no-mistakes-env.sh"
+TEST_SCRIPT = REPO_ROOT / "scripts" / "no-mistakes-test.sh"
+LINT_SCRIPT = REPO_ROOT / "scripts" / "no-mistakes-lint.sh"
+
+
+def _run(
+    args: list[str],
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=merged_env,
+    )
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = _run(["git", *args], repo)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    _run(["git", "init", "-b", "dev", str(repo)], tmp_path)
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def test_no_mistakes_config_uses_repo_wrapper_commands() -> None:
+    text = CONFIG.read_text(encoding="utf-8")
+
+    assert 'test: "bash scripts/no-mistakes-test.sh"' in text
+    assert 'lint: "bash scripts/no-mistakes-lint.sh"' in text
+    assert "format:" not in text
+    assert 'agents/superpowers/**' in text
+
+
+def test_no_mistakes_scripts_are_executable() -> None:
+    for script in (ENV_SCRIPT, TEST_SCRIPT, LINT_SCRIPT):
+        mode = script.stat().st_mode
+        assert mode & stat.S_IXUSR, f"{script} must be user-executable"
+
+
+def test_no_mistakes_env_preserves_existing_values() -> None:
+    result = _run(
+        [
+            "bash",
+            "-c",
+            (
+                "source scripts/no-mistakes-env.sh; "
+                "printf '%s\\n' "
+                "\"$AUTH_ENABLED\" "
+                "\"$SUPABASE_URL\" "
+                "\"$SESSION_COOKIE_KEY\" "
+                "\"$SOCRATINK_E2E_LOCAL_GUEST\""
+            ),
+        ],
+        REPO_ROOT,
+        {
+            "AUTH_ENABLED": "false",
+            "SUPABASE_URL": "https://real.example",
+            "SESSION_COOKIE_KEY": "keep-this-key",
+            "SOCRATINK_E2E_LOCAL_GUEST": "0",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "false",
+        "https://real.example",
+        "keep-this-key",
+        "0",
+    ]
+
+
+def test_no_mistakes_env_uses_test_safe_guest_defaults() -> None:
+    result = _run(
+        [
+            "bash",
+            "-c",
+            (
+                "unset GITHUB_ACTIONS SOCRATINK_DEV_AUTOGUEST SOCRATINK_E2E_LOCAL_GUEST; "
+                "source scripts/no-mistakes-env.sh; "
+                "printf '%s\\n' "
+                "\"$GITHUB_ACTIONS\" "
+                "\"$SOCRATINK_DEV_AUTOGUEST\" "
+                "\"$SOCRATINK_E2E_LOCAL_GUEST\""
+            ),
+        ],
+        REPO_ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["true", "0", "1"]
+
+
+def test_no_mistakes_lint_diff_check_uses_compare_branch_merge_base(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "origin/dev")
+    (repo / "remote.txt").write_text("remote\n", encoding="utf-8")
+    _git(repo, "add", "remote.txt")
+    _git(repo, "commit", "-m", "remote work")
+    _git(repo, "checkout", "dev")
+    (repo / "local.txt").write_text("bad trailing whitespace \n", encoding="utf-8")
+    _git(repo, "add", "local.txt")
+    _git(repo, "commit", "-m", "local whitespace")
+
+    result = _run(
+        [
+            "bash",
+            "-c",
+            (
+                f"source {LINT_SCRIPT}; "
+                "base=$(resolve_no_mistakes_diff_base); "
+                "run_no_mistakes_diff_check \"$base\""
+            ),
+        ],
+        repo,
+        {"COMPARE_BRANCH": "origin/dev"},
+    )
+
+    assert result.returncode != 0
+    assert "trailing whitespace" in result.stdout
+    assert "remote.txt" not in result.stdout

--- a/tests/test_no_mistakes_config.py
+++ b/tests/test_no_mistakes_config.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import stat
 import subprocess
 from pathlib import Path
@@ -118,6 +119,8 @@ def test_no_mistakes_lint_diff_check_uses_compare_branch_merge_base(
     tmp_path: Path,
 ) -> None:
     repo = _init_repo(tmp_path)
+    spaced_script = tmp_path / "lint wrapper with spaces.sh"
+    spaced_script.symlink_to(LINT_SCRIPT)
     _git(repo, "checkout", "-b", "origin/dev")
     (repo / "remote.txt").write_text("remote\n", encoding="utf-8")
     _git(repo, "add", "remote.txt")
@@ -132,7 +135,7 @@ def test_no_mistakes_lint_diff_check_uses_compare_branch_merge_base(
             "bash",
             "-c",
             (
-                f"source {LINT_SCRIPT}; "
+                f"source {shlex.quote(str(spaced_script))}; "
                 "base=$(resolve_no_mistakes_diff_base); "
                 "run_no_mistakes_diff_check \"$base\""
             ),


### PR DESCRIPTION
## Intent

The transcript is irrelevant or empty for determining a developer goal, because it contains only environment instructions and an interruption marker without a substantive user request.

## What Changed
- Updated the concept page repair flow so hidden-route/saved-draft and post-reveal repair states use a single-column expanded workspace, and completed repairs hide the composer/save controls while showing the retry affordance.
- Added repo-owned no-mistakes gate configuration and wrapper scripts for env setup, lint, and test execution, with coverage for the new config contract.
- Brought the product spec, QA prompt, workflow handoff, and git integration docs in line with the repaired expansion state and no-mistakes gate behavior.

## Risk Assessment

✅ Low: The branch changes are narrowly scoped to gate wrapper scripts/config and small concept-page rendering/layout fixes, with no substantiated correctness, security, or behavior regressions found in the changed code paths.

## Testing

- `bash scripts/no-mistakes-test.sh`
- Outcome: ✅ passed across 1 run (2m23s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `bash scripts/no-mistakes-test.sh`

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

**Round 1** - found 1 warning
- ⚠️ `agents/founder/WORKFLOWS/01-git-integration.md:35` - The no-mistakes gate now has repo-owned `lint` and `test` commands in `.no-mistakes.yaml`, backed by new wrapper scripts that set test-safe auth/env defaults, choose `origin/dev` as the default compare ref, run `doctor.sh`, `git diff --check`, `npm ci`, Playwright Chromium install, and the full diff-coverage gate. The canonical no-mistakes workflow docs still describe only publish/attach/finish behavior, so they do not tell agents or the founder what the gate actually executes or how to reproduce/interpret failures from the configured commands.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md:57` - The handoff still describes `renderActiveEntryHtml()` on current `dev` as always producing the 2-column `.concept-page-b2__gestalt` grid. The change now adds `.concept-page-b2__gestalt--single-column` for hidden-route states, and tests assert the saved-draft and post-reveal comparison renders use that single-column class. Update this implementation-truth section so agents do not treat the 2-column route margin as the only current render shape.
- ⚠️ `docs/qa/gestalt-hybrid-launch-qa-prompt.md:92` - The manual QA prompt says to save a repair and then click `Keep working`, but the changed repair panel behavior hides the completed repair form and exposes `Try from memory again` after a repair record exists. Update the walkthrough to verify the completed-repair state, including the absence of the repair textarea/save button and the `Try from memory again` affordance, instead of instructing testers to click `Keep working` after saving repair.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `docs/product/spec.md:142` - The spec still states that the only post-reveal comparison exit is `Keep working`. The current repair path now has a completed-repair state: after a repair record exists, the repair composer/save controls are hidden, `Try from memory again` is shown, and the source-less view can render the expanded workspace via the repair-record path rather than only through comparison acknowledgement. Update this section to document the repair-save exception without implying the repair mutates graph truth or progress.
- ⚠️ `docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md:236` - This handoff still describes full Route Margin Canvas expansion as happening only after `Keep working` or later return with comparison acknowledgement, and the seam table only lists `Keep working` as the comparison-to-expanded trigger. The changed repair contract now documents and tests a completed-repair state where the composer/helper/save controls disappear and `Try from memory again` appears; the route can expand after that repair record exists. Update the narrative and seam table so agents do not preserve a stale Keep-working-only expansion rule for the repair branch.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `docs/superpowers/plans/2026-05-21-gestalt-hybrid-handoff.md:35` - The high-level handoff still frames expanded workspace as happening after comparison acknowledgement / `Keep working`, and the manual inspection checklist only covers the `Keep working` path. The code now derives `expanded-workspace` when a repair record exists, and the completed-repair UI hides the composer/save controls while showing `Try from memory again`. Update the stage summary/key constraint/manual inspection bullets to include the repair-save expansion path so this active handoff is consistent with the updated spec and seam table.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
