### PR TITLE
fix(proxy): strip encoded loop headers

### DIFF
--- a/loop_backend_proxy.py
+++ b/loop_backend_proxy.py
@@ -23,6 +23,9 @@ _HOP_BY_HOP = frozenset(
     }
 )
 
+_REQUEST_HEADER_DENYLIST = _HOP_BY_HOP | {"accept-encoding"}
+_RESPONSE_HEADER_DENYLIST = _HOP_BY_HOP | {"content-encoding"}
+
 _POOL = urllib3.PoolManager()
 
 
@@ -40,7 +43,7 @@ def _forward_headers(request: Request) -> dict[str, str]:
     headers: dict[str, str] = {}
     for key, value in request.headers.items():
         lowered = key.lower()
-        if lowered in _HOP_BY_HOP:
+        if lowered in _REQUEST_HEADER_DENYLIST:
             continue
         headers[key] = value
     return headers
@@ -50,7 +53,7 @@ def _response_headers(upstream: Mapping[str, str]) -> dict[str, str]:
     return {
         key: value
         for key, value in upstream.items()
-        if key.lower() not in _HOP_BY_HOP
+        if key.lower() not in _RESPONSE_HEADER_DENYLIST
     }
 
 

--- a/tests/test_loop_backend_proxy.py
+++ b/tests/test_loop_backend_proxy.py
@@ -29,7 +29,7 @@ def test_loop_proxy_returns_503_when_backend_unconfigured(client: TestClient) ->
 def test_loop_proxy_forwards_to_configured_backend(client: TestClient) -> None:
     upstream = MagicMock()
     upstream.status = 200
-    upstream.headers = {"content-type": "text/html"}
+    upstream.headers = {"content-type": "text/html", "content-encoding": "gzip"}
     upstream.read.return_value = b"<p>loop</p>"
     upstream.release_conn = MagicMock()
 
@@ -41,9 +41,30 @@ def test_loop_proxy_forwards_to_configured_backend(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.text == "<p>loop</p>"
+    assert "content-encoding" not in response.headers
     request.assert_called_once()
     assert request.call_args[0][1] == "https://loop.example/loop?q=1"
     upstream.release_conn.assert_called_once()
+
+
+def test_loop_proxy_does_not_forward_accept_encoding(client: TestClient) -> None:
+    upstream = MagicMock()
+    upstream.status = 200
+    upstream.headers = {"content-type": "application/json"}
+    upstream.read.return_value = b'{"status":"ok"}'
+    upstream.release_conn = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"LOOP_BACKEND_URL": "https://loop.example"}, clear=False),
+        patch("loop_backend_proxy._POOL.request", return_value=upstream) as request,
+    ):
+        response = client.get("/health", headers={"Accept-Encoding": "gzip, deflate, br"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    headers = request.call_args.kwargs["headers"]
+    assert "Accept-Encoding" not in headers
+    assert "accept-encoding" not in {key.lower() for key in headers}
 
 
 def test_loop_proxy_releases_connection_when_read_fails(client: TestClient) -> None:


### PR DESCRIPTION
## Context & Intent
- Salvages the one loadbearing proxy slice from codex/loop-proxy-encoding-rescue.
- The current proxy forwards Accept-Encoding and can return stale Content-Encoding after reading/decompressing upstream content, which can confuse browser clients.

## Implementation Details
- Drops request Accept-Encoding before proxying to the loop backend.
- Drops response Content-Encoding before returning proxied content.
- Adds focused loop backend proxy coverage.

## MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No.
- [x] Are there SSRF or error leakage risks in new external calls? No new external call surface.
- [x] If dealing with ingestion, is the manual fallback preserved? Not applicable.

## UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce Generation Before Recognition? Not learner-surface behavior.
- [x] Does the graph still tell the truth? Not graph behavior.
- [x] Is the active cognitive target explicitly clear to the user? Not UI behavior.

Verification:
- .venv/bin/pytest tests/test_loop_backend_proxy.py -q