### PR TITLE
Consolidate loop proxy on LOOP_BACKEND_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,8 @@ LEARNING_COMMONS_API_KEY=
 # or set SOCRATINK_LOCAL_AUTH_BYPASS=0, for prod parity locally.
 SOCRATINK_LOCAL_AUTH_BYPASS=
 SOCRATINK_DEV_AUTOGUEST=
+# Source-less loop (Railway loop-server). Required for /loop drawer link and
+# proxied /health + /api/session/* routes. Set on Vercel production before
+# removing any legacy Vercel edge rewrites for those paths.
+# Example: https://loop-production-07a3.up.railway.app
+LOOP_BACKEND_URL=

--- a/vercel.json
+++ b/vercel.json
@@ -9,26 +9,6 @@
   },
   "rewrites": [
     {
-      "source": "/loop",
-      "destination": "https://loop-production-07a3.up.railway.app/loop"
-    },
-    {
-      "source": "/loop/:path*",
-      "destination": "https://loop-production-07a3.up.railway.app/loop/:path*"
-    },
-    {
-      "source": "/health",
-      "destination": "https://loop-production-07a3.up.railway.app/health"
-    },
-    {
-      "source": "/api/session",
-      "destination": "https://loop-production-07a3.up.railway.app/api/session"
-    },
-    {
-      "source": "/api/session/:path*",
-      "destination": "https://loop-production-07a3.up.railway.app/api/session/:path*"
-    },
-    {
       "source": "/(.*)",
       "destination": "/api/index.py"
     }


### PR DESCRIPTION
## Summary
- Remove Vercel edge rewrites for `/loop`, `/health`, `/api/session/*` from `vercel.json`
- Document `LOOP_BACKEND_URL` in `.env.example`
- Production already has `LOOP_BACKEND_URL` set on Vercel; FastAPI `loop_backend_proxy.py` becomes the single proxy path

## Test plan
- [x] `pytest tests/test_loop_backend_proxy.py -q` (3 pass)
- [ ] After merge + deploy, verify:
  ```bash
  curl -s https://app.socratink.ai/health | jq .
  curl -s https://app.socratink.ai/api/health | jq .
  curl -s -X POST https://app.socratink.ai/api/session | jq .sessionId
  ```


Made with [Cursor](https://cursor.com)