### PR TITLE
Proxy /loop to Railway loop host

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,26 @@
   },
   "rewrites": [
     {
+      "source": "/loop",
+      "destination": "https://loop-production-07a3.up.railway.app/loop"
+    },
+    {
+      "source": "/loop/:path*",
+      "destination": "https://loop-production-07a3.up.railway.app/loop/:path*"
+    },
+    {
+      "source": "/health",
+      "destination": "https://loop-production-07a3.up.railway.app/health"
+    },
+    {
+      "source": "/api/session",
+      "destination": "https://loop-production-07a3.up.railway.app/api/session"
+    },
+    {
+      "source": "/api/session/:path*",
+      "destination": "https://loop-production-07a3.up.railway.app/api/session/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/api/index.py"
     }


### PR DESCRIPTION
## Summary
- Add Vercel rewrites so `app.socratink.ai/loop` proxies to the faithful SEDA loop on Railway (`loop-production-07a3.up.railway.app`)
- Includes `/health` (version/LLM pills) and `/api/session/*` (chat turns) before the FastAPI catch-all

## Test plan
- [ ] Merge and wait for Vercel production deploy
- [ ] `curl -s https://app.socratink.ai/health | jq .` → `app_version`, `gemini_configured: true`
- [ ] Open `https://app.socratink.ai/loop` — version pill not "health unreachable"
- [ ] Full session: concept → map → cold → `/exit`
- [ ] No nav link yet (unlisted dogfood URL)


Made with [Cursor](https://cursor.com)