### PR TITLE
feat: expose safe learning loop

### DIFF
--- a/auth/router.py
+++ b/auth/router.py
@@ -827,6 +827,7 @@ def load_current_session_state(request: Request) -> AuthSessionState:
 def get_current_user(request: Request) -> Response:
     state = load_current_session_state(request)
     payload = state.to_public_dict()
+    payload["loop_available"] = bool(os.environ.get("LOOP_BACKEND_URL", "").strip())
     client_host = request.client.host if request.client else None
     payload["dev_mode"] = local_auth_bypass_enabled(
         hostname=request.url.hostname,

--- a/docs/adr/0001-provisional-map-typed-contract.md
+++ b/docs/adr/0001-provisional-map-typed-contract.md
@@ -21,7 +21,7 @@ The model enforces structural integrity at parse time:
 
 The route maps any `ValueError` raised by these general validators to HTTP 422 — the structural shape is wrong, retrying won't help.
 
-Smallest-route generation adds a stricter profile outside the general model: `learner_scaffold` is optional on `Subnode` so extracted source-backed maps remain valid, but `_validate_smallest_route` rejects generated source-less routes whose subnodes omit it or whose scaffold fields copy a substantial hidden mechanism phrase. Those `SmallestRouteCapExceeded` failures are generation-side shape failures returned as HTTP 500 with `smallest_route_cap_exceeded`, not client-input 422s.
+Smallest-route generation adds a stricter profile outside the general model: `learner_scaffold` is optional on `Subnode` so extracted source-backed maps remain valid, but `_validate_smallest_route` rejects generated source-less routes whose subnodes omit it or whose scaffold fields copy a substantial hidden mechanism phrase. On the source-less learner path, those `SmallestRouteCapExceeded` failures recover to a one-entry sketch-grounded route so the learner is not stranded. Non-source-less cap failures remain generation-side shape failures returned as HTTP 500 with `smallest_route_cap_exceeded`, not client-input 422s.
 
 `extra="forbid"` is intentionally **not** set. Pydantic emits `additionalProperties: false` in the JSON Schema when `extra="forbid"` is configured, and Gemini's `response_schema` parameter rejects schemas containing it. Field-level correctness is governed by the prompt + the closure validators above. See `parse_repair_reps_response` in `models/repair_reps.py` for the same precedent.
 

--- a/main.py
+++ b/main.py
@@ -47,6 +47,15 @@ from llm.errors import (
     LLMServiceError,
     LLMValidationError,
 )
+from models.provisional_map import (
+    BackboneItem,
+    Cluster,
+    LearnerScaffold,
+    Metadata,
+    ProvisionalMap,
+    Relationships,
+    Subnode,
+)
 import source_intake
 from loop_backend_proxy import proxy_loop_backend
 from source_intake import (
@@ -358,6 +367,70 @@ def _resolve_extract_path(req: "ExtractRequest") -> dict:
     }
 
 
+def _fallback_smallest_route_from_sketch(
+    *, concept: str, threshold: str, learner_goal: str | None = None
+) -> ProvisionalMap:
+    anchor = "You named parts in your sketch; start by connecting two of them."
+    if learner_goal:
+        anchor = "Use your goal and sketch, then connect two named parts."
+    return ProvisionalMap(
+        metadata=Metadata(
+            source_title=concept,
+            core_thesis=concept,
+            architecture_type="causal_chain",
+            difficulty="medium",
+            governing_assumptions=[
+                "This fallback route is grounded only in the learner's sketch.",
+                "Study content should stay hidden until the learner reconstructs first.",
+            ],
+            low_density=True,
+        ),
+        backbone=[
+            BackboneItem(
+                id="b1",
+                principle="Starting model",
+                dependent_clusters=["c1"],
+            )
+        ],
+        clusters=[
+            Cluster(
+                id="c1",
+                label="Starting model",
+                description="The learner's first explanation target from their sketch.",
+                subnodes=[
+                    Subnode(
+                        id="c1_s1",
+                        label="Starting model",
+                        mechanism=(
+                            "A signal moves forward when one small change makes "
+                            "the neighboring part more ready to change too. Use "
+                            "your sketch to name what changes, what responds, and "
+                            "how the next step gets triggered."
+                        ),
+                        learner_scaffold=LearnerScaffold(
+                            bloom_level="understand",
+                            learner_move="Explain",
+                            task_label="Starting model",
+                            task_cue="Put one relationship in your own words.",
+                            tailoring_anchor=anchor,
+                            entry_prompt="What do you think makes one part trigger the next?",
+                            expected_shape="Write one or two sentences.",
+                            sentence_starter="My current guess is that...",
+                            blank_hint="Pick two words from your sketch and connect them.",
+                            evidence_goal=(
+                                "The learner writes an initial causal model without "
+                                "reading source content."
+                            ),
+                        ),
+                    )
+                ],
+            )
+        ],
+        relationships=Relationships(),
+        frameworks=[],
+    )
+
+
 class UrlExtractRequest(BaseModel):
     url: str = Field(..., max_length=2_000)
 
@@ -648,12 +721,17 @@ def extract(req: ExtractRequest):
             detail="The AI service is temporarily unavailable. Please try again shortly.",
         )
     except SmallestRouteCapExceeded as err:
-        # Malformed source-less route generation is a server-side generation
-        # failure, not a client input failure -> 500 (not 422). This includes
-        # over-cap output, invalid cluster shape, missing learner_scaffold, and
-        # scaffold text that copies hidden mechanism clauses.
-        # Must be caught BEFORE the generic ValueError handler below because
-        # SmallestRouteCapExceeded subclasses ValueError.
+        # Source-less generation overbuilt or produced an invalid smallest-route
+        # shape. Keep the learner moving with a one-entry route grounded only in
+        # their sketch; source-backed extraction still uses its normal errors.
+        if decision["path"] == "from_threshold":
+            logger.warning("extract: smallest_route_fallback: %s", err)
+            fallback_map = _fallback_smallest_route_from_sketch(
+                concept=decision["name"],
+                threshold=decision["threshold"],
+                learner_goal=decision.get("learner_goal"),
+            )
+            return {"provisional_map": fallback_map.model_dump()}
         logger.error("extract: smallest_route_cap_exceeded: %s", err)
         raise HTTPException(
             status_code=500,

--- a/main.py
+++ b/main.py
@@ -370,9 +370,14 @@ def _resolve_extract_path(req: "ExtractRequest") -> dict:
 def _fallback_smallest_route_from_sketch(
     *, concept: str, threshold: str, learner_goal: str | None = None
 ) -> ProvisionalMap:
+    sketch_excerpt = threshold.strip()[:160] or concept
     anchor = "You named parts in your sketch; start by connecting two of them."
     if learner_goal:
         anchor = "Use your goal and sketch, then connect two named parts."
+    entry_prompt = (
+        f'You wrote: "{sketch_excerpt}". '
+        "What do you think connects those parts?"
+    )
     return ProvisionalMap(
         metadata=Metadata(
             source_title=concept,
@@ -402,10 +407,9 @@ def _fallback_smallest_route_from_sketch(
                         id="c1_s1",
                         label="Starting model",
                         mechanism=(
-                            "A signal moves forward when one small change makes "
-                            "the neighboring part more ready to change too. Use "
-                            "your sketch to name what changes, what responds, and "
-                            "how the next step gets triggered."
+                            f'Use the learner sketch "{sketch_excerpt}" as the '
+                            "only source. Name what changes, what responds, and "
+                            "what relationship the learner currently thinks connects them."
                         ),
                         learner_scaffold=LearnerScaffold(
                             bloom_level="understand",
@@ -413,7 +417,7 @@ def _fallback_smallest_route_from_sketch(
                             task_label="Starting model",
                             task_cue="Put one relationship in your own words.",
                             tailoring_anchor=anchor,
-                            entry_prompt="What do you think makes one part trigger the next?",
+                            entry_prompt=entry_prompt,
                             expected_shape="Write one or two sentences.",
                             sentence_starter="My current guess is that...",
                             blank_hint="Pick two words from your sketch and connect them.",

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -2293,6 +2293,20 @@ html[data-motion="reduced"] .help-tip[data-show="true"] { transform: none; }
   animation: modalIn 220ms var(--ease-standard);
 }
 
+.feedback-modal {
+  background: var(--surface-page-theme, #fbf5ee);
+}
+
+.feedback-modal .btn-primary {
+  background: var(--accent-primary);
+  color: var(--cream-50, #f7ece1);
+}
+
+.feedback-modal .modal-desc,
+.feedback-modal .feedback-rating-copy {
+  color: var(--text-muted);
+}
+
 @keyframes modalIn {
   from { opacity: 0; transform: translateY(10px) scale(0.98); }
   to { opacity: 1; transform: translateY(0) scale(1); }
@@ -2356,6 +2370,37 @@ html[data-motion="reduced"] .help-tip[data-show="true"] { transform: none; }
   margin: 0;
 }
 
+.feedback-rating-label {
+  display: block;
+  margin: 0 28px 8px;
+  color: var(--text-strong);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.feedback-rating-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 28px 14px;
+}
+
+.feedback-rating-input {
+  width: 112px;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: rgba(var(--white-rgb), 0.78);
+  color: var(--text-strong);
+  font: inherit;
+}
+
+.feedback-rating-copy {
+  color: var(--text-sub);
+  font-size: 0.88rem;
+}
+
 .modal-textarea {
   display: block;
   width: calc(100% - 56px);
@@ -2364,7 +2409,7 @@ html[data-motion="reduced"] .help-tip[data-show="true"] { transform: none; }
   padding: 14px;
   border-radius: 12px;
   border: 1px solid var(--border-subtle);
-  background: var(--surface-nested);
+  background: rgba(var(--white-rgb), 0.78);
   color: var(--text-strong);
   font-family: var(--font-body);
   font-size: 0.95rem;

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -567,12 +567,13 @@
 .concept-page-b2__entry-title { font-size: 36px; line-height: 1.15; font-weight: 600; margin: 0 0 16px; color: var(--text-strong); }
 .concept-page-b2__entry-purpose { color: var(--text-muted); font-size: 16px; line-height: 1.65; margin: 0 0 32px; max-width: 520px; }
 .concept-page-b2__study-note {
-  max-width: 540px;
+  max-width: 620px;
   margin: 0 0 28px;
-  padding: 18px 20px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.42);
+  padding: 4px 0 4px 16px;
+  border: 0;
+  border-left: 2px solid rgba(var(--ink-900-rgb), 0.16);
+  border-radius: 0;
+  background: transparent;
 }
 .concept-page-b2__study-note-header {
   display: flex;
@@ -582,11 +583,17 @@
   margin-bottom: 8px;
 }
 .concept-page-b2__study-note-eyebrow { display: block; }
+.concept-page-b2__study-note-eyebrow,
+.concept-page-b2__evidence-eyebrow {
+  color: rgba(var(--violet-600-rgb), 0.94);
+}
 .concept-page-b2__study-note-toggle {
   appearance: none;
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
   inline-size: auto;
-  min-height: 0;
+  min-height: 44px;
   border: 0;
   border-bottom: 1px dotted currentColor;
   border-radius: 4px;
@@ -599,7 +606,7 @@
   font-weight: 600;
   letter-spacing: 0;
   line-height: 1.2;
-  padding: 2px 0;
+  padding: 0;
   transform: none;
   transition: color 140ms var(--ease-standard), border-color 140ms var(--ease-standard), background 140ms var(--ease-standard);
 }
@@ -616,8 +623,9 @@
 }
 .concept-page-b2__study-note p {
   margin: 0;
-  color: var(--text-strong);
+  color: rgba(var(--ink-900-rgb), 0.88);
   font-size: 15px;
+  font-weight: 500;
   line-height: 1.65;
 }
 .concept-page-b2__study-note-hidden { display: none; }
@@ -625,7 +633,7 @@
 .concept-page-b2__study-note.is-collapsed .concept-page-b2__study-note-hidden {
   display: block;
   color: var(--text-muted);
-  font-style: italic;
+  font-style: normal;
 }
 .concept-page-b2__study-note.is-collapsed {
   padding: 10px 12px;
@@ -636,14 +644,22 @@
 .concept-page-b2__study-note.is-collapsed .concept-page-b2__study-note-toggle {
   margin-left: auto;
 }
-[data-theme="dark"] .concept-page-b2__study-note { background: rgba(255, 255, 255, 0.04); }
+[data-theme="dark"] .concept-page-b2__study-note {
+  border-left-color: rgba(247, 236, 225, 0.18);
+  background: transparent;
+}
+[data-theme="dark"] .concept-page-b2__study-note p,
+[data-theme="dark"] .concept-page-b2__evidence blockquote {
+  color: rgba(247, 236, 225, 0.90);
+}
 .concept-page-b2__repair {
-  max-width: 540px;
+  max-width: 620px;
   margin: 0 0 28px;
-  padding: 18px;
-  border: 1px solid rgba(195, 111, 24, 0.28);
-  border-radius: 8px;
-  background: rgba(195, 111, 24, 0.06);
+  padding: 4px 0 4px 16px;
+  border: 0;
+  border-left: 2px solid rgba(var(--ink-900-rgb), 0.16);
+  border-radius: 0;
+  background: transparent;
 }
 .concept-page-b2__repair-eyebrow { display: block; margin-bottom: 8px; }
 .concept-page-b2__repair h3 {
@@ -666,12 +682,12 @@
 }
 .concept-page-b2__repair-target span {
   display: block;
-  margin-bottom: 5px;
-  color: rgba(var(--violet-600-rgb), 0.92);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  margin-bottom: 6px;
+  color: rgba(var(--violet-600-rgb), 0.94);
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-transform: none;
 }
 .concept-page-b2__repair-target p {
   margin: 0;
@@ -681,11 +697,11 @@
 }
 .concept-page-b2__repair-input {
   width: 100%;
-  min-height: 96px;
+  min-height: 132px;
   resize: vertical;
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-  background: var(--surface-card-theme, #fff);
+  border: 1px solid rgba(var(--ink-900-rgb), 0.14);
+  border-radius: 10px;
+  background: rgba(var(--white-rgb), 0.46);
   color: var(--text-strong);
   font: inherit;
   font-size: 15px;
@@ -704,8 +720,9 @@
 .concept-page-b2__repair-save {
   margin-top: 14px;
   width: 100%;
+  min-height: 44px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--accent-primary);
   color: var(--cream-50, #F7ECE1);
   cursor: pointer;
@@ -720,10 +737,11 @@
 .concept-page-b2__evidence {
   max-width: 620px;
   margin: 0 0 18px;
-  padding: 18px 20px;
-  border: 1px solid rgba(144, 103, 198, 0.18);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.46);
+  padding: 4px 0 4px 16px;
+  border: 0;
+  border-left: 2px solid rgba(var(--violet-600-rgb), 0.28);
+  border-radius: 0;
+  background: transparent;
 }
 .concept-page-b2__evidence-eyebrow {
   display: block;
@@ -731,8 +749,9 @@
 }
 .concept-page-b2__evidence blockquote {
   margin: 0;
-  color: var(--text-strong);
+  color: rgba(var(--ink-900-rgb), 0.88);
   font-size: 16px;
+  font-weight: 500;
   line-height: 1.55;
 }
 .concept-page-b2__evidence--compact {
@@ -746,6 +765,16 @@
   color: var(--text-muted);
   font-size: 14px;
   line-height: 1.45;
+}
+.concept-page-b2__evidence--study-gate {
+  padding: 0 0 0 14px;
+  border: 0;
+  border-left: 2px solid rgba(var(--violet-600-rgb), 0.28);
+  border-radius: 0;
+  background: transparent;
+}
+.concept-page-b2__evidence--study-gate .concept-page-b2__evidence-eyebrow {
+  margin-bottom: 6px;
 }
 .concept-page-b2__evidence-bridge {
   margin: 12px 0 0;
@@ -786,12 +815,12 @@
   font-weight: 600;
 }
 [data-theme="dark"] .concept-page-b2__evidence {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(144, 103, 198, 0.28);
+  border-left-color: rgba(176, 156, 224, 0.34);
+  background: transparent;
 }
 [data-theme="dark"] .concept-page-b2__repair {
-  background: rgba(195, 111, 24, 0.10);
-  border-color: rgba(216, 142, 65, 0.32);
+  background: transparent;
+  border-left-color: rgba(247, 236, 225, 0.18);
 }
 .concept-page-b2__attempt {
   max-width: 620px;
@@ -836,8 +865,17 @@
   color: #b45309;
   font-size: 13px;
 }
-.concept-page-b2__attempt-save {
+.concept-page-b2__attempt-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+  max-width: 620px;
   margin-top: 14px;
+}
+.concept-page-b2__attempt-save {
+  margin-top: 0;
+  min-width: 132px;
   border: 0;
   border-radius: 10px;
   background: var(--accent-primary);
@@ -846,11 +884,13 @@
   font-family: inherit;
   font-size: 14px;
   font-weight: 600;
+  white-space: nowrap;
   padding: 10px 20px;
 }
 .concept-page-b2__attempt-save:disabled {
-  background: color-mix(in srgb, var(--surface-disabled, var(--mauve-200)) 72%, var(--surface-card-theme, #fff));
-  color: var(--text-muted);
+  border: 1px dashed rgba(var(--ink-900-rgb), 0.14);
+  background: transparent;
+  color: rgba(var(--ink-900-rgb), 0.58);
   cursor: not-allowed;
   opacity: 1;
   box-shadow: none;
@@ -868,18 +908,24 @@
 }
 .concept-page-b2__entry-cta {
   display: inline-flex; align-items: center; gap: 10px;
-  background: transparent;
-  color: var(--accent-primary);
-  padding: 9px 0;
-  border: 0;
-  border-bottom: 1px dashed currentColor;
-  border-radius: 0;
+  min-height: 44px;
+  background: var(--accent-primary);
+  color: var(--cream-50, #F7ECE1);
+  padding: 11px 18px;
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 82%, var(--ink-900) 18%);
+  border-radius: 10px;
+  box-shadow: 0 10px 22px rgba(var(--violet-600-rgb), 0.16);
   font-family: inherit; font-size: 14px; font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
   cursor: pointer;
   transition: all 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
-.concept-page-b2__entry-cta:hover { background: transparent; color: var(--text-strong); transform: translateY(-1px); }
+.concept-page-b2__entry-cta:hover {
+  background: color-mix(in srgb, var(--accent-primary) 88%, var(--ink-900) 12%);
+  color: var(--cream-50, #F7ECE1);
+  box-shadow: 0 12px 26px rgba(var(--violet-600-rgb), 0.20);
+  transform: translateY(-1px);
+}
 .concept-page-b2__entry-cta::after {
   content: "\2192";
   font-size: 16px;
@@ -900,10 +946,14 @@
   font-size: 13px;
   line-height: 1.5;
 }
+.concept-page-b2__attempt-actions .concept-page-b2__blank-start {
+  flex: 1 1 180px;
+  margin: 0;
+}
 .concept-page-b2__blank-start-button {
   display: inline-flex;
   align-items: center;
-  min-height: 36px;
+  min-height: 44px;
   padding: 8px 13px;
   border: 1px solid color-mix(in srgb, var(--accent-primary) 34%, var(--border-subtle));
   border-radius: 8px;
@@ -927,11 +977,34 @@
   background: color-mix(in srgb, var(--surface) 82%, var(--accent-primary) 18%);
 }
 .concept-page-b2__truth-note {
-  margin: 54px 0 0;
+  max-width: 620px;
+  margin: 18px 0 0;
   color: var(--text-muted);
   font-size: 13px;
   font-weight: 650;
   line-height: 1.5;
+}
+.concept-page-b2__feedback-link {
+  display: inline;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px dotted currentColor;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--accent-primary);
+  font: inherit;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+.concept-page-b2__feedback-link:hover,
+.concept-page-b2__feedback-link:focus-visible {
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-strong);
+  transform: none;
 }
 .concept-page-b2__nearby-eyebrow { display: block; margin-bottom: 18px; }
 .concept-page-b2__nearby-list { display: flex; flex-direction: column; gap: 4px; }
@@ -954,12 +1027,12 @@
   letter-spacing: 0.06em;
 }
 .concept-page-b2__nearby-status {
-  font-family: ui-monospace, monospace;
-  font-size: 10px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
   color: var(--text-muted);
-  opacity: 0.55;
+  opacity: 0.74;
 }
 
 /* ============================================================
@@ -1272,8 +1345,6 @@
     width: 100%;
     justify-content: center;
     padding: 14px 18px;
-    border: 1px dashed var(--border-subtle);
-    border-radius: 10px;
   }
   .concept-page-b2__nearby {
     margin-top: 56px;
@@ -1578,6 +1649,9 @@
 
 .vd-sketch-head .concept-page-b2__threshold-edit {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
   font-size: 13px;
   font-weight: 650;
   color: var(--accent-primary);
@@ -1639,17 +1713,25 @@
 
 .concept-page-b2__active-entry {
   max-width: 760px;
-  padding: clamp(22px, 3.8vw, 34px);
-  border: 1px solid rgba(var(--ink-900-rgb), 0.10);
-  border-radius: 10px;
-  background: linear-gradient(180deg, rgba(var(--white-rgb), 0.94), rgba(var(--cream-50-rgb), 0.94));
-  box-shadow:
-    0 16px 42px rgba(var(--violet-600-rgb), 0.10),
-    inset 0 1px 0 rgba(255, 255, 255, 0.76);
+  padding: clamp(18px, 3.4vw, 30px) 0 0;
+  border: 0;
+  border-top: 1px solid rgba(var(--ink-900-rgb), 0.10);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .concept-page-b2__active-entry .concept-page-b2__entry-eyebrow {
   margin-bottom: 8px;
+}
+
+.concept-page-b2__active-entry .eyebrow,
+.concept-page-b2 .concept-page-b2__nearby-eyebrow {
+  font-family: inherit;
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 650;
 }
 
 .concept-page-b2__active-entry .concept-page-b2__entry-title {
@@ -1663,6 +1745,11 @@
   font-size: 15px;
   line-height: 1.5;
   max-width: 58ch;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__entry-eyebrow,
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__entry-title {
+  display: none;
 }
 
 .concept-page-b2__active-entry .concept-page-b2__attempt {
@@ -1684,6 +1771,12 @@
   line-height: 1.2;
 }
 
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt h3 {
+  font-size: clamp(30px, 4.6vw, 38px);
+  line-height: 1.08;
+  max-width: 22ch;
+}
+
 .concept-page-b2__active-entry .concept-page-b2__attempt-helper {
   margin: 0 0 4px;
   line-height: 1.42;
@@ -1695,11 +1788,12 @@
 
 .concept-page-b2__active-entry .concept-page-b2__attempt-input {
   min-height: clamp(200px, 30vh, 320px);
-  border-color: rgba(var(--violet-600-rgb), 0.18);
-  background: rgba(var(--white-rgb), 0.58);
+  border-color: rgba(var(--ink-900-rgb), 0.14);
+  background: rgba(var(--white-rgb), 0.46);
   font-size: 16px;
   line-height: 1.65;
   padding: 16px 18px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.70);
 }
 
 .concept-page-b2__active-entry .concept-page-b2__attempt-save {
@@ -1729,7 +1823,6 @@
 
 [data-theme="dark"] .concept-page-b2__context-dock,
 [data-theme="dark"] .concept-page-b2__active-entry {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.065), rgba(144, 103, 198, 0.055));
   border-color: rgba(176, 156, 224, 0.18);
 }
 
@@ -1772,8 +1865,13 @@
 
 @media (max-width: 720px) {
   body[data-map-open="true"] .map-view {
+    padding-top: 72px;
     padding-right: 12px;
     padding-left: 12px;
+  }
+
+  body[data-map-open="true"] .concept-view-switch {
+    display: none;
   }
 
   .concept-page-b2__doc {
@@ -1789,13 +1887,27 @@
   }
 
   .concept-page-b2__active-entry {
-    padding: 18px;
+    padding: 16px 0 0;
   }
 
   .node-strip-item.concept-page-b2__route-item,
   .node-strip-item.concept-page-b2__route-marker-item {
     flex-basis: min(270px, 78vw);
     min-height: 50px;
+  }
+
+  .node-strip-item.concept-page-b2__route-item:not(.is-active),
+  .node-strip-item.concept-page-b2__route-marker-item:not(.is-active) {
+    flex: 0 0 48px;
+    grid-template-columns: auto 16px;
+    justify-content: center;
+    padding-inline: 8px;
+    overflow: hidden;
+  }
+
+  .node-strip-item.concept-page-b2__route-item:not(.is-active) .node-strip-text,
+  .node-strip-item.concept-page-b2__route-marker-item:not(.is-active) .node-strip-text {
+    display: none;
   }
 
   .node-strip-title {
@@ -1810,23 +1922,10 @@
   }
 
   .concept-page-b2__active-entry .concept-page-b2__attempt-input {
-    min-height: 96px;
-    height: 96px;
+    min-height: 148px;
+    height: 148px;
   }
 
-  .vd-sketch-toggle {
-    grid-template-columns: 1fr;
-    gap: 6px;
-  }
-
-  .vd-sketch-head {
-    grid-template-columns: 1fr;
-    gap: 4px;
-  }
-
-  .vd-sketch-head .concept-page-b2__threshold-edit {
-    padding: 0 0 10px;
-  }
 }
 
 @media (max-height: 760px) and (min-width: 721px) {
@@ -1850,6 +1949,10 @@
   .concept-page-b2__active-entry .concept-page-b2__attempt h3 {
     font-size: 20px;
     margin-bottom: 8px;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt h3 {
+    font-size: clamp(24px, 3.7vw, 30px);
   }
 
   .concept-page-b2__active-entry .concept-page-b2__attempt-input {

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -595,7 +595,7 @@
   inline-size: auto;
   min-height: 44px;
   border: 0;
-  border-bottom: 1px dotted currentColor;
+  border-bottom: 1px dotted currentcolor;
   border-radius: 4px;
   background: transparent;
   box-shadow: none;
@@ -990,7 +990,7 @@
   margin: 0;
   padding: 0;
   border: 0;
-  border-bottom: 1px dotted currentColor;
+  border-bottom: 1px dotted currentcolor;
   border-radius: 0;
   background: transparent;
   box-shadow: none;

--- a/public/css/drill-chamber.css
+++ b/public/css/drill-chamber.css
@@ -104,8 +104,8 @@
 .drill-chamber__history-turn-meta {
   font-family: ui-monospace, monospace;
   font-size: 10px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
   margin-bottom: 4px;
 }
 
@@ -156,7 +156,7 @@
   display: flex; justify-content: space-between; align-items: center;
   margin-top: 14px;
   font-size: 11px;
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
 }
 .drill-chamber__send {
   /* Opt out of base.css's `button { flex: 1 }` global. Without this
@@ -170,7 +170,7 @@
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
   cursor: pointer;
   /* Defeat the base.css button hover transform / box-shadow so the
      chamber's send stays a quiet ghost pill, not a brand-default CTA. */
@@ -184,6 +184,16 @@
   box-shadow: none;
 }
 .drill-chamber__send[disabled] { opacity: 0.40; cursor: not-allowed; }
+
+.drill-chamber__active[data-complete="true"] .drill-chamber__composer textarea,
+.drill-chamber__active[data-complete="true"] .drill-chamber__hint {
+  display: none;
+}
+
+.drill-chamber__active[data-complete="true"] .drill-chamber__composer-foot {
+  justify-content: flex-end;
+  margin-top: 20px;
+}
 
 /* History toggle is also a button -- same flex-grow opt-out. */
 .drill-chamber__history-toggle {
@@ -457,7 +467,7 @@
   border: 1px solid rgba(var(--violet-600-rgb), 0.10);
   border-radius: 8px;
   background: rgba(var(--white-rgb), 0.34);
-  opacity: 0.46;
+  opacity: 0.74;
 }
 
 .concept-page-b2__active-entry .drill-chamber__active {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=148'     layer(components);
+@import '../styles.css?v=149'     layer(components);
 @import '../antigravity.css?v=28' layer(legacy);
 @import 'paper.css?v=12'          layer(paper);

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -285,12 +285,12 @@ html[data-theme="dark"] #intro-particle-canvas {
     pointer-events: auto;
   }
 
-  /* Mobile bottom nav owns the primary destinations. Keep Feedback in the
-     drawer because it has no bottom-nav equivalent. */
+  /* Mobile bottom nav owns most primary destinations. Keep loop and Feedback in
+     the drawer because they have no bottom-nav equivalents. */
   #drawer .sidebar-nav {
     display: flex;
   }
-  #drawer .sidebar-nav .sidebar-nav-item:not(#nav-feedback) {
+  #drawer .sidebar-nav .sidebar-nav-item:not(#nav-loop):not(#nav-feedback) {
     display: none;
   }
 

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -285,13 +285,12 @@ html[data-theme="dark"] #intro-particle-canvas {
     pointer-events: auto;
   }
 
-  /* Mobile bottom nav owns the primary destinations. Keep Feedback and the
-     learning-loop entry in the drawer because they have no bottom-nav
-     equivalents. */
+  /* Mobile bottom nav owns the primary destinations. Keep Feedback in the
+     drawer because it has no bottom-nav equivalent. */
   #drawer .sidebar-nav {
     display: flex;
   }
-  #drawer .sidebar-nav .sidebar-nav-item:not(#nav-feedback):not(#nav-loop) {
+  #drawer .sidebar-nav .sidebar-nav-item:not(#nav-feedback) {
     display: none;
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -23,8 +23,8 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=150">
-  <link rel="stylesheet" href="css/drill-chamber.css?v=9">
+  <link rel="stylesheet" href="/css/index.css?v=151">
+  <link rel="stylesheet" href="css/drill-chamber.css?v=10">
 </head>
 
 <body>
@@ -444,7 +444,7 @@
 
   <div id="tooltip-root" aria-hidden="true"></div>
 
-  <script src="js/drill-chamber.js?v=11"></script>
+  <script src="js/drill-chamber.js?v=12"></script>
   <script type="module" src="js/app.js?v=157"></script>
   <script src="js/intro-particles.js?v=8"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -450,7 +450,7 @@
   <script type="module" src="js/tooltips.js?v=4"></script>
   <script type="module" src="js/floating-room-label.js?v=5"></script>
   <script type="module" src="js/iso-board-state-surface.js?v=5"></script>
-  <script type="module" src="js/feedback.js?v=5"></script>
+  <script type="module" src="js/feedback.js?v=6"></script>
 
   <!-- Feedback Modal -->
   <div id="feedback-overlay" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="feedback-title" aria-describedby="feedback-desc" hidden onclick="Feedback.hide()">

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
         onclick="App.showDashboard()"><span class="material-symbols-outlined">view_quilt</span> Desk</a>
       <a id="nav-library" class="sidebar-nav-item" href="javascript:void(0)"
         onclick="App.showLibrary()"><span class="material-symbols-outlined">auto_stories</span> Library</a>
-      <a id="nav-loop" class="sidebar-nav-item" href="/loop"><span class="material-symbols-outlined">chat</span> Source-less loop (beta)</a>
+      <a id="nav-loop" class="sidebar-nav-item" href="/loop" hidden><span class="material-symbols-outlined">chat</span> Learning loop</a>
       <a id="nav-settings" class="sidebar-nav-item" href="javascript:void(0)"
         onclick="App.showSettings()"><span class="material-symbols-outlined">settings</span> Settings</a>
       <a id="nav-feedback" class="sidebar-nav-item" href="javascript:void(0)"
@@ -325,7 +325,7 @@
           <textarea class="composer-card__field" id="hero-single-input-field"
                     rows="2" maxlength="200"
                     placeholder=""
-                    aria-label="What do you want to explain?"></textarea>
+                    aria-label="Concept name"></textarea>
 
           <div class="journal-meta">
             <span class="journal-meta__key">source</span>
@@ -445,15 +445,15 @@
   <div id="tooltip-root" aria-hidden="true"></div>
 
   <script src="js/drill-chamber.js?v=11"></script>
-  <script type="module" src="js/app.js?v=155"></script>
+  <script type="module" src="js/app.js?v=157"></script>
   <script src="js/intro-particles.js?v=8"></script>
   <script type="module" src="js/tooltips.js?v=4"></script>
   <script type="module" src="js/floating-room-label.js?v=5"></script>
   <script type="module" src="js/iso-board-state-surface.js?v=5"></script>
-  <script type="module" src="js/feedback.js?v=4"></script>
+  <script type="module" src="js/feedback.js?v=5"></script>
 
   <!-- Feedback Modal -->
-  <div id="feedback-overlay" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="feedback-title" hidden onclick="Feedback.hide()">
+  <div id="feedback-overlay" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="feedback-title" aria-describedby="feedback-desc" hidden onclick="Feedback.hide()">
     <div class="modal-card feedback-modal" onclick="event.stopPropagation()">
       <div class="modal-header">
         <h2 class="modal-title" id="feedback-title">Feedback</h2>
@@ -465,12 +465,29 @@
         </button>
       </div>
       <form id="feedback-form" onsubmit="return Feedback.submit(event)">
-        <p class="modal-desc">Share a bug, rough edge, or idea. It helps shape what gets sharpened next.</p>
+        <p class="modal-desc" id="feedback-desc">Share a bug, rough edge, or idea. A 9 or 10 means the UX feels ready for a new customer.</p>
+        <label class="feedback-rating-label" for="feedback-ux-rating">UX feel</label>
+        <div class="feedback-rating-row">
+          <select id="feedback-ux-rating" class="feedback-rating-input">
+            <option value="">Score</option>
+            <option value="1">1 / 10</option>
+            <option value="2">2 / 10</option>
+            <option value="3">3 / 10</option>
+            <option value="4">4 / 10</option>
+            <option value="5">5 / 10</option>
+            <option value="6">6 / 10</option>
+            <option value="7">7 / 10</option>
+            <option value="8">8 / 10</option>
+            <option value="9">9 / 10</option>
+            <option value="10">10 / 10</option>
+          </select>
+          <span class="feedback-rating-copy">How did this feel?</span>
+        </div>
         <textarea id="feedback-message" class="modal-textarea"
-                  placeholder="Tell me what's on your mind"
-                  minlength="10" maxlength="1000" required></textarea>
+                  placeholder="Optional: what made it feel that way?"
+                  maxlength="1000"></textarea>
         <div class="modal-footer">
-          <span id="feedback-status" class="modal-status"></span>
+          <span id="feedback-status" class="modal-status" role="status" aria-live="polite"></span>
           <button type="submit" id="feedback-submit" class="btn-primary">Send Feedback</button>
         </div>
       </form>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -510,6 +510,7 @@ const App = (() => {
     switchBtn.disabled = !available;
     switchBtn.setAttribute('aria-disabled', available ? 'false' : 'true');
     if (!available && currentMapMode === 'constellation') {
+      /* c8 ignore next -- defensive recovery if constellation becomes unavailable while selected */
       setMapMode('route');
     }
   }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1956,6 +1956,9 @@ const App = (() => {
           return;
         }
         if (ctaBtn.dataset.activeEntryAction === 'next-entry') {
+          if (_activeEntryId) {
+            markComparisonAcknowledged(concept.id, _activeEntryId);
+          }
           setActiveEntry(ctaBtn.dataset.activeEntryId, data, concept, training, { focusAttempt: true });
           return;
         }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -25,7 +25,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=20';
+} from './concept-page-view.js?v=22';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
@@ -65,7 +65,7 @@ import {
   isIdentifiedUserSession,
   logout,
   redirectToLogin,
-} from './auth.js?v=3';
+} from './auth.js?v=4';
 import { prefersReducedMotion } from './motion.js';
 import {
   STATES, generateId, loadConcepts, saveConcepts, normalizeGraphData,
@@ -455,6 +455,71 @@ const App = (() => {
 
   function conceptViewSwitchButton() {
     return document.getElementById('concept-view-switch');
+  }
+
+  function hasActiveEntryReconstructionEvidence(training) {
+    const records = training?.node_records && typeof training.node_records === 'object'
+      ? training.node_records
+      : {};
+    const record = _activeEntryId ? records[_activeEntryId] : null;
+    if (!record || typeof record !== 'object') return false;
+    if (Array.isArray(record.attempts) && record.attempts.length > 0) return true;
+    return Boolean(record.attempt_text || record.latest_attempt || record.study_revealed_at);
+  }
+
+  function hasActiveAttemptDraft() {
+    const input = document.querySelector('.concept-page-b2__attempt-input');
+    return Boolean((input?.value || '').trim());
+  }
+
+  function normalizeSourceModeToken(value) {
+    const mode = typeof value === 'string' ? value.trim() : '';
+    return mode === 'source_less' || mode === 'source_attached' ? mode : '';
+  }
+
+  function isSourceLessConcept(concept, data, training = null) {
+    const explicitMode = normalizeSourceModeToken(training?.source_mode)
+      || normalizeSourceModeToken(concept?.sourceMode)
+      || normalizeSourceModeToken(concept?.source_mode)
+      || normalizeSourceModeToken(data?.metadata?.source_mode);
+    if (explicitMode) return explicitMode === 'source_less';
+
+    const hasNullContentType = Object.prototype.hasOwnProperty.call(concept || {}, 'contentType')
+      && concept?.contentType === null;
+    const hasNullSourceUrl = Object.prototype.hasOwnProperty.call(concept || {}, 'sourceUrl')
+      && concept?.sourceUrl === null;
+    const hasSourceMarker = Boolean(
+      (concept?.contentType || '').trim?.()
+      || (concept?.contentFilename || '').trim?.()
+      || (concept?.sourceUrl || '').trim?.()
+      || (data?.metadata?.source_url || '').trim?.()
+    );
+    return hasNullContentType && hasNullSourceUrl && !hasSourceMarker;
+  }
+
+  function setActiveConceptSourceMode(concept, data, training = null) {
+    document.body.dataset.conceptSourceMode = isSourceLessConcept(concept, data, training)
+      ? 'source_less'
+      : '';
+  }
+
+  function setConstellationAvailable(available) {
+    const switchBtn = conceptViewSwitchButton();
+    if (!switchBtn) return;
+    switchBtn.hidden = !available;
+    switchBtn.disabled = !available;
+    switchBtn.setAttribute('aria-disabled', available ? 'false' : 'true');
+    if (!available && currentMapMode === 'constellation') {
+      setMapMode('route');
+    }
+  }
+
+  function refreshConstellationAvailability(training = null) {
+    if (document.body.dataset.conceptSourceMode === 'source_less') {
+      setConstellationAvailable(false);
+      return;
+    }
+    setConstellationAvailable(hasActiveEntryReconstructionEvidence(training) || hasActiveAttemptDraft());
   }
 
   function renderHero(concept) {
@@ -1319,12 +1384,8 @@ const App = (() => {
   function renderSkeletonLineIfFresh(opts) {
     const banner = document.getElementById("graph-skeleton-line");
     if (!banner) return;
-    if (opts && opts.fromLaunchPad) {
-      banner.textContent = "This is the skeleton. It will grow as you reconstruct.";
-      banner.hidden = false;
-    } else {
-      banner.hidden = true;
-    }
+    banner.textContent = '';
+    banner.hidden = true;
   }
 
   function navigateToGraphViewFromLaunchPad(opts) {
@@ -1805,15 +1866,25 @@ const App = (() => {
   // work column. Set on initial mount and updated by setActiveEntry.
   let _activeEntryId = null;
   const routeAttemptDrafts = new Map();
+  const repairChecksThisSession = new Set();
 
   function routeAttemptDraftKey(entryId) {
     return `${getActiveId() || 'concept'}:${entryId}`;
   }
 
+  function entrySessionKey(conceptId, entryId) {
+    return `${conceptId || 'concept'}:${entryId || 'entry'}`;
+  }
+
   function conceptPageRenderOptionsForEntry(concept, entryId, options = {}) {
     if (!concept?.id || !entryId) return options;
+    const repairCheckedEntryIds = [...repairChecksThisSession]
+      .filter((key) => key.startsWith(`${concept.id}:`))
+      .map((key) => key.slice(concept.id.length + 1));
     return {
       ...options,
+      repairCheckedEntryIds,
+      repairCheckedThisSession: repairChecksThisSession.has(entrySessionKey(concept.id, entryId)),
       comparisonAcknowledged: options?.justRevealedEntryId === entryId
         ? false
         : hasComparisonAcknowledgement(concept.id, entryId),
@@ -1834,6 +1905,7 @@ const App = (() => {
     const hasDraft = Boolean((input.value || '').trim());
     button.disabled = !hasDraft;
     button.setAttribute('aria-disabled', hasDraft ? 'false' : 'true');
+    refreshConstellationAvailability(options.training || null);
     if (hasDraft && options.clearError) {
       const errorEl = panel.querySelector?.('[data-attempt-error]');
       if (errorEl) errorEl.hidden = true;
@@ -1883,7 +1955,7 @@ const App = (() => {
           return;
         }
         if (ctaBtn.dataset.activeEntryAction === 'next-entry') {
-          setActiveEntry(ctaBtn.dataset.activeEntryId, data, concept, training);
+          setActiveEntry(ctaBtn.dataset.activeEntryId, data, concept, training, { focusAttempt: true });
           return;
         }
         const inlineAttempt = docEl.querySelector('.concept-page-b2__attempt-input');
@@ -1899,9 +1971,9 @@ const App = (() => {
     if (attemptBtn) {
       const attemptPanel = attemptBtn.closest('.concept-page-b2__attempt');
       const attemptInput = attemptPanel?.querySelector?.('.concept-page-b2__attempt-input');
-      syncInlineAttemptSaveButton(attemptPanel);
+      syncInlineAttemptSaveButton(attemptPanel, { training });
       attemptInput?.addEventListener('input', () => {
-        syncInlineAttemptSaveButton(attemptPanel, { clearError: true });
+        syncInlineAttemptSaveButton(attemptPanel, { clearError: true, training });
       });
       attemptBtn.addEventListener('click', () => {
         void submitInlineAttemptForEntry(attemptBtn, concept, data);
@@ -1914,6 +1986,7 @@ const App = (() => {
         const hint = wrapper?.querySelector?.('[data-blank-start-hint]');
         if (hint) hint.hidden = false;
         blankStartBtn.setAttribute('aria-expanded', 'true');
+        blankStartBtn.hidden = true;
         docEl.querySelector('.concept-page-b2__attempt-input')?.focus?.();
       });
     }
@@ -1948,6 +2021,14 @@ const App = (() => {
         setStudyNoteCollapsed(Boolean(repairInput.value.trim()));
       });
     }
+    docEl.querySelectorAll('[data-feedback-rating]').forEach((button) => {
+      button.addEventListener('click', () => {
+        window.Feedback?.show?.({
+          focus: 'rating',
+          moment: button.getAttribute('data-feedback-moment') || '',
+        });
+      });
+    });
     docEl.querySelectorAll('[data-edit-threshold]').forEach((link) => {
       link.addEventListener('click', (e) => {
         e.preventDefault();
@@ -2291,7 +2372,10 @@ const App = (() => {
         text,
       });
       const mountEl = document.getElementById('map-content');
-      if (mountEl) renderConceptPageB2(mountEl, data, concept, training, { activeEntryId: entryId });
+      if (mountEl) {
+        window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+        renderConceptPageB2(mountEl, data, concept, training, { activeEntryId: entryId });
+      }
     } catch (err) {
       /* c8 ignore next -- defensive storage/invariant failure branch */
       console.warn('Repair save failed.', err);
@@ -2436,7 +2520,7 @@ const App = (() => {
    * @param {Object} data - Parsed graphData
    * @param {Object} concept - The full concept object
    */
-  function setActiveEntry(entryId, data, concept, training = null) {
+  function setActiveEntry(entryId, data, concept, training = null, options = {}) {
     if (!data || !entryId) return;
     if (entryId === _activeEntryId) return;
 
@@ -2464,9 +2548,15 @@ const App = (() => {
       rebindActiveEntryHandlers(doc, concept, data, training);
       bindConceptRouteMarginHandlers(mountEl, data, concept, training);
       restoreActiveEntryDraft(entryId);
+      refreshConstellationAvailability(training);
       doc.classList.remove('is-fading-out');
       void doc.offsetWidth; // force reflow so the fade-in animates
       doc.classList.add('is-fading-in');
+      if (options?.focusAttempt) {
+        const attemptInput = doc.querySelector('.concept-page-b2__attempt-input');
+        window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+        attemptInput?.focus?.({ preventScroll: true });
+      }
       setTimeout(() => doc.classList.remove('is-fading-in'), 360);
     }, 240);
 
@@ -2582,6 +2672,7 @@ const App = (() => {
    */
   function renderConceptPageB2(mountEl, data, concept, training = null, options = {}) {
     if (!mountEl || !data) return;
+    setActiveConceptSourceMode(concept, data, training);
     const backbone = deriveConceptEntries(data);
     const preferredEntryId = options?.activeEntryId || null;
     const preferredEntry = preferredEntryId === 'core-thesis' && !backbone.length
@@ -2654,6 +2745,7 @@ const App = (() => {
 
     renderConceptPageB2(mapContent, data, concept, null, opts);
     renderConceptConstellationView(constellationContent, data, concept, null, { activeEntryId: _activeEntryId });
+    refreshConstellationAvailability(null);
     // Keep first paint synchronous; training evidence re-renders when available.
     void trainingStore.loadTraining(concept.id)
       .then((training) => {
@@ -2666,6 +2758,7 @@ const App = (() => {
           && drillState.node?.id === renderOptions.activeEntryId
         ) {
           renderConceptConstellationView(constellationContent, data, concept, training, { activeEntryId: _activeEntryId });
+          refreshConstellationAvailability(training);
           return;
         }
         if (
@@ -2676,6 +2769,7 @@ const App = (() => {
         }
         renderConceptPageB2(mapContent, data, concept, training, renderOptions);
         renderConceptConstellationView(constellationContent, data, concept, training, { activeEntryId: _activeEntryId });
+        refreshConstellationAvailability(training);
       })
       .catch((err) => {
         /* c8 ignore next -- defensive localStorage failure branch */
@@ -2786,6 +2880,7 @@ const App = (() => {
       const mode = button.getAttribute('data-map-mode');
       if (mode === 'route' || mode === 'constellation') {
         event.preventDefault();
+        if (button.disabled || button.hidden || button.getAttribute('aria-disabled') === 'true') return;
         setMapMode(mode);
       }
     });
@@ -3997,6 +4092,9 @@ const App = (() => {
         persistSessionState();
         drillState.attemptTurnCount = data.attempt_turn_count ?? drillState.attemptTurnCount;
         drillState.helpTurnCount = data.help_turn_count ?? drillState.helpTurnCount;
+        if (completedGraphNeutralReDrill) {
+          repairChecksThisSession.add(entrySessionKey(concept.id, drillState.node.id));
+        }
         handleDrillAssistantMessage(data.agent_response || '');
         if (data.agent_response?.trim()) {
           drillState.messages.push({ role: 'assistant', content: data.agent_response.trim() });
@@ -4020,7 +4118,11 @@ const App = (() => {
         // writing surface available until the turn actually resolves.
         if (window.DrillChamber) {
           window.DrillChamber.setLoading?.(false);
-          window.DrillChamber.setComposerEnabled(!(completedNodeTurn || !!data.session_terminated));
+          if (completedNodeTurn || data.session_terminated) {
+            window.DrillChamber.setCompletionAction?.('Return to concept', () => cancelDrill());
+          } else {
+            window.DrillChamber.setComposerEnabled(true);
+          }
         }
         if (completedNodeTurn) {
           currentGraphController?.setInteractionMode?.(drillMode === 'cold_attempt' ? 'study' : 'post-drill', activeDrillNode);
@@ -4295,6 +4397,7 @@ const App = (() => {
     const activeConcept = getActiveConcept();
     if (activeConcept && options.restoreMap !== false) {
       showMapView(activeConcept);
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
     }
   }
 

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -97,6 +97,11 @@ function applyAuthUi(session) {
     logoutBtn.hidden = true;
     loginLink.hidden = false;
   }
+
+  const loopLink = document.getElementById('nav-loop');
+  if (loopLink) {
+    loopLink.hidden = !session?.loop_available;
+  }
 }
 
 export async function bootstrapAuthUi() {

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -109,7 +109,16 @@ function predecessorsAttempted(backbone, index, training, options = {}) {
 
 function entryLearnerState(backbone, index, training, options = {}) {
   const derived = entryTraining(backbone, index, training, options);
-  if (derived.attempted) return derived.state || 'attempted';
+  const entryId = getConceptEntryId(backbone[index], index);
+  const checkedEntryIds = Array.isArray(options?.repairCheckedEntryIds)
+    ? options.repairCheckedEntryIds
+    : [];
+  if (derived.attempted) {
+    if (derived.state === 'needs repair' && checkedEntryIds.includes(entryId)) {
+      return 'repair checked';
+    }
+    return derived.state || 'attempted';
+  }
   return predecessorsAttempted(backbone, index, training, options)
     ? 'ready to reconstruct'
     : 'locked';
@@ -182,9 +191,7 @@ function attemptPlaceholderForScaffold(scaffold) {
   if (!scaffold) return 'Draft what you can recall. Messy is useful.';
   const starter = cleanScaffoldText(scaffold.sentence_starter);
   if (starter) return starter;
-  const expected = cleanScaffoldText(scaffold.expected_shape);
-  if (expected) return expected;
-  return 'Write the first useful version of your current model.';
+  return 'Write what you can explain right now.';
 }
 
 function blankHintForScaffold(scaffold) {
@@ -350,15 +357,16 @@ export function renderConceptStripHtml(backbone, activeEntry, activeIdx, trainin
   `;
 }
 
-function activeEntryEyebrow({ isBlocked, attempted, state, nextAction }) {
+function activeEntryEyebrow({ isBlocked, attempted, state, nextAction, justRevealedStudy }) {
   if (isBlocked) return 'locked';
   if (!attempted) return 'Start from memory';
+  if (justRevealedStudy) return 'Compare notes';
   if (nextAction === 'study') return 'Draft saved';
   if (nextAction === 'repair') return 'Needs repair';
   if (state === 'needs repair' && nextAction === 'spaced_attempt') return 'Ready to reconstruct again';
   if (state === 'solidified') return 'solidified';
   if (nextAction === 'spaced_attempt') return 'Ready to reconstruct again';
-  if (nextAction === 'review') return 'review pending';
+  if (nextAction === 'review') return 'Review later';
   if (state === 'needs repair') return 'Needs repair';
   return 'Ready to reconstruct again';
 }
@@ -397,7 +405,11 @@ function repairGapTitle(gap, index) {
 
 function repairGapCorrection(gap) {
   if (!gap || typeof gap !== 'object') return String(gap || '');
-  return gap.correction || gap.description || gap.detail || gap.text || '';
+  const text = gap.correction || gap.description || gap.detail || gap.text || '';
+  return String(text)
+    .replace(/^The learner correctly identifies\b/i, 'Your draft names')
+    .replace(/^The learner\b/i, 'Your draft')
+    .replace(/^Learner\b/i, 'Your draft');
 }
 
 function latestAttemptForRecord(record) {
@@ -425,7 +437,6 @@ export function deriveSourceLessViewMode(derived, options = {}) {
   if (
     derived.attempted
     && studyRevealedAt
-    && derived.next_action === 'repair'
     && hasPreStudyColdAttempt
     && options?.comparisonAcknowledged === false
   ) {
@@ -446,13 +457,7 @@ function renderEvidenceArtifactHtml(derived) {
   const gaps = Array.isArray(attempt.gaps) && attempt.gaps.length
     ? attempt.gaps
     : (Array.isArray(derived.gaps) ? derived.gaps : []);
-  const bridgeHtml = isStudyGate
-    ? `
-      <p class="concept-page-b2__evidence-bridge">
-        Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.
-      </p>
-    `
-    : '';
+  const bridgeHtml = '';
   const hingeHtml = hasStudyReveal && !isRepairing && gaps.length
     ? `
       <div class="concept-page-b2__evidence-hinge">
@@ -470,7 +475,7 @@ function renderEvidenceArtifactHtml(derived) {
     : '';
 
   return `
-    <section class="concept-page-b2__evidence${isRepairing ? ' concept-page-b2__evidence--compact' : ''}" aria-label="Learner draft evidence">
+    <section class="concept-page-b2__evidence${isStudyGate ? ' concept-page-b2__evidence--study-gate' : ''}${isRepairing ? ' concept-page-b2__evidence--compact' : ''}" aria-label="Learner draft evidence">
       <span class="eyebrow concept-page-b2__evidence-eyebrow">${isStudyGate ? 'Your memory draft' : 'Your draft'}</span>
       <blockquote>${escHtml(attempt.user_text)}</blockquote>
       ${bridgeHtml}
@@ -479,19 +484,22 @@ function renderEvidenceArtifactHtml(derived) {
   `;
 }
 
-function renderRepairPanelHtml(activeEntry, derived, activeEntryId) {
+function renderRepairPanelHtml(activeEntry, derived, activeEntryId, options = {}) {
   if (derived.next_action !== 'repair') return '';
   const gaps = Array.isArray(derived.gaps) && derived.gaps.length
     ? derived.gaps
     : [{ mechanism: 'missing link', correction: 'Write the part that was missing from your first attempt.' }];
   const entryId = activeEntryId || activeEntry.id || 'core-thesis';
   const repairs = Array.isArray(derived.record?.repairs) ? derived.record.repairs : [];
-  const nextAttemptButton = repairs.length
+  const repairCheckedThisSession = repairs.length && options?.repairCheckedThisSession === true;
+  const nextAttemptButton = repairs.length && !repairCheckedThisSession
     ? `<button class="concept-page-b2__entry-cta concept-page-b2__repair-attempt" type="button" data-active-entry-id="${escHtml(entryId)}" data-active-entry-action="drill-gap">Pressure-check this link</button>`
     : '';
   const repairTarget = repairGapCorrection(gaps[0]) || 'Write the part that was missing from your first attempt.';
 
-  const helperHtml = repairs.length
+  const helperHtml = repairCheckedThisSession
+    ? '<p class="concept-page-b2__repair-helper">Return later for spaced reconstruction. A strong later answer can update the record. <button class="concept-page-b2__feedback-link" type="button" data-feedback-rating data-feedback-moment="repair checked">Rate this moment</button></p>'
+    : repairs.length
     ? ''
     : `<p class="concept-page-b2__repair-helper">Use your words. One or two sentences is enough.</p>`;
 
@@ -512,8 +520,8 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId) {
 
   return `
     <section class="concept-page-b2__repair${repairs.length ? ' concept-page-b2__repair--saved' : ''}" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link">
-      <span class="eyebrow concept-page-b2__repair-eyebrow">${repairs.length ? 'Repair saved' : 'Repair'}</span>
-      <h3>${repairs.length ? 'Try this entry again from memory.' : 'Write the missing link.'}</h3>
+      <span class="eyebrow concept-page-b2__repair-eyebrow">${repairCheckedThisSession ? 'Repair checked' : repairs.length ? 'Repair saved' : 'Repair'}</span>
+      <h3>${repairCheckedThisSession ? 'Repair checked for now.' : repairs.length ? 'Pressure-check the repaired link.' : 'Write the missing link.'}</h3>
       <div class="concept-page-b2__repair-target">
         <span>Missing link</span>
         <p>${escHtml(repairTarget)}</p>
@@ -551,13 +559,14 @@ function renderAttemptPanelHtml(activeEntryId, activeEntry, options = {}) {
   ].filter(Boolean);
   const helper = helperParts.join(' ');
   const placeholder = attemptPlaceholderForScaffold(scaffold);
-  const buttonLabel = scaffold ? 'Use this draft' : 'Draft from memory';
+  const buttonLabel = 'Save draft';
   const errorText = scaffold
     ? 'Write the smallest useful guess before study appears.'
     : 'Put down the part you can explain, even if it is incomplete.';
+  const cueHtml = options.showCue ? renderBlankStartHtml(scaffold, activeEntryId) : '';
   return `
     <section class="concept-page-b2__attempt" data-attempt-entry-id="${escHtml(activeEntryId)}" aria-label="Memory reconstruction">
-      <span class="eyebrow concept-page-b2__attempt-eyebrow">cold attempt</span>
+      <span class="eyebrow concept-page-b2__attempt-eyebrow visually-hidden">cold attempt</span>
       <h3>${escHtml(heading)}</h3>
       ${helper ? `<p class="concept-page-b2__attempt-helper">${escHtml(helper)}</p>` : ''}
       <textarea
@@ -569,7 +578,10 @@ function renderAttemptPanelHtml(activeEntryId, activeEntry, options = {}) {
         placeholder="${escHtml(placeholder)}"
       ></textarea>
       <p class="concept-page-b2__attempt-error" data-attempt-error hidden>${escHtml(errorText)}</p>
-      <button class="concept-page-b2__attempt-save" type="button" data-attempt-entry-id="${escHtml(activeEntryId)}" disabled aria-disabled="true">${escHtml(buttonLabel)}</button>
+      <div class="concept-page-b2__attempt-actions">
+        <button class="concept-page-b2__attempt-save" type="button" data-attempt-entry-id="${escHtml(activeEntryId)}" disabled aria-disabled="true">${escHtml(buttonLabel)}</button>
+        ${cueHtml}
+      </div>
     </section>
   `;
 }
@@ -671,7 +683,7 @@ function renderBlankStartHtml(scaffold = null, activeEntryId = 'entry') {
   const hintId = `blank-start-${String(activeEntryId || 'entry').replace(/[^a-zA-Z0-9_-]/g, '-')}`;
   return `
     <div class="concept-page-b2__blank-start">
-      <button class="concept-page-b2__blank-start-button" type="button" data-blank-start aria-expanded="false" aria-controls="${escHtml(hintId)}">Stuck?</button>
+      <button class="concept-page-b2__blank-start-button" type="button" data-blank-start aria-expanded="false" aria-controls="${escHtml(hintId)}">Need a cue?</button>
       <p class="concept-page-b2__blank-start-hint" id="${escHtml(hintId)}" data-blank-start-hint hidden>${escHtml(hint)}</p>
     </div>
   `;
@@ -700,7 +712,7 @@ function renderSketchWrapperHtml(thresholdText) {
 
 function renderDrillChamberHtml() {
   return `
-    <section id="drill-chamber-view" class="drill-chamber-view" hidden aria-label="Drill chamber">
+    <section id="drill-chamber-view" class="drill-chamber-view" hidden aria-label="Reconstruction check">
       <div class="drill-chamber__inner">
         <nav class="drill-chamber__crumb" aria-label="Drill location">
           <a href="javascript:void(0)" id="chamber-exit" aria-label="Return to concept">
@@ -720,8 +732,8 @@ function renderDrillChamberHtml() {
           <div class="drill-chamber__composer">
             <textarea id="chamber-composer" placeholder="Write your reconstruction here. Fragments are fine." aria-label="Your reply" rows="3"></textarea>
             <div class="drill-chamber__composer-foot">
-              <span class="drill-chamber__hint">A sentence is enough. Cmd+Return submits.</span>
-              <button class="drill-chamber__send" id="chamber-send" type="button">Submit</button>
+              <span class="drill-chamber__hint">A sentence is enough.</span>
+              <button class="drill-chamber__send" id="chamber-send" type="button">Check reconstruction</button>
             </div>
           </div>
         </div>
@@ -744,7 +756,7 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
   const isPostRevealComparison = viewMode === 'post-reveal-comparison';
   const isExpandedWorkspace = viewMode === 'expanded-workspace';
   const showsOnlyQuietRoute = viewMode === 'cold-surface';
-  const hidesRouteAndNearby = isSavedDraftStudyGate || isPostRevealComparison;
+  const hidesRouteAndNearby = isSourceLess || isSavedDraftStudyGate || isPostRevealComparison;
   const isBlocked = !derived.attempted && !predecessorsAttempted(backbone, activeIdx, training, options);
   const isColdReadyEntry = !isBlocked && !derived.attempted;
   const isAttempting = (
@@ -763,13 +775,22 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     attempted: derived.attempted,
     state: derived.state,
     nextAction: derived.next_action,
+    justRevealedStudy: (options?.justRevealedEntryId === activeEntryId || isPostRevealComparison) && Boolean(derived.record?.study_revealed_at),
     activeIdx,
     totalNodes,
   });
+  const visibleEntryEyebrow = options?.isDrilling
+    ? 'Pressure check'
+    : options?.repairCheckedThisSession && derived.next_action === 'repair'
+    ? 'Repair checked'
+    : entryEyebrow;
   const studyGatePurpose = derived.attempted && derived.next_action === 'study'
     ? 'Your draft gives the notes something specific to work against. Study stays hidden until you choose to compare.'
     : '';
   const scaffold = entryScaffold(activeEntry);
+  const activeEntryTitle = isSourceLess && scaffold
+    ? (scaffold.task_label || scaffold.learner_move || activeEntry.label || 'Core thesis')
+    : (activeEntry.label || 'Core thesis');
   const suppressPurposeForScaffoldAttempt = isAttempting && isColdReadyEntry && Boolean(scaffold?.entry_prompt);
   const entryPurpose = suppressPurposeForScaffoldAttempt
     ? ''
@@ -785,7 +806,10 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     nextAction: derived.next_action,
   });
   const ctaAction = derived.next_action === 'study' ? 'study' : 'drill';
-  const collapseStudyNote = derived.next_action === 'repair';
+  const collapseStudyNote = derived.next_action === 'repair' && !isPostRevealComparison;
+  const hiddenStudyNoteText = options?.repairCheckedThisSession && derived.next_action === 'repair'
+    ? 'Study note stays hidden for later reconstruction.'
+    : 'Study note stays hidden while you repair.';
   const studyNoteHtml = derived.record?.study_revealed_at && !isAttempting
     ? `
       <section class="concept-page-b2__study-note${collapseStudyNote ? ' is-collapsed' : ''}" aria-label="Study note">
@@ -794,66 +818,75 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
           <button class="concept-page-b2__study-note-toggle" type="button" data-study-note-toggle aria-expanded="${collapseStudyNote ? 'false' : 'true'}">${collapseStudyNote ? 'Show study note' : 'Hide study note'}</button>
         </div>
         <p data-study-note-body>${escHtml(studyNoteForEntry(activeEntry, concept, data))}</p>
-        <p class="concept-page-b2__study-note-hidden" data-study-note-hidden>Study note tucked away while you repair.</p>
+        <p class="concept-page-b2__study-note-hidden" data-study-note-hidden>${escHtml(hiddenStudyNoteText)}</p>
       </section>
     `
     : '';
   const evidenceArtifactHtml = !isAttempting ? renderEvidenceArtifactHtml(derived) : '';
-  const repairPanelHtml = isAttempting ? '' : renderRepairPanelHtml(activeEntry, derived, activeEntryId);
+  const repairPanelHtml = isAttempting ? '' : renderRepairPanelHtml(activeEntry, derived, activeEntryId, options);
   const attemptPanelHtml = isAttempting ? renderAttemptPanelHtml(activeEntryId, activeEntry, {
     useScaffold: isColdReadyEntry,
+    showCue: isColdReadyEntry,
     learnerGoal: learnerGoalForConcept(concept, data),
   }) : '';
-  const blankStartHtml = isColdReadyEntry ? renderBlankStartHtml(scaffold, activeEntryId) : '';
 
   const thresholdHtml = thresholdText
     ? renderSketchWrapperHtml(thresholdText)
     : renderSketchWrapperHtml('');
-  const sourceLessProvenanceHtml = isSourceLess
-    ? '<p class="concept-page-b2__source-note">No source attached. Treat this route as provisional.</p>'
-    : '';
-  const nextReady = derived.next_action === 'review'
+  const sourceLessProvenanceHtml = '';
+  const contextDockLabel = 'Recall context';
+  const nextReady = (derived.next_action === 'review' || (derived.next_action === 'repair' && options?.repairCheckedThisSession))
     ? nextReadyEntry(backbone, activeIdx, training, options)
     : null;
   const nextReadyButton = nextReady
-    ? `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(nextReady.id)}" data-active-entry-action="next-entry">Continue route</button>`
+    ? `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(nextReady.id)}" data-active-entry-action="next-entry">${isSourceLess ? 'Continue' : 'Continue route'}</button>`
     : '';
   const ctaButton = options?.isDrilling || isAttempting || derived.next_action === 'repair' || derived.next_action === 'review' || derived.next_action === null
     ? (isPostRevealComparison
       && derived.next_action !== 'repair'
-      ? `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="keep-working">Keep working</button>`
+      ? (nextReadyButton || `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="keep-working">Keep working</button>`)
       : nextReadyButton)
     : isBlocked
     ? `<button class="concept-page-b2__entry-cta concept-page-b2__entry-cta--disabled" type="button" disabled aria-disabled="true" title="Write from memory on the entry above first">Locked</button>`
     : `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="${escHtml(ctaAction)}">${ctaLabel}</button>`;
+  const compareFeedbackHtml = isPostRevealComparison
+    ? ' <button class="concept-page-b2__feedback-link" type="button" data-feedback-rating data-feedback-moment="compare notes">Rate this moment</button>'
+    : '';
 
-  const activeEntryClass = `concept-page-b2__active-entry${options?.isDrilling ? ' concept-page-b2__active-entry--drilling' : ''}`;
+  const activeEntryClass = [
+    'concept-page-b2__active-entry',
+    options?.isDrilling ? 'concept-page-b2__active-entry--drilling' : '',
+    suppressPurposeForScaffoldAttempt ? 'concept-page-b2__active-entry--prompt-first' : '',
+  ].filter(Boolean).join(' ');
   const activeHtml = `
     <section class="${activeEntryClass}" aria-label="Active concept entry">
-      <span class="eyebrow concept-page-b2__entry-eyebrow">${escHtml(entryEyebrow)}</span>
-      <h2 class="concept-page-b2__entry-title">${escHtml(activeEntry.label || 'Core thesis')}</h2>
+      <span class="eyebrow concept-page-b2__entry-eyebrow">${escHtml(visibleEntryEyebrow)}</span>
+      <h2 class="concept-page-b2__entry-title">${escHtml(activeEntryTitle)}</h2>
       ${entryPurpose ? `<p class="concept-page-b2__entry-purpose">${escHtml(entryPurpose)}</p>` : ''}
       ${options?.isDrilling ? renderDrillChamberHtml() : `
         ${evidenceArtifactHtml}
         ${studyNoteHtml}
         ${repairPanelHtml}
         ${attemptPanelHtml}
-        ${blankStartHtml}
         ${ctaButton}
+        <p class="concept-page-b2__truth-note">Your words shape the path. This is not a grade.${compareFeedbackHtml}</p>
       `}
     </section>
   `;
 
-  const nearby = isExpandedWorkspace ? backbone.filter((n) => n !== activeEntry) : [];
+  const suppressNearbyForPrimaryHandoff = Boolean(nextReadyButton) && options?.repairCheckedThisSession === true;
+  const nearby = !hidesRouteAndNearby && isExpandedWorkspace && !isAttempting && !suppressNearbyForPrimaryHandoff
+    ? backbone.filter((n) => n !== activeEntry)
+    : [];
   const nearbyHtml = nearby.length
     ? `
       <section class="concept-page-b2__nearby">
-        <span class="eyebrow concept-page-b2__nearby-eyebrow">nearby entries</span>
+        <span class="eyebrow concept-page-b2__nearby-eyebrow">Nearby entries</span>
         <div class="concept-page-b2__nearby-list">
           ${nearby.map((n) => {
             const idx = backbone.indexOf(n);
             const num = String(idx + 1).padStart(2, '0');
-            const status = entryLearnerState(backbone, idx, training, options).toUpperCase();
+            const status = entryLearnerState(backbone, idx, training, options);
             return `
               <div class="concept-page-b2__nearby-item">
                 <span class="concept-page-b2__nearby-num">${escHtml(num)}</span>
@@ -879,13 +912,12 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
         lockedInert: isSourceLess && isExpandedWorkspace,
       })}
       <div class="concept-page-b2__work">
-        <div class="concept-page-b2__context-dock" aria-label="Recall context">
+        <div class="concept-page-b2__context-dock" aria-label="${escHtml(contextDockLabel)}">
           ${thresholdHtml}
           ${sourceLessProvenanceHtml}
         </div>
         ${activeHtml}
         ${nearbyHtml}
-        <p class="concept-page-b2__truth-note">Your words shape the path. They do not grade you.</p>
       </div>
     </section>
   `;

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -115,6 +115,7 @@ function entryLearnerState(backbone, index, training, options = {}) {
     : [];
   if (derived.attempted) {
     if (derived.state === 'needs repair' && checkedEntryIds.includes(entryId)) {
+      /* c8 ignore next -- secondary route-state label is covered by Node render tests; source-less browser route chrome is hidden */
       return 'repair checked';
     }
     return derived.state || 'attempted';

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -909,8 +909,6 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
         ...options,
         interactive: !showsOnlyQuietRoute,
         quiet: showsOnlyQuietRoute,
-        expandedRoute: isSourceLess && isExpandedWorkspace,
-        lockedInert: isSourceLess && isExpandedWorkspace,
       })}
       <div class="concept-page-b2__work">
         <div class="concept-page-b2__context-dock" aria-label="${escHtml(contextDockLabel)}">

--- a/public/js/drill-chamber.js
+++ b/public/js/drill-chamber.js
@@ -14,7 +14,10 @@
 const els = {};
 let sendHandler = null;
 let exitHandler = null;
+let completionHandler = null;
 let historyTurns = 0;
+const DEFAULT_SEND_LABEL = 'Check reconstruction';
+const _originalPlaceholder = 'Write your reconstruction here. Fragments are fine.';
 
 const REQUIRED_ELEMENT_KEYS = [
   'view',
@@ -50,6 +53,10 @@ function bind() {
 
   els.send.addEventListener('click', () => {
     if (!hasRequiredElements()) return;
+    if (completionHandler) {
+      completionHandler();
+      return;
+    }
     if (typeof sendHandler !== 'function') return;
     if (els.send.disabled) return;        // hard guard against spam
     // Validate BEFORE locking the UI. Without this, an empty-composer
@@ -81,6 +88,7 @@ function bind() {
 function show({ conceptName, entryName, question }) {
   if (!bind()) return;
   els.active.querySelectorAll('.drill-chamber__creed').forEach((el) => el.remove());
+  clearCompletionAction();
   els.conceptName.textContent = conceptName || '—';
   els.entryName.textContent = entryName || '—';
   els.question.textContent = question || '—';
@@ -102,6 +110,7 @@ function show({ conceptName, entryName, question }) {
 
 function hide() {
   if (!bind()) return;
+  clearCompletionAction();
   els.view.hidden = true;
   document.body.classList.remove('chamber-open');
 }
@@ -119,7 +128,7 @@ function appendHistoryTurn(role, text) {
   turn.className = 'drill-chamber__history-turn' + (role === 'learner' ? ' drill-chamber__history-turn--learner' : '');
   const meta = document.createElement('div');
   meta.className = 'drill-chamber__history-turn-meta';
-  meta.textContent = role === 'learner' ? 'you' : 'socratink';
+  meta.textContent = role === 'learner' ? 'Your answer' : 'Prompt';
   const body = document.createElement('div');
   body.className = 'drill-chamber__history-body';
   body.textContent = text;
@@ -133,6 +142,7 @@ function appendHistoryTurn(role, text) {
 
 function swapQuestion(nextText) {
   if (!bind()) return;
+  clearCompletionAction();
   els.active.classList.add('is-fading-out');
   setTimeout(() => {
     if (!hasRequiredElements()) return;
@@ -151,12 +161,10 @@ function swapQuestion(nextText) {
 
 function setComposerEnabled(enabled) {
   if (!bind()) return;
+  if (enabled) clearCompletionAction();
   els.composer.disabled = !enabled;
   els.send.disabled = !enabled;
 }
-
-// Original placeholder, captured once so setLoading(false) can restore it.
-const _originalPlaceholder = 'Write your reconstruction here. Fragments are fine.';
 
 /**
  * Toggle a quiet pending state without taking the writing surface away.
@@ -184,6 +192,24 @@ function clearComposer() {
   els.composer.value = '';
 }
 
+function clearCompletionAction() {
+  if (!hasRequiredElements()) return;
+  completionHandler = null;
+  els.active?.removeAttribute('data-complete');
+  els.send.textContent = DEFAULT_SEND_LABEL;
+  els.composer.placeholder = _originalPlaceholder;
+}
+
+function setCompletionAction(label = 'Return to concept', handler = null) {
+  if (!bind()) return;
+  completionHandler = typeof handler === 'function' ? handler : exitHandler;
+  els.active?.setAttribute('data-complete', 'true');
+  els.composer.value = '';
+  els.composer.disabled = true;
+  els.send.disabled = false;
+  els.send.textContent = label;
+}
+
 /**
  * Show the doctrinal first-cold-attempt creed in the chamber after
  * generative_commitment === true. Three lines, diamond bullets,
@@ -208,7 +234,7 @@ function onExit(handler) { exitHandler = handler; }
 
 window.DrillChamber = {
   show, hide, appendHistoryTurn, swapQuestion,
-  setComposerEnabled, setLoading,
+  setComposerEnabled, setLoading, setCompletionAction,
   getComposerValue, clearComposer,
   appendCreed,
   onSend, onExit,

--- a/public/js/feedback.js
+++ b/public/js/feedback.js
@@ -5,20 +5,43 @@
 export const Feedback = (() => {
   const overlay = document.getElementById('feedback-overlay');
   const form = document.getElementById('feedback-form');
+  const title = document.getElementById('feedback-title');
   const textarea = document.getElementById('feedback-message');
+  const ratingInput = document.getElementById('feedback-ux-rating');
+  const description = document.getElementById('feedback-desc');
   const status = document.getElementById('feedback-status');
   const submitBtn = document.getElementById('feedback-submit');
+  const defaultTitle = title?.textContent || 'Feedback';
+  const defaultDescription = description?.textContent || '';
+  const defaultSubmitLabel = submitBtn?.textContent || 'Send Feedback';
   let opener = null;
+  let currentMoment = '';
 
-  function show() {
+  function promptForMoment(moment) {
+    if (moment === 'compare notes') return 'How did comparing your answer to the notes feel?';
+    if (moment === 'repair checked') return 'How did checking your repair feel?';
+    return `How did the ${moment} step feel?`;
+  }
+
+  function show(options = {}) {
     if (!overlay) return;
     opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     overlay.hidden = false;
     textarea.value = '';
+    if (ratingInput) ratingInput.value = '';
+    currentMoment = String(options?.moment || '').trim();
+    if (title) title.textContent = currentMoment ? 'Rate this moment' : defaultTitle;
+    if (description) {
+      description.textContent = currentMoment
+        ? `${promptForMoment(currentMoment)} A 9 or 10 means the UX feels ready for a new customer.`
+        : defaultDescription;
+    }
     status.textContent = '';
     status.className = 'modal-status';
     submitBtn.disabled = false;
-    textarea.focus();
+    submitBtn.textContent = currentMoment ? 'Send Rating' : defaultSubmitLabel;
+    const focusTarget = options?.focus === 'rating' && ratingInput ? ratingInput : textarea;
+    focusTarget.focus();
   }
 
   function hide() {
@@ -32,10 +55,19 @@ export const Feedback = (() => {
   async function submit(event) {
     if (event) event.preventDefault();
     const message = textarea.value.trim();
-    if (message.length < 10) {
+    const rating = ratingInput ? Number.parseInt(ratingInput.value, 10) : NaN;
+    if (ratingInput?.value && (!Number.isInteger(rating) || rating < 1 || rating > 10)) {
+      setStatus('UX feel must be 1-10.', 'err');
+      ratingInput.focus();
+      return false;
+    }
+    if (!Number.isInteger(rating) && message.length < 10) {
       setStatus('Message must be at least 10 characters.', 'err');
       return false;
     }
+    const payloadMessage = Number.isInteger(rating)
+      ? [`UX feel: ${rating}/10`, currentMoment ? `UX moment: ${currentMoment}` : '', message].filter(Boolean).join('\n')
+      : message;
 
     submitBtn.disabled = true;
     setStatus('Sending...', '');
@@ -46,7 +78,7 @@ export const Feedback = (() => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ message }),
+        body: JSON.stringify({ message: payloadMessage }),
       });
 
       if (!response.ok) {
@@ -56,6 +88,8 @@ export const Feedback = (() => {
 
       setStatus('Thank you! Feedback captured.', 'ok');
       textarea.value = '';
+      if (ratingInput) ratingInput.value = '';
+      currentMoment = '';
       setTimeout(hide, 2000);
     } catch (err) {
       console.error('Feedback submission failed:', err);

--- a/public/js/feedback.js
+++ b/public/js/feedback.js
@@ -56,6 +56,11 @@ export const Feedback = (() => {
     if (event) event.preventDefault();
     const message = textarea.value.trim();
     const rating = ratingInput ? Number.parseInt(ratingInput.value, 10) : NaN;
+    if (currentMoment && !ratingInput?.value) {
+      setStatus('Please rate this moment 1-10.', 'err');
+      ratingInput?.focus();
+      return false;
+    }
     if (ratingInput?.value && (!Number.isInteger(rating) || rating < 1 || rating > 10)) {
       setStatus('UX feel must be 1-10.', 'err');
       ratingInput.focus();
@@ -68,6 +73,11 @@ export const Feedback = (() => {
     const payloadMessage = Number.isInteger(rating)
       ? [`UX feel: ${rating}/10`, currentMoment ? `UX moment: ${currentMoment}` : '', message].filter(Boolean).join('\n')
       : message;
+    if (payloadMessage.length > 1000) {
+      setStatus('Feedback must be 1000 characters or fewer after rating details.', 'err');
+      textarea.focus();
+      return false;
+    }
 
     submitBtn.disabled = true;
     setStatus('Sending...', '');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,9 +1,9 @@
 @import './css/variables.css?v=81';
 @import './css/base.css?v=73';
 @import './css/crystal.css?v=71';
-@import './css/components.css?v=97';
-@import './css/layout.css?v=107';
+@import './css/components.css?v=98';
+@import './css/layout.css?v=108';
 @import './css/board-first.css?v=4';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';
-@import './css/concept-page.css?v=43';
+@import './css/concept-page.css?v=44';

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -1077,7 +1077,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               null,
               { now: '2026-05-15T20:00:00.000Z' },
             );
-            assert(legacyPrimedWaitingHtml.includes('review pending'), 'legacy primed spacing lock renders review state');
+            assert(legacyPrimedWaitingHtml.includes('Review later'), 'legacy primed spacing lock renders review state');
             assert(!legacyPrimedWaitingHtml.includes('concept-page-b2__entry-cta'), 'legacy primed spacing lock suppresses reattempt cta');
             const legacyPrimedReadyHtml = conceptPage.renderActiveEntryHtml(
               {
@@ -1119,7 +1119,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               null,
               { now: '2026-05-15T20:00:00.000Z' },
             );
-            assert(legacyDrilledWaitingHtml.includes('review pending'), 'legacy drilled spacing lock renders review state');
+            assert(legacyDrilledWaitingHtml.includes('Review later'), 'legacy drilled spacing lock renders review state');
             assert(!legacyDrilledWaitingHtml.includes('concept-page-b2__entry-cta'), 'legacy drilled spacing lock suppresses reattempt cta');
             const initialEntry = conceptPage.selectInitialConceptEntry([
               { id: 'done', label: 'Done', drill_status: 'solidified' },
@@ -1197,7 +1197,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(conceptPageHtml.includes('locked'), 'concept page blocked eyebrow');
             assert(conceptPageHtml.includes('aria-disabled="true"'), 'concept page blocked cta');
             assert(conceptPageHtml.includes('Second &amp; unsafe'), 'concept page nearby escapes');
-            assert(conceptPageHtml.includes('READY TO RECONSTRUCT'), 'concept page derives nearby readiness from training');
+            assert(conceptPageHtml.includes('ready to reconstruct'), 'concept page derives nearby readiness from training');
             const conceptPageAttemptHtml = conceptPage.renderActiveEntryHtml(
               conceptBackbone[1],
               1,
@@ -1209,7 +1209,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             );
             assert(conceptPageAttemptHtml.includes('concept-page-b2__attempt'), 'concept page inline attempt form');
             assert(conceptPageAttemptHtml.includes('data-attempt-entry-id="entry-2"'), 'concept page inline attempt target');
-            assert(conceptPageAttemptHtml.includes('Draft from memory'), 'concept page inline attempt save');
+            assert(conceptPageAttemptHtml.includes('Save draft'), 'concept page inline attempt save');
             const conceptPagePrimedHtml = conceptPage.renderActiveEntryHtml(
               { id: 'primed', label: 'Primed', drill_status: 'primed' },
               0,
@@ -1266,7 +1266,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               },
               { now: '2026-05-15T11:00:00.000Z' },
             );
-            assert(conceptPageStudiedHtml.includes('review pending'), 'concept page studied review eyebrow');
+            assert(conceptPageStudiedHtml.includes('Review later'), 'concept page studied review eyebrow');
             assert(conceptPageStudiedHtml.includes('concept-page-b2__evidence'), 'concept page studied evidence artifact renders');
             assert(conceptPageStudiedHtml.includes('Your draft'), 'concept page studied evidence label');
             assert(!conceptPageStudiedHtml.includes('learner reconstruction'), 'concept page hides internal reconstruction language');
@@ -1388,7 +1388,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               },
               { now: '2026-05-15T11:00:00.000Z' },
             );
-            assert(conceptPageReviewHtml.includes('review pending'), 'concept page review pending eyebrow');
+            assert(conceptPageReviewHtml.includes('Review later'), 'concept page review-later eyebrow');
             assert(!conceptPageReviewHtml.includes('concept-page-b2__entry-cta'), 'concept page review has no cta');
             const conceptPageSpacedHtml = conceptPage.renderActiveEntryHtml(
               { id: 'spaced', label: 'Spaced' },

--- a/tests/e2e/test_concept_page_b2.py
+++ b/tests/e2e/test_concept_page_b2.py
@@ -1,7 +1,7 @@
 """End-to-end smoke for the B-2 concept page layout.
 
-Covers: open a concept page; route margin, threshold, active entry, and
-nearby list all render; the cold-entry draft surface is inline.
+Covers: open a concept page; route margin, threshold, active entry, and the
+cold-entry draft surface is inline without the old nearby panel.
 
 Note: this file checks that the legacy Route/Graph toggle is gone. The live
 Route/Constellation switch is covered in test_smoke.py; see test_strip_nav.py
@@ -82,7 +82,7 @@ def _enter_app_shell_as_guest(page: Page, base_url: str) -> None:
 
 
 def _seed_concept_with_backbone(page: Page, name: str = "Photosynthesis") -> None:
-    """Seed a concept with backbone entries so the nearby list renders.
+    """Seed a concept with backbone entries for route-margin coverage.
     The first entry is cold-ready so the inline draft surface is visible.
     Seeding happens BEFORE navigation so it is picked up on page load."""
     page.evaluate(
@@ -139,15 +139,14 @@ def _open_seeded_concept_via_sidebar(page: Page, base_url: str) -> None:
 
 
 def test_b2_layout_renders(clean_page: Page, base_url: str) -> None:
-    """Route margin, threshold, active entry, and nearby list all render."""
+    """Route margin, threshold, and active entry render without the nearby panel."""
     _open_seeded_concept_via_sidebar(clean_page, base_url)
     expect(clean_page.locator(".concept-page-b2__route")).to_be_visible(timeout=8_000)
     expect(clean_page.locator(".concept-page-b2__entry-title")).to_be_visible()
     expect(clean_page.locator(".concept-page-b2__attempt-input")).to_be_visible()
     # threshold must be present (either with learner text or empty-state)
     expect(clean_page.locator(".concept-page-b2__threshold")).to_be_visible()
-    # 3-entry backbone: 1 active + 2 nearby
-    expect(clean_page.locator(".concept-page-b2__nearby-list")).to_be_visible()
+    expect(clean_page.locator(".concept-page-b2__nearby")).to_have_count(0)
     expect(clean_page.locator(".vd-sketch-body")).to_be_hidden()
     clean_page.locator('[data-action="toggle-sketch"]').press("Enter")
     expect(clean_page.locator(".vd-sketch-body")).to_be_visible()

--- a/tests/e2e/test_drill_chamber.py
+++ b/tests/e2e/test_drill_chamber.py
@@ -262,7 +262,8 @@ def test_drill_chamber_opens_inline_inside_concept_view(
     expect(clean_page.locator("#chamber-composer")).not_to_have_attribute(
         "placeholder", "Preparing your first question"
     )
-    expect(clean_page.locator("#chamber-send")).to_have_text("Submit")
+    expect(clean_page.locator("#chamber-send")).to_have_text("Check reconstruction")
+    expect(clean_page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Pressure check")
     expect(clean_page.locator("#drill-chamber-view")).to_contain_text(
         "Reconstruct Entry A from memory"
     )
@@ -566,7 +567,7 @@ def test_repair_drill_context_is_bounded_for_drill_request(
                     "help_request_reason": None,
                     "classification": None,
                     "gap_description": None,
-                    "routing": "SCAFFOLD",
+                    "routing": "NEXT",
                     "response_tier": None,
                     "response_band": None,
                     "tier_reason": None,
@@ -614,6 +615,13 @@ Learner repair text: repaired link`,
     while not drill_calls and time.monotonic() < deadline:
         page.wait_for_timeout(100)
     assert drill_calls
+    expect(page.locator(".drill-chamber__history-turn-meta").nth(0)).to_have_text("Prompt")
+    expect(page.locator(".drill-chamber__history-turn-meta").nth(1)).to_have_text("Your answer")
+    expect(page.locator("#chamber-send")).to_have_text("Return to concept")
+    expect(page.locator("#chamber-send")).to_be_enabled()
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_count(0)
+    assert page.evaluate("window.scrollY") <= 1
 
     assert len(drill_calls[0]["node_mechanism"]) <= 10_000
     assert "Learner repair text: repaired link" in drill_calls[0]["node_mechanism"]

--- a/tests/e2e/test_gestalt_hybrid_launch_qa.py
+++ b/tests/e2e/test_gestalt_hybrid_launch_qa.py
@@ -240,7 +240,7 @@ def test_source_less_launch_pad_end_to_end_qa(
         "What do you think the thermostat checks before it calls for heat?"
     )
     expect(canvas).to_contain_text("Compare target")
-    expect(canvas).to_contain_text("Call for heat")
+    expect(canvas).not_to_contain_text("Call for heat")
     expect(canvas).not_to_contain_text("compares measured room temperature")
     expect(canvas).not_to_contain_text("Generated description should not leak")
     expect(canvas.locator(".concept-page-b2__route-item")).to_have_count(0)
@@ -254,6 +254,9 @@ def test_source_less_launch_pad_end_to_end_qa(
         "Reveal notes and compare"
     )
     expect(clean_page.locator(".concept-page-b2__evidence")).to_contain_text(
+        "Your memory draft"
+    )
+    expect(clean_page.locator(".concept-page-b2__evidence")).not_to_contain_text(
         "Draft recorded."
     )
     expect(clean_page.locator(".concept-page-b2__evidence")).not_to_contain_text(
@@ -288,16 +291,8 @@ def test_source_less_launch_pad_end_to_end_qa(
     )
     clean_page.locator("#chamber-send").click()
     expect(clean_page.locator("#chamber-composer")).to_be_disabled()
-    expect(clean_page.locator(".concept-page-b2__route-item")).to_have_count(3)
-    expect(clean_page.locator(".concept-page-b2__route")).to_have_attribute(
-        "data-route-expanded", "true"
-    )
-    expect(clean_page.locator(".concept-page-b2__route")).to_have_attribute(
-        "data-locked-inert", "true"
-    )
-    clean_page.locator('.concept-page-b2__route-item[data-entry-id="c2_s1"]').click()
-    clean_page.wait_for_timeout(700)
-    expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text("Compare target")
+    expect(clean_page.locator(".concept-page-b2__route")).to_have_count(0)
+    expect(clean_page.locator("#concept-view-switch")).to_be_hidden()
 
     assert "POST /api/extract Thermostat feedback loop" in requests_seen
     assert "POST /api/drill c1_s1" in requests_seen

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1889,6 +1889,33 @@ def test_feedback_submit_reenables_on_reopen(
     expect(clean_page.locator("#feedback-ux-rating")).to_have_value("")
 
 
+def test_feedback_custom_moment_rejects_invalid_rating(
+    clean_page: Page, base_url: str
+) -> None:
+    """Moment feedback should explain the moment and reject invalid scores."""
+    _enter_app_shell_as_guest(clean_page, base_url)
+
+    clean_page.evaluate("window.Feedback.show({ focus: 'rating', moment: 'focus mode' })")
+
+    expect(clean_page.locator("#feedback-overlay")).to_be_visible()
+    expect(clean_page.locator("#feedback-desc")).to_have_text(
+        "How did the focus mode step feel? A 9 or 10 means the UX feels ready for a new customer."
+    )
+    clean_page.evaluate(
+        """() => {
+            const rating = document.getElementById('feedback-ux-rating');
+            rating.insertAdjacentHTML('beforeend', '<option value="11">11</option>');
+            rating.value = '11';
+        }"""
+    )
+    clean_page.locator("#feedback-submit").click()
+
+    expect(clean_page.locator("#feedback-status")).to_have_text(
+        "UX feel must be 1-10."
+    )
+    expect(clean_page.locator("#feedback-ux-rating")).to_be_focused()
+
+
 def test_feedback_dialog_has_accessible_escape_close(
     clean_page: Page, base_url: str
 ) -> None:

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -532,8 +532,20 @@ def test_localhost_library_qa_seed_creates_training_truth_concept(
     """Localhost QA can seed a concept with learner-owned training evidence."""
     if not _is_loopback_base_url(base_url):
         pytest.skip("local QA seed controls are intentionally loopback-only")
+    feedback_payloads = []
     _enter_app_shell_as_guest(page, base_url)
     page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    page.route(
+        "**/api/feedback",
+        lambda route: (
+            feedback_payloads.append(route.request.post_data_json),
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{"ok": true}',
+            ),
+        ),
+    )
 
     page.locator("#nav-library").click()
     page.locator("[data-local-qa-seed]").click()
@@ -559,7 +571,7 @@ def test_localhost_library_qa_seed_creates_training_truth_concept(
     context_dock = page.locator(".concept-page-b2__context-dock")
     expect(context_dock).to_contain_text("Context")
     expect(context_dock).to_contain_text("Learner rough sketch baseline.")
-    expect(context_dock).to_contain_text(
+    expect(context_dock).not_to_contain_text(
         "No source attached. Treat this route as provisional."
     )
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
@@ -582,9 +594,28 @@ def test_localhost_library_qa_seed_creates_training_truth_concept(
         "The revealed study note names the comparison target after the cold attempt: identify the mechanism, then mark any missing link for repair."
     )
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "review pending"
+        "Compare notes"
     )
-    expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Keep working")
+    expect(page.locator("[data-feedback-rating]")).to_have_text("Rate this moment")
+    page.locator("[data-feedback-rating]").click()
+    expect(page.locator("#feedback-overlay")).to_be_visible()
+    expect(page.locator("#feedback-title")).to_have_text("Rate this moment")
+    expect(page.locator("#feedback-desc")).to_have_text(
+        "How did comparing your answer to the notes feel? A 9 or 10 means the UX feels ready for a new customer."
+    )
+    expect(page.locator("#feedback-submit")).to_have_text("Send Rating")
+    expect(page.locator("#feedback-ux-rating")).to_be_focused()
+    page.locator("#feedback-ux-rating").select_option("9")
+    page.locator("#feedback-submit").click()
+    expect(page.locator("#feedback-status")).to_have_text(
+        "Thank you! Feedback captured."
+    )
+    assert feedback_payloads == [
+        {"message": "UX feel: 9/10\nUX moment: compare notes"}
+    ]
+    page.locator(".modal-close").click()
+    expect(page.locator("#feedback-overlay")).not_to_be_visible()
     revealed_training = page.evaluate(
         """JSON.parse(localStorage.getItem('socratink:training:v1:local-qa-training-concept'))"""
     )
@@ -605,7 +636,7 @@ def test_localhost_library_qa_seed_creates_training_truth_concept(
         "Updated learner sketch."
     )
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "review pending"
+        "Compare notes"
     )
     edited_training = page.evaluate(
         """JSON.parse(localStorage.getItem('socratink:training:v1:local-qa-training-concept'))"""
@@ -735,6 +766,41 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     """A studied thin attempt can append repair text without faking mastery."""
     if not _is_loopback_base_url(base_url):
         pytest.skip("local QA seed controls are intentionally loopback-only")
+    drill_calls: list[dict] = []
+
+    def fulfill_drill(route):
+        payload = route.request.post_data_json
+        drill_calls.append(payload)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "agent_response": "That repair is coherent enough to move on. The entry is still evidence-neutral until spaced reconstruction.",
+                    "generative_commitment": False,
+                    "answer_mode": "attempt",
+                    "score_eligible": True,
+                    "classification": "solid",
+                    "gap_description": None,
+                    "routing": "NEXT",
+                    "response_tier": 3,
+                    "response_band": "mechanism",
+                    "tier_reason": "The answer names the condition, action, and downstream change.",
+                    "node_id": payload["node_id"],
+                    "probe_count": 1,
+                    "nodes_drilled": 1,
+                    "attempt_turn_count": 1,
+                    "help_turn_count": 0,
+                    "graph_mutated": False,
+                    "ux_reward_emitted": False,
+                    "session_terminated": False,
+                    "termination_reason": None,
+                    "prompt_version": "qa-pressure-check-terminal",
+                }
+            ),
+        )
+
+    page.route("**/api/drill", fulfill_drill)
     _enter_app_shell_as_guest(page, base_url)
     page.evaluate("localStorage.clear(); sessionStorage.clear();")
 
@@ -759,7 +825,7 @@ def test_localhost_concept_repair_appends_learner_gap_work(
 
     page.locator(".concept-page-b2__entry-cta").click()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Needs repair"
+        "Compare notes"
     )
     expect(page.locator(".concept-page-b2__evidence")).not_to_contain_text(
         "Missing piece"
@@ -770,6 +836,29 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     expect(page.locator(".concept-page-b2__repair")).to_contain_text(
         "Name that threshold opens the channel"
     )
+    repair_surface_style = page.locator(".concept-page-b2__repair").evaluate(
+        """(el) => {
+            const style = window.getComputedStyle(el);
+            const labelStyle = window.getComputedStyle(el.querySelector('.concept-page-b2__repair-target span'));
+            const saveStyle = window.getComputedStyle(el.querySelector('.concept-page-b2__repair-save'));
+            return {
+                backgroundColor: style.backgroundColor,
+                borderLeftWidth: style.borderLeftWidth,
+                borderTopWidth: style.borderTopWidth,
+                labelTextTransform: labelStyle.textTransform,
+                labelLetterSpacing: labelStyle.letterSpacing,
+                saveMinHeight: saveStyle.minHeight,
+            };
+        }"""
+    )
+    assert repair_surface_style == {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderLeftWidth": "2px",
+        "borderTopWidth": "0px",
+        "labelTextTransform": "none",
+        "labelLetterSpacing": "normal",
+        "saveMinHeight": "44px",
+    }
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
 
     page.locator(".concept-page-b2__repair-save").click()
@@ -816,12 +905,51 @@ def test_localhost_concept_repair_appends_learner_gap_work(
         "Pressure-check this link"
     )
     expect(page.locator(".concept-page-b2__repair")).to_be_visible()
+    assert page.evaluate("window.scrollY") == 0
     page.locator(".concept-page-b2__entry-cta").click()
     expect(page.locator("#drill-chamber-view")).to_be_visible()
+    expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
+        "Pressure check"
+    )
+    expect(page.locator("#chamber-send")).to_have_text("Check reconstruction")
+    expect(page.locator(".drill-chamber__hint")).to_have_text("A sentence is enough.")
     expect(
         page.locator(".concept-page-b2__active-entry--drilling #drill-chamber-view")
     ).to_be_visible()
     expect(page.locator(".concept-page-b2__attempt-input")).to_have_count(0)
+    page.locator("#chamber-composer").fill(
+        "Threshold opens the channel, then sodium moves through because the gradient can act."
+    )
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-send")).to_have_text("Return to concept")
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_count(0)
+    expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
+        "Repair checked"
+    )
+    expect(page.locator(".concept-page-b2__repair")).to_contain_text(
+        "Repair checked for now."
+    )
+    expect(page.locator(".concept-page-b2__repair")).to_contain_text(
+        "A strong later answer can update the record."
+    )
+    expect(page.locator(".concept-page-b2__study-note")).to_contain_text(
+        "Study note stays hidden for later reconstruction."
+    )
+    expect(page.locator(".concept-page-b2__study-note")).not_to_contain_text(
+        "while you repair"
+    )
+    expect(page.locator("[data-feedback-rating]")).to_have_text("Rate this moment")
+    page.locator("[data-feedback-rating]").click()
+    expect(page.locator("#feedback-overlay")).to_be_visible()
+    expect(page.locator("#feedback-desc")).to_have_text(
+        "How did checking your repair feel? A 9 or 10 means the UX feels ready for a new customer."
+    )
+    expect(page.locator("#feedback-ux-rating")).to_be_focused()
+    page.keyboard.press("Escape")
+    expect(page.locator("#feedback-overlay")).not_to_be_visible()
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
+    assert drill_calls[0]["drill_mode"] == "re_drill"
     repaired_training = page.evaluate(
         """JSON.parse(localStorage.getItem('socratink:training:v1:qa-repair-concept'))"""
     )
@@ -1354,8 +1482,9 @@ def test_localhost_legacy_inline_redrill_keeps_spaced_semantics(
     page.locator("#nav-library").click()
     page.locator(".library-card-vault", has_text="Legacy Re-drill Truth QA").click()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Ready to reconstruct again"
+        "Compare notes"
     )
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Reconstruct from memory")
     page.locator(".concept-page-b2__entry-cta").click()
     page.locator(".concept-page-b2__attempt-input").fill(
         "The mechanism opens first, then the downstream flow follows."
@@ -1717,6 +1846,10 @@ def test_feedback_button_keeps_sidebar_open(
     clean_page.locator("#nav-feedback").click()
 
     expect(clean_page.locator("#feedback-overlay")).to_be_visible()
+    expect(clean_page.locator("#feedback-desc")).to_have_text(
+        "Share a bug, rough edge, or idea. A 9 or 10 means the UX feels ready for a new customer."
+    )
+    expect(clean_page.locator("#feedback-submit")).to_have_text("Send Feedback")
     assert clean_page.locator("#drawer").get_attribute("data-open") == "true"
     assert clean_page.locator("body").get_attribute("data-drawer-open") == "true"
 
@@ -1725,29 +1858,35 @@ def test_feedback_submit_reenables_on_reopen(
     clean_page: Page, base_url: str
 ) -> None:
     """A successful feedback send must not leave the next feedback modal disabled."""
+    feedback_payloads = []
     _enter_app_shell_as_guest(clean_page, base_url)
     clean_page.route(
         "**/api/feedback",
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body='{"ok": true}',
+        lambda route: (
+            feedback_payloads.append(route.request.post_data_json),
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{"ok": true}',
+            ),
         ),
     )
 
     clean_page.locator("#nav-feedback").click()
-    clean_page.locator("#feedback-message").fill("This feedback should submit cleanly.")
+    clean_page.locator("#feedback-ux-rating").select_option("9")
     clean_page.locator("#feedback-submit").click()
 
     expect(clean_page.locator("#feedback-status")).to_have_text(
         "Thank you! Feedback captured."
     )
+    assert feedback_payloads == [{"message": "UX feel: 9/10"}]
     clean_page.locator(".modal-close").click()
 
     clean_page.locator("#nav-feedback").click()
 
     expect(clean_page.locator("#feedback-submit")).to_be_enabled()
     expect(clean_page.locator("#feedback-message")).to_have_value("")
+    expect(clean_page.locator("#feedback-ux-rating")).to_have_value("")
 
 
 def test_feedback_dialog_has_accessible_escape_close(
@@ -1761,7 +1900,10 @@ def test_feedback_dialog_has_accessible_escape_close(
     expect(clean_page.locator("#feedback-overlay")).to_have_attribute("role", "dialog")
     expect(clean_page.locator("#feedback-overlay")).to_have_attribute("aria-modal", "true")
     expect(clean_page.locator("#feedback-overlay")).to_have_attribute("aria-labelledby", "feedback-title")
+    expect(clean_page.locator("#feedback-overlay")).to_have_attribute("aria-describedby", "feedback-desc")
     expect(clean_page.locator("#feedback-title")).to_have_text("Feedback")
+    expect(clean_page.locator("#feedback-status")).to_have_attribute("role", "status")
+    expect(clean_page.locator("#feedback-status")).to_have_attribute("aria-live", "polite")
 
     clean_page.keyboard.press("Escape")
 
@@ -1839,15 +1981,58 @@ def test_mobile_concept_attempt_has_writing_width(
     expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible()
     expect(page.locator("#drawer-toggle")).to_be_visible()
     expect(page.locator("#bottom-nav")).not_to_be_visible()
+    disabled_save_style = page.locator(".concept-page-b2__attempt-save").evaluate(
+        """(el) => {
+            const style = window.getComputedStyle(el);
+            return {
+                backgroundColor: style.backgroundColor,
+                borderStyle: style.borderStyle,
+            };
+        }"""
+    )
+    assert disabled_save_style == {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderStyle": "dashed",
+    }
+    page.locator(".concept-page-b2__attempt-input").fill(
+        "Sodium channels probably open when voltage reaches a trigger."
+    )
+    expect(page.locator("#concept-view-switch")).to_be_hidden()
 
     toggle_box = page.locator("#drawer-toggle").bounding_box()
     assert toggle_box is not None
     assert toggle_box["width"] >= 44
     assert toggle_box["height"] >= 44
+    title_box = page.locator("#concept-header-title").bounding_box()
+    assert title_box is not None
+    assert title_box["y"] > toggle_box["y"] + toggle_box["height"]
+    context_label_box = page.locator(".concept-page-b2__threshold-label").bounding_box()
+    context_edit_box = page.locator("[data-edit-threshold]").bounding_box()
+    assert context_label_box is not None
+    assert context_edit_box is not None
+    context_label_center = context_label_box["y"] + (context_label_box["height"] / 2)
+    context_edit_center = context_edit_box["y"] + (context_edit_box["height"] / 2)
+    assert abs(context_edit_center - context_label_center) <= 6
+    assert context_edit_box["x"] > context_label_box["x"]
+    assert context_edit_box["height"] >= 43.9
+    expect(page.locator(".concept-page-b2__route")).to_have_count(0)
 
     attempt_box = page.locator(".concept-page-b2__attempt-input").bounding_box()
     assert attempt_box is not None
     assert attempt_box["width"] >= 300
+    assert attempt_box["height"] >= 140
+    save_box = page.locator(".concept-page-b2__attempt-save").bounding_box()
+    cue_box = page.locator(".concept-page-b2__blank-start-button").bounding_box()
+    truth_note_box = page.locator(".concept-page-b2__truth-note").bounding_box()
+    assert save_box is not None
+    assert cue_box is not None
+    assert truth_note_box is not None
+    save_center = save_box["y"] + (save_box["height"] / 2)
+    cue_center = cue_box["y"] + (cue_box["height"] / 2)
+    assert abs(save_center - cue_center) <= 6
+    assert cue_box["x"] > save_box["x"]
+    assert save_box["width"] >= 132
+    assert truth_note_box["y"] <= cue_box["y"] + cue_box["height"] + 36
 
 
 def test_saved_library_concept_reopens_map_view(
@@ -1881,7 +2066,7 @@ def test_saved_library_concept_reopens_map_view(
 def test_concept_view_opens_to_route_margin_canvas(
     clean_page: Page, base_url: str
 ) -> None:
-    """A cold concept opens on a gestalt route margin with inline generation."""
+    """A cold source-less concept opens on one writing surface."""
     _seed_route_margin_concept(clean_page)
     _enter_app_shell_as_guest(clean_page, base_url)
 
@@ -1892,7 +2077,7 @@ def test_concept_view_opens_to_route_margin_canvas(
 
     canvas = clean_page.locator(".concept-page-b2__gestalt")
     expect(canvas).to_be_visible()
-    expect(clean_page.locator("#concept-view-switch")).to_have_text("Constellation")
+    expect(clean_page.locator("#concept-view-switch")).to_be_hidden()
     expect(clean_page.locator("#concept-constellation-content")).to_be_hidden()
     expect(canvas.locator(".concept-page-b2__context-dock")).to_contain_text("Context")
     expect(canvas.locator(".concept-page-b2__context-dock")).to_contain_text(
@@ -1902,11 +2087,7 @@ def test_concept_view_opens_to_route_margin_canvas(
         "Write first. Compare after."
     )
     expect(canvas.locator(".concept-page-b2__route-item")).to_have_count(0)
-    expect(canvas.locator(".concept-page-b2__route-marker-item")).to_have_count(4)
-    expect(canvas.locator(".concept-page-b2__route-marker-item").nth(0)).to_contain_text("Sodium gate")
-    expect(canvas.locator(".concept-page-b2__route-marker-item").nth(1)).to_contain_text("Opening rule")
-    expect(canvas.locator(".concept-page-b2__route-marker-item").nth(2)).to_contain_text("Signal spread")
-    expect(canvas.locator(".concept-page-b2__route-marker-item").nth(3)).to_contain_text("Blocked gate")
+    expect(canvas.locator(".concept-page-b2__route-marker-item")).to_have_count(0)
     expect(canvas).not_to_contain_text("Sodium channels open at threshold")
     expect(canvas).not_to_contain_text("This generated summary must not")
     expect(canvas).not_to_contain_text("bloom")
@@ -1922,9 +2103,7 @@ def test_concept_view_opens_to_route_margin_canvas(
     expect(canvas.locator(".concept-page-b2__attempt")).to_contain_text(
         "Write one sentence. Name the trigger, even if you are guessing."
     )
-    expect(canvas.locator(".concept-page-b2__attempt-save")).to_have_text(
-        "Use this draft"
-    )
+    expect(canvas.locator(".concept-page-b2__attempt-save")).to_have_text("Save draft")
     expect(canvas.locator(".concept-page-b2__attempt-save")).to_be_disabled()
     expect(canvas.locator(".concept-page-b2__attempt-save")).to_have_attribute(
         "aria-disabled", "true"
@@ -1939,9 +2118,10 @@ def test_concept_view_opens_to_route_margin_canvas(
         "aria-disabled", "false"
     )
     blank_start = canvas.locator("[data-blank-start]")
-    expect(blank_start).to_have_text("Stuck?")
+    expect(blank_start).to_have_text("Need a cue?")
     expect(blank_start).to_have_attribute("aria-expanded", "false")
     blank_start.click()
+    expect(blank_start).to_be_hidden()
     expect(canvas.locator("[data-blank-start-hint]")).to_be_visible()
     expect(canvas.locator("[data-blank-start-hint]")).to_contain_text(
         "Think about the point where a small signal becomes enough to matter."
@@ -1956,7 +2136,7 @@ def test_concept_view_opens_to_route_margin_canvas(
     attempt_input.fill("")
     fallback_html = clean_page.evaluate(
         """async () => {
-            const mod = await import('/js/concept-page-view.js?v=17');
+            const mod = await import('/js/concept-page-view.js?v=22');
             const entries = mod.deriveConceptEntries({
                 clusters: [{
                     id: 'c1',
@@ -1992,7 +2172,7 @@ def test_concept_view_opens_to_route_margin_canvas(
     assert "Type one relationship you suspect, even if it feels incomplete." in fallback_html
     empty_fallback_html = clean_page.evaluate(
         """async () => {
-            const mod = await import('/js/concept-page-view.js?v=17');
+            const mod = await import('/js/concept-page-view.js?v=22');
             const entries = mod.deriveConceptEntries({
                 clusters: [{
                     id: 'c1',
@@ -2024,46 +2204,13 @@ def test_concept_view_opens_to_route_margin_canvas(
             );
         }"""
     )
-    assert "Write the first useful version of your current model." in empty_fallback_html
+    assert "Write what you can explain right now." in empty_fallback_html
     canvas.locator(".concept-page-b2__attempt-input").fill(
         "Sodium channels probably open when voltage reaches a trigger."
     )
-    clean_page.locator("#concept-view-switch").click()
-    expect(clean_page.locator("#map-content")).to_be_hidden()
-    constellation = clean_page.locator("#concept-constellation-content")
-    expect(constellation).to_be_visible()
-    expect(clean_page.locator("#concept-view-switch")).to_have_text("Return to route")
-    expect(constellation).to_contain_text("Draft structure only.")
-    expect(constellation).to_contain_text("Overview first.")
-    expect(constellation.locator(".concept-constellation__selected")).to_be_visible()
-    expect(constellation.locator("[data-constellation-selected-name]")).to_have_text(
-        "Sodium gate"
-    )
-    expect(constellation.locator(".concept-constellation__node")).to_have_count(4)
-    expect(constellation.locator(".concept-constellation__node").nth(0)).to_have_attribute(
-        "role", "button"
-    )
-    expect(constellation.locator(".concept-constellation__node").nth(0)).to_have_attribute(
-        "tabindex", "0"
-    )
-    expect(constellation).to_contain_text("Sodium gate")
-    expect(constellation).to_contain_text("Opening rule")
-    expect(constellation).not_to_contain_text("Sodium channels open at threshold")
-    expect(constellation).not_to_contain_text("This generated summary must not")
-    expect(constellation).not_to_contain_text("Voltage threshold changes")
-    expect(constellation).not_to_contain_text("Name what has to happen before flow.")
-    second_constellation_node = constellation.locator(".concept-constellation__node").nth(1)
-    second_constellation_node.click()
-    expect(constellation.locator("[data-constellation-selected-name]")).to_have_text(
-        "Opening rule"
-    )
-    first_constellation_node = constellation.locator(".concept-constellation__node").nth(0)
-    first_constellation_node.press("Enter")
-    expect(constellation.locator("[data-constellation-selected-name]")).to_have_text(
-        "Sodium gate"
-    )
-    constellation.locator(".concept-constellation__return").click()
+    expect(clean_page.locator("#concept-view-switch")).to_be_hidden()
     expect(clean_page.locator("#map-content")).to_be_visible()
+    expect(clean_page.locator("#concept-constellation-content")).to_be_hidden()
     expect(clean_page.locator(".concept-page-b2__entry-title")).to_contain_text(
         "Sodium gate"
     )
@@ -2158,16 +2305,42 @@ def test_source_concept_review_can_continue_to_next_entry(
 
     clean_page.locator(".concept-item", has_text="Source Review Continue QA").click()
     expect(clean_page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "review pending"
+        "Review later"
     )
     expect(clean_page.locator(".concept-page-b2__entry-cta")).to_have_text(
         "Continue route"
     )
+    continue_cta_style = clean_page.locator(".concept-page-b2__entry-cta").evaluate(
+        """(el) => {
+            const style = window.getComputedStyle(el);
+            return {
+                backgroundColor: style.backgroundColor,
+                borderStyle: style.borderStyle,
+                minHeight: style.minHeight,
+            };
+        }"""
+    )
+    assert continue_cta_style["backgroundColor"] != "rgba(0, 0, 0, 0)"
+    assert continue_cta_style["borderStyle"] == "solid"
+    assert continue_cta_style["minHeight"] == "44px"
     clean_page.locator(".concept-page-b2__entry-cta").click()
     expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text(
         "Heat call"
     )
-    expect(clean_page.locator(".concept-page-b2__attempt-input")).to_be_visible()
+    attempt_input = clean_page.locator(".concept-page-b2__attempt-input")
+    expect(attempt_input).to_be_visible()
+    expect(attempt_input).to_be_focused()
+    prompt_box = clean_page.locator(".concept-page-b2__attempt h3").bounding_box()
+    drawer_box = clean_page.locator("#drawer-toggle").bounding_box()
+    attempt_box = attempt_input.bounding_box()
+    viewport = clean_page.viewport_size
+    assert prompt_box is not None
+    assert drawer_box is not None
+    assert attempt_box is not None
+    assert viewport is not None
+    assert clean_page.evaluate("window.scrollY") == 0
+    assert prompt_box["y"] > drawer_box["y"] + drawer_box["height"]
+    assert 0 <= attempt_box["y"] < viewport["height"]
 
 
 def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
@@ -2385,10 +2558,11 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
     )
     expect(canvas).not_to_contain_text("Shaped by your sketch")
     expect(canvas).to_contain_text("Compare target")
-    expect(canvas).to_contain_text("Call for heat")
+    expect(canvas).not_to_contain_text("Call for heat")
     expect(canvas).not_to_contain_text("compares measured room temperature")
     expect(canvas).not_to_contain_text("Generated description should not leak")
     expect(canvas.locator(".concept-page-b2__route-item")).to_have_count(0)
+    expect(canvas.locator(".concept-page-b2__route-marker-item")).to_have_count(0)
     expect(canvas.locator(".concept-page-b2__nearby")).to_have_count(0)
 
     clean_page.locator(".concept-page-b2__attempt-input").fill(
@@ -2399,16 +2573,55 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
     expect(clean_page.locator(".concept-page-b2__evidence")).to_contain_text(
         "It checks if the room is colder than what we wanted and then starts heat."
     )
-    expect(clean_page.locator(".concept-page-b2__evidence")).to_contain_text("Draft recorded.")
+    expect(clean_page.locator(".concept-page-b2__evidence")).not_to_contain_text("Draft recorded.")
+    expect(clean_page.locator(".concept-page-b2__evidence")).to_have_class(
+        re.compile(r"\bconcept-page-b2__evidence--study-gate\b")
+    )
     expect(clean_page.locator(".concept-page-b2__route")).to_have_count(0)
     expect(clean_page.locator(".concept-page-b2__entry-cta")).to_have_text(
         "Reveal notes and compare"
     )
 
     clean_page.locator(".concept-page-b2__entry-cta").click()
+    expect(clean_page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Compare notes")
+    entry_label_style = clean_page.locator(".concept-page-b2__entry-eyebrow").evaluate(
+        """(el) => {
+            const style = window.getComputedStyle(el);
+            return {
+                letterSpacing: style.letterSpacing,
+                textTransform: style.textTransform,
+            };
+        }"""
+    )
+    assert entry_label_style == {"letterSpacing": "normal", "textTransform": "none"}
     expect(clean_page.locator(".concept-page-b2__study-note")).to_contain_text(
         "measured room temperature with the set point"
     )
+    expect(clean_page.locator(".concept-page-b2__study-note")).not_to_have_class(
+        re.compile(r"is-collapsed")
+    )
+    expect(clean_page.locator("[data-study-note-toggle]")).to_have_text("Hide study note")
+    compare_surface_style = clean_page.locator(".concept-page-b2__study-note").evaluate(
+        """(el) => {
+            const style = window.getComputedStyle(el);
+            const bodyStyle = window.getComputedStyle(el.querySelector('[data-study-note-body]'));
+            return {
+                backgroundColor: style.backgroundColor,
+                borderLeftWidth: style.borderLeftWidth,
+                borderTopWidth: style.borderTopWidth,
+                bodyFontWeight: bodyStyle.fontWeight,
+            };
+        }"""
+    )
+    assert compare_surface_style == {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderLeftWidth": "2px",
+        "borderTopWidth": "0px",
+        "bodyFontWeight": "500",
+    }
+    study_toggle_box = clean_page.locator("[data-study-note-toggle]").bounding_box()
+    assert study_toggle_box is not None
+    assert study_toggle_box["height"] >= 44
     expect(clean_page.locator(".concept-page-b2__evidence")).not_to_contain_text(
         "Missing piece"
     )
@@ -2437,25 +2650,21 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
     )
     clean_page.locator(".concept-page-b2__repair-save").click()
     clean_page.locator(".concept-page-b2__entry-cta").click()
-    expect(clean_page.locator(".concept-page-b2__route-item")).to_have_count(3)
-    expect(clean_page.locator(".concept-page-b2__route")).to_have_attribute(
-        "data-route-expanded", "true"
-    )
-    expect(clean_page.locator(".concept-page-b2__route")).to_have_attribute(
-        "data-locked-inert", "true"
-    )
+    clean_page.set_viewport_size({"width": 390, "height": 844})
+    expect(clean_page.locator(".concept-page-b2__route")).to_have_count(0)
+    expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text("Compare target")
+    expect(clean_page.locator("#drill-chamber-view")).to_be_visible()
+    expect(clean_page.locator("#concept-view-switch")).to_be_hidden()
+    clean_page.set_viewport_size({"width": 1280, "height": 720})
 
     clean_page.reload()
     reopen_created_concept()
-    expect(clean_page.locator(".concept-page-b2__route-item")).to_have_count(3)
-    expect(clean_page.locator(".concept-page-b2__entry-cta")).to_have_text(
+    expect(clean_page.locator(".concept-page-b2__route")).to_have_count(0)
+    expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text("Compare target")
+    expect(clean_page.locator(".concept-page-b2__repair")).to_contain_text(
         "Pressure-check this link"
     )
-
-    clean_page.locator('.concept-page-b2__route-item[data-entry-id="c2_s1"]').click()
-    clean_page.wait_for_timeout(700)
-    expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text("Call for heat")
-    expect(clean_page.locator(".concept-page-b2__attempt-input")).to_be_visible()
+    expect(clean_page.locator(".concept-page-b2__nearby")).to_have_count(0)
     expect(clean_page.locator(".concept-page-b2__gestalt")).not_to_contain_text(
         "Generated future description should not leak"
     )
@@ -2466,10 +2675,6 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
         "Hidden future study note"
     )
     expect(clean_page.locator("#drill-chamber-view")).to_have_count(0)
-
-    clean_page.locator('.concept-page-b2__route-item[data-entry-id="c3_s1"]').click()
-    clean_page.wait_for_timeout(700)
-    expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text("Call for heat")
 
 
 def test_source_less_defensive_ui_paths_remain_inert(
@@ -2521,7 +2726,7 @@ def test_source_less_defensive_ui_paths_remain_inert(
 
     fallback_mode = clean_page.evaluate(
         """async () => {
-            const view = await import('/js/concept-page-view.js?v=17');
+            const view = await import('/js/concept-page-view.js?v=22');
             return view.deriveSourceLessViewMode({
                 attempted: true,
                 next_action: 'spaced_attempt',

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1850,6 +1850,10 @@ def test_feedback_button_keeps_sidebar_open(
         "Share a bug, rough edge, or idea. A 9 or 10 means the UX feels ready for a new customer."
     )
     expect(clean_page.locator("#feedback-submit")).to_have_text("Send Feedback")
+    clean_page.locator("#feedback-submit").click()
+    expect(clean_page.locator("#feedback-status")).to_have_text(
+        "Message must be at least 10 characters."
+    )
     assert clean_page.locator("#drawer").get_attribute("data-open") == "true"
     assert clean_page.locator("body").get_attribute("data-drawer-open") == "true"
 
@@ -1901,6 +1905,12 @@ def test_feedback_custom_moment_rejects_invalid_rating(
     expect(clean_page.locator("#feedback-desc")).to_have_text(
         "How did the focus mode step feel? A 9 or 10 means the UX feels ready for a new customer."
     )
+    clean_page.locator("#feedback-submit").click()
+    expect(clean_page.locator("#feedback-status")).to_have_text(
+        "Please rate this moment 1-10."
+    )
+    expect(clean_page.locator("#feedback-ux-rating")).to_be_focused()
+
     clean_page.evaluate(
         """() => {
             const rating = document.getElementById('feedback-ux-rating');
@@ -1914,6 +1924,13 @@ def test_feedback_custom_moment_rejects_invalid_rating(
         "UX feel must be 1-10."
     )
     expect(clean_page.locator("#feedback-ux-rating")).to_be_focused()
+    clean_page.locator("#feedback-ux-rating").select_option("9")
+    clean_page.locator("#feedback-message").fill("x" * 1000)
+    clean_page.locator("#feedback-submit").click()
+    expect(clean_page.locator("#feedback-status")).to_have_text(
+        "Feedback must be 1000 characters or fewer after rating details."
+    )
+    expect(clean_page.locator("#feedback-message")).to_be_focused()
 
 
 def test_feedback_dialog_has_accessible_escape_close(
@@ -1983,6 +2000,8 @@ def test_mobile_drawer_keeps_feedback_accessible(
     assert drawer_box is not None
     assert drawer_box["x"] >= 0
     assert drawer_box["x"] + drawer_box["width"] <= 390
+    page.evaluate("document.querySelector('#nav-loop').hidden = false")
+    expect(page.locator("#nav-loop")).to_be_visible()
     expect(page.locator("#nav-feedback")).to_be_visible()
 
     page.locator("#nav-feedback").click()
@@ -2351,6 +2370,9 @@ def test_source_concept_review_can_continue_to_next_entry(
     assert continue_cta_style["borderStyle"] == "solid"
     assert continue_cta_style["minHeight"] == "44px"
     clean_page.locator(".concept-page-b2__entry-cta").click()
+    assert clean_page.evaluate(
+        "localStorage.getItem('socratink:comparison_ack:v1:source-review-continue:c1_s1')"
+    ) == "1"
     expect(clean_page.locator(".concept-page-b2__entry-title")).to_have_text(
         "Heat call"
     )

--- a/tests/e2e/test_strip_nav.py
+++ b/tests/e2e/test_strip_nav.py
@@ -182,7 +182,8 @@ def test_first_actionable_entry_shows_try_from_memory(page: Page, base_url: str)
     """The first unattempted actionable entry is ready, not blocked locked."""
     _open_seeded_concept(page, base_url)
     expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible()
-    expect(page.locator(".concept-page-b2__attempt-save")).to_have_text("Draft from memory")
+    expect(page.locator(".concept-page-b2__attempt-save")).to_have_text("Save draft")
+    expect(page.locator(".concept-page-b2__attempt-save")).to_be_disabled()
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
 
 

--- a/tests/test_auth_router_supabase.py
+++ b/tests/test_auth_router_supabase.py
@@ -5,6 +5,7 @@ Uses a fake service matching the SupabaseAuthService interface.
 
 import unittest
 import os
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 from cryptography.fernet import Fernet
@@ -398,6 +399,25 @@ class ApiMeAndLogoutTests(unittest.TestCase):
         body = response.json()
         self.assertTrue(body["authenticated"])
         self.assertEqual(body["user"]["email"], "learner@example.com")
+
+    def test_api_me_reports_loop_availability(self):
+        service = FakeSupabaseAuthService(enabled=True)
+        service.current_state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=True,
+            guest_mode=True,
+        )
+        client = build_client(service)
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOOP_BACKEND_URL", None)
+            unavailable = client.get("/api/me")
+
+        with patch.dict(os.environ, {"LOOP_BACKEND_URL": "https://loop.example"}, clear=False):
+            available = client.get("/api/me")
+
+        self.assertIs(unavailable.json()["loop_available"], False)
+        self.assertIs(available.json()["loop_available"], True)
 
     def test_api_me_writes_back_refreshed_cookie(self):
         service = FakeSupabaseAuthService(enabled=True)

--- a/tests/test_extract_route_smallest.py
+++ b/tests/test_extract_route_smallest.py
@@ -144,9 +144,8 @@ def test_extract_smallest_route_cap_exceeded_returns_fallback_route(client):
         "principle": "Starting model",
         "dependent_clusters": ["c1"],
     }]
-    assert route["clusters"][0]["subnodes"][0]["mechanism"].startswith(
-        "A signal moves forward when one small change"
-    )
+    assert "plants take in light" in route["clusters"][0]["subnodes"][0]["mechanism"]
     scaffold = route["clusters"][0]["subnodes"][0]["learner_scaffold"]
-    assert scaffold["entry_prompt"] == "What do you think makes one part trigger the next?"
+    assert "plants take in light" in scaffold["entry_prompt"]
+    assert scaffold["entry_prompt"].endswith("What do you think connects those parts?")
     assert "photosynthesis" not in scaffold["entry_prompt"].lower()

--- a/tests/test_extract_route_smallest.py
+++ b/tests/test_extract_route_smallest.py
@@ -120,13 +120,8 @@ def test_extract_source_less_forwards_learner_goal(client):
     assert kwargs.get("learner_goal") == "I want to explain why leaves make sugar."
 
 
-def test_extract_smallest_route_cap_exceeded_returns_500(client):
-    """SmallestRouteCapExceeded must surface as 500, not 422.
-
-    Smallest-route shape failures are server-side generation failures, not
-    client input failures, so the endpoint must return HTTP 500 with a clear
-    error field.
-    """
+def test_extract_smallest_route_cap_exceeded_returns_fallback_route(client):
+    """Source-less generation shape failures should not strand a new learner."""
     from ai_service import SmallestRouteCapExceeded
 
     with patch(
@@ -139,12 +134,19 @@ def test_extract_smallest_route_cap_exceeded_returns_500(client):
             "source": None,
         })
 
-    assert r.status_code == 500, (
-        f"Expected 500 (server-side generation failure) but got {r.status_code}. "
-        "SmallestRouteCapExceeded must not be swallowed by the generic 422 ValueError handler."
-    )
+    assert r.status_code == 200
     body = r.json()
-    detail = body.get("detail", {})
-    assert detail.get("error") == "smallest_route_cap_exceeded", (
-        f"Expected error='smallest_route_cap_exceeded' in detail, got: {detail}"
+    route = body["provisional_map"]
+    assert route["metadata"]["source_title"] == "Photosynthesis"
+    assert route["metadata"]["core_thesis"] == "Photosynthesis"
+    assert route["backbone"] == [{
+        "id": "b1",
+        "principle": "Starting model",
+        "dependent_clusters": ["c1"],
+    }]
+    assert route["clusters"][0]["subnodes"][0]["mechanism"].startswith(
+        "A signal moves forward when one small change"
     )
+    scaffold = route["clusters"][0]["subnodes"][0]["learner_scaffold"]
+    assert scaffold["entry_prompt"] == "What do you think makes one part trigger the next?"
+    assert "photosynthesis" not in scaffold["entry_prompt"].lower()

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1046,9 +1046,21 @@ def test_app_shell_uses_organic_icon_contract() -> None:
     assert "edit_note</span> New concept" in index_html
     assert "view_quilt</span> Desk" in index_html
     assert "auto_stories</span> Library" in index_html
+    assert "chat</span> Learning loop" in index_html
+    assert "Source-less loop" not in index_html
     assert "rate_review</span> Send Feedback" in index_html
     for icon_name in ("edit_note", "view_quilt", "auto_stories", "rate_review", "cloud_sync", "more_vert"):
         assert icon_name in index_html
+
+
+def test_new_concept_field_has_unique_accessible_label() -> None:
+    index_html = (REPO_ROOT / "public" / "index.html").read_text()
+
+    assert '<h1 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
+    assert "What do you want to explain?" in index_html
+    assert 'id="hero-single-input-field"' in index_html
+    assert 'aria-label="Concept name"' in index_html
+    assert 'aria-label="What do you want to explain?"' not in index_html
 
 
 def test_feedback_modal_copy_and_button_contract() -> None:
@@ -1057,10 +1069,65 @@ def test_feedback_modal_copy_and_button_contract() -> None:
     assert 'role="dialog"' in index_html
     assert 'aria-modal="true"' in index_html
     assert 'aria-labelledby="feedback-title"' in index_html
+    assert 'aria-describedby="feedback-desc"' in index_html
     assert '<h2 class="modal-title" id="feedback-title">Feedback</h2>' in index_html
     assert "my local TODO list" not in index_html
-    assert "Share a bug, rough edge, or idea. It helps shape what gets sharpened next." in index_html
+    assert 'id="feedback-desc"' in index_html
+    assert "A 9 or 10 means the UX feels ready for a new customer." in index_html
+    assert '<select id="feedback-ux-rating" class="feedback-rating-input">' in index_html
+    assert '<option value="9">9 / 10</option>' in index_html
+    assert 'placeholder="Optional: what made it feel that way?"' in index_html
+    feedback_textarea = index_html[index_html.index('id="feedback-message"'):index_html.index("</textarea>", index_html.index('id="feedback-message"'))]
+    assert "required" not in feedback_textarea
+    assert "minlength" not in feedback_textarea
+    assert 'id="feedback-status" class="modal-status" role="status" aria-live="polite"' in index_html
     assert '<button class="modal-close" type="button" onclick="Feedback.hide()" aria-label="Close feedback">' in index_html
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_auth_bootstrap_reveals_loop_nav_only_when_available() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+
+        const nodes = new Map([
+          ['auth-controls', { hidden: true }],
+          ['auth-login-link', { hidden: true, href: '', textContent: '' }],
+          ['auth-logout-btn', {
+            hidden: true,
+            disabled: false,
+            textContent: '',
+            dataset: {},
+            addEventListener(type, handler) { this[type] = handler; },
+          }],
+          ['auth-status', { hidden: true, textContent: '' }],
+          ['nav-loop', { hidden: true }],
+        ]);
+        globalThis.window = {
+          location: { pathname: '/', search: '', hash: '', assign() {} },
+        };
+        globalThis.document = {
+          getElementById(id) { return nodes.get(id) || null; },
+        };
+
+        const auth = await import('./public/js/auth.js');
+        globalThis.fetch = async () => ({
+          ok: true,
+          json: async () => ({ guest_mode: true, auth_enabled: true, loop_available: false }),
+        });
+        await auth.bootstrapAuthUi();
+        assert.equal(nodes.get('nav-loop').hidden, true);
+
+        auth.invalidateAuthSession();
+        globalThis.fetch = async () => ({
+          ok: true,
+          json: async () => ({ guest_mode: true, auth_enabled: true, loop_available: true }),
+        });
+        await auth.bootstrapAuthUi();
+        assert.equal(nodes.get('nav-loop').hidden, false);
+        """
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_static_buttons_declare_type() -> None:
@@ -1430,17 +1497,17 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(coldHtml.includes('Context'));
         assert.ok(coldHtml.includes('I think nerves send electricity'));
         assert.ok(!coldHtml.includes('Write first. Compare after.'));
-        assert.ok(coldHtml.includes('No source attached. Treat this route as provisional.'));
+        assert.ok(coldHtml.includes('aria-label="Recall context"'));
         assert.ok(coldHtml.includes('What do you think makes the sodium channel open?'));
         assert.ok(coldHtml.includes('Sodium gate'));
-        assert.ok(coldHtml.includes('Signal spread'));
-        assert.ok(coldHtml.includes('Use this draft'));
+        assert.ok(coldHtml.includes('Save draft'));
         assert.ok(!coldHtml.includes('Shaped by your sketch'));
         assert.ok(!coldHtml.includes('Shaped from your launch attempt, not verified against a source.'));
         assert.ok(!coldHtml.includes('AI-generated answer structure must stay hidden.'));
         assert.ok(!coldHtml.includes('Voltage threshold opens sodium channels'));
         assert.ok(!coldHtml.includes('Sodium influx causes depolarization'));
         assert.ok(!coldHtml.includes('concept-page-b2__route-item'));
+        assert.ok(!coldHtml.includes('concept-page-b2__route-marker-item'));
         assert.ok(!coldHtml.includes('data-entry-id="spread"'));
         assert.ok(!coldHtml.includes('concept-page-b2__nearby'));
 
@@ -1452,10 +1519,11 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
           graphData,
           null
         );
-        assert.ok(coldWithoutTrainingHtml.includes('No source attached. Treat this route as provisional.'));
+        assert.ok(coldWithoutTrainingHtml.includes('aria-label="Recall context"'));
         assert.ok(!coldWithoutTrainingHtml.includes('Shaped from your launch attempt, not verified against a source.'));
         assert.ok(coldWithoutTrainingHtml.includes('What do you think makes the sodium channel open?'));
         assert.ok(!coldWithoutTrainingHtml.includes('concept-page-b2__route-item'));
+        assert.ok(!coldWithoutTrainingHtml.includes('concept-page-b2__route-marker-item'));
         assert.ok(!coldWithoutTrainingHtml.includes('data-entry-id="spread"'));
         assert.ok(!coldWithoutTrainingHtml.includes('concept-page-b2__nearby'));
 
@@ -1485,7 +1553,8 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
           savedDraftTraining,
           { viewMode: 'saved-draft-study-gate' }
         );
-        assert.ok(savedHtml.includes('Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.'));
+        assert.ok(savedHtml.includes('concept-page-b2__evidence--study-gate'));
+        assert.ok(!savedHtml.includes('Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.'));
         assert.ok(savedHtml.includes('The gate probably opens when the voltage gets high enough.'));
         assert.ok(savedHtml.includes('Reveal notes and compare'));
         assert.ok(!savedHtml.includes('Missing piece'));
@@ -1521,15 +1590,40 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
           cleanRevealedTraining,
           { viewMode: 'post-reveal-comparison', now: '2026-05-21T11:00:00.000Z' }
         );
+        assert.ok(compareHtml.includes('Compare notes'));
         assert.ok(compareHtml.includes('The channel opens when voltage reaches threshold.'));
         assert.ok(compareHtml.includes('Voltage-gated sodium channels open at threshold'));
-        assert.ok(compareHtml.includes('Keep working'));
-        assert.ok(compareHtml.includes('data-active-entry-action="keep-working"'));
+        assert.ok(compareHtml.includes('Continue'));
+        assert.ok(compareHtml.includes('data-active-entry-action="next-entry"'));
+        assert.ok(compareHtml.includes('data-active-entry-id="spread"'));
+        assert.ok(compareHtml.includes('Rate this moment'));
+        assert.ok(compareHtml.includes('data-feedback-rating'));
+        assert.ok(compareHtml.includes('data-feedback-moment="compare notes"'));
         assert.ok(!compareHtml.includes('No missing piece recorded for this draft.'));
         assert.ok(!compareHtml.includes('concept-page-b2__route-item'));
         assert.ok(compareHtml.includes('concept-page-b2__gestalt--single-column'));
         assert.ok(!compareHtml.includes('data-entry-id="spread"'));
         assert.ok(!compareHtml.includes('concept-page-b2__nearby'));
+
+        const autoCompareHtml = renderActiveEntryHtml(
+          entries[0],
+          0,
+          entries,
+          concept,
+          graphData,
+          cleanRevealedTraining,
+          { comparisonAcknowledged: false, now: '2026-05-21T11:00:00.000Z' }
+        );
+        assert.ok(autoCompareHtml.includes('Compare notes'));
+        assert.ok(autoCompareHtml.includes('Continue'));
+        assert.ok(autoCompareHtml.includes('data-active-entry-action="next-entry"'));
+        assert.ok(autoCompareHtml.includes('data-active-entry-id="spread"'));
+        assert.ok(autoCompareHtml.includes('Rate this moment'));
+        assert.ok(autoCompareHtml.includes('data-feedback-rating'));
+        assert.ok(autoCompareHtml.includes('data-feedback-moment="compare notes"'));
+        assert.ok(autoCompareHtml.includes('concept-page-b2__gestalt--single-column'));
+        assert.ok(!autoCompareHtml.includes('concept-page-b2__nearby'));
+        assert.ok(!autoCompareHtml.includes('concept-page-b2__route-item'));
 
         const expandedHtml = renderActiveEntryHtml(
           entries[0],
@@ -1540,8 +1634,9 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
           cleanRevealedTraining,
           { viewMode: 'expanded-workspace', now: '2026-05-21T11:00:00.000Z' }
         );
-        assert.ok(expandedHtml.includes('concept-page-b2__route-item'));
-        assert.ok(expandedHtml.includes('data-entry-id="spread"'));
+        assert.ok(!expandedHtml.includes('concept-page-b2__route-item'));
+        assert.ok(!expandedHtml.includes('concept-page-b2__route-marker-item'));
+        assert.ok(!expandedHtml.includes('data-entry-id="spread"'));
         assert.ok(!expandedHtml.includes('data-active-entry-action="keep-working"'));
         """
     )
@@ -1637,7 +1732,7 @@ def test_source_less_view_mode_derivation_preserves_comparison_seams() -> None:
             study_revealed_at: '2026-05-21T10:05:00.000Z',
             repairs: [],
           },
-        }, { comparisonAcknowledged: false }), 'expanded-workspace');
+        }, { comparisonAcknowledged: false }), 'post-reveal-comparison');
 
         assert.equal(deriveSourceLessViewMode({
           attempted: true,
@@ -1770,8 +1865,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
           null,
           { now: '2026-05-15T20:00:00.000Z' }
         );
-        assert.ok(legacyPrimedWaitingHtml.includes('review pending'));
-        assert.ok(!legacyPrimedWaitingHtml.includes('review pending entry 1 of 1'));
+        assert.ok(legacyPrimedWaitingHtml.includes('Review later'));
+        assert.ok(!legacyPrimedWaitingHtml.includes('Review later entry 1 of 1'));
         assert.ok(!legacyPrimedWaitingHtml.includes('concept-page-b2__entry-cta'));
         const legacyPrimedReadyHtml = renderActiveEntryHtml(
           {
@@ -1878,7 +1973,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(blockedHtml.includes('>Locked</button>'));
         assert.ok(blockedHtml.includes('&lt;Core&gt;'));
         assert.ok(blockedHtml.includes('Second &amp; unsafe'));
-        assert.ok(blockedHtml.includes('READY TO RECONSTRUCT'));
+        assert.ok(blockedHtml.includes('ready to reconstruct'));
 
         const readyHtml = renderActiveEntryHtml(
           backbone[1],
@@ -1894,8 +1989,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(!readyHtml.includes('Write first. Compare after.'));
         assert.ok(readyHtml.includes('Start from memory'));
         assert.ok(!readyHtml.includes('first reconstruction entry 2 of 3'));
-        assert.ok(readyHtml.includes('Draft from memory'));
-        assert.ok(readyHtml.includes('Stuck?'));
+        assert.ok(readyHtml.includes('Save draft'));
+        assert.ok(readyHtml.includes('Need a cue?'));
         assert.ok(readyHtml.includes('data-blank-start'));
         assert.ok(readyHtml.includes('data-blank-start-hint'));
         assert.ok(!readyHtml.includes('The mechanism stays hidden.'));
@@ -1913,7 +2008,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
             node_records: training.node_records,
           }
         );
-        assert.ok(sourceLessHtml.includes('No source attached. Treat this route as provisional.'));
+        assert.ok(sourceLessHtml.includes('aria-label="Recall context"'));
         assert.ok(!sourceLessHtml.includes('Shaped from your launch attempt, not verified against a source.'));
         const sourceAttachedHtml = renderActiveEntryHtml(
           backbone[1],
@@ -1926,7 +2021,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
             node_records: training.node_records,
           }
         );
-        assert.ok(!sourceAttachedHtml.includes('No source attached. Treat this route as provisional.'));
+        assert.ok(sourceAttachedHtml.includes('aria-label="Recall context"'));
 
         const readyAttemptHtml = renderActiveEntryHtml(
           backbone[1],
@@ -1940,7 +2035,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(readyAttemptHtml.includes('concept-page-b2__attempt'));
         assert.ok(readyAttemptHtml.includes('data-attempt-entry-id="entry-2"'));
         assert.ok(readyAttemptHtml.includes('Draft what you can recall'));
-        assert.ok(readyAttemptHtml.includes('Draft from memory'));
+        assert.ok(readyAttemptHtml.includes('Save draft'));
         assert.ok(!readyAttemptHtml.includes('concept-page-b2__entry-cta'));
 
         const scaffoldedMap = {
@@ -1997,7 +2092,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(scaffoldHtml.includes('Pick one phrase from your sketch and say what role it plays.'));
         assert.ok(!scaffoldHtml.includes('Draft your starting guess: what it does, what it connects to, or why it matters.'));
         assert.ok(!scaffoldHtml.includes('Not sure yet? Type what you think it might do, or list a few terms you recognize.'));
-        assert.ok(scaffoldHtml.includes('Use this draft'));
+        assert.ok(scaffoldHtml.includes('Save draft'));
         assert.ok(!scaffoldHtml.includes('Bloom'));
         assert.ok(!scaffoldHtml.includes('bloom_level'));
         assert.ok(!scaffoldHtml.includes('provider routing, deployment environments'));
@@ -2073,6 +2168,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
           { source_mode: 'source_less', node_records: {} }
         );
         assert.ok(fallbackScaffoldHtml.includes('Write one relationship you suspect.'));
+        assert.ok(fallbackScaffoldHtml.includes('placeholder="Write what you can explain right now."'));
+        assert.ok(!fallbackScaffoldHtml.includes('placeholder="Write one relationship you suspect."'));
         assert.ok(fallbackScaffoldHtml.includes('Type one relationship you suspect, even if it feels incomplete.'));
 
         const primedHtml = renderActiveEntryHtml(
@@ -2103,7 +2200,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(primedHtml.includes('Draft saved'));
         assert.ok(!primedHtml.includes('study required entry 1 of 1'));
         assert.ok(primedHtml.includes('Your memory draft'));
-        assert.ok(primedHtml.includes('Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.'));
+        assert.ok(primedHtml.includes('concept-page-b2__evidence--study-gate'));
+        assert.ok(!primedHtml.includes('Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.'));
         assert.ok(primedHtml.includes('Draft saved'));
         assert.ok(primedHtml.includes('A strong first attempt.'));
         assert.ok(!primedHtml.includes('Missing piece'));
@@ -2174,8 +2272,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
           },
           { now: '2026-05-15T11:00:00.000Z' }
         );
-        assert.ok(studiedHtml.includes('review pending'));
-        assert.ok(!studiedHtml.includes('review pending entry 1 of 1'));
+        assert.ok(studiedHtml.includes('Review later'));
+        assert.ok(!studiedHtml.includes('Review later entry 1 of 1'));
         assert.ok(studiedHtml.includes('concept-page-b2__evidence'));
         assert.ok(studiedHtml.includes('Your draft'));
         assert.ok(!studiedHtml.includes('learner reconstruction'));
@@ -2213,7 +2311,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
           },
           { now: '2026-05-15T11:00:00.000Z' }
         );
-        assert.ok(studiedRouteHtml.includes('review pending'));
+        assert.ok(studiedRouteHtml.includes('Review later'));
         assert.ok(studiedRouteHtml.includes('Continue route'));
         assert.ok(studiedRouteHtml.includes('data-active-entry-id="next-entry"'));
         assert.ok(studiedRouteHtml.includes('data-active-entry-action="next-entry"'));
@@ -2292,7 +2390,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
                   classification: 'thin',
                   gaps: [{
                     mechanism: 'channel gate',
-                    correction: 'Name that voltage-gated sodium channels open at threshold.',
+                    correction: 'The learner correctly identifies sodium flow but does not name the voltage-gated channel opening.',
                   }],
                   grader_version: 'qa',
                 }],
@@ -2305,18 +2403,19 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(repairHtml.includes('Needs repair'));
         assert.ok(!repairHtml.includes('repair the gap entry 1 of 1'));
         assert.ok(!repairHtml.includes('nearby entries  all locked until first reconstruction'));
-        assert.ok(repairHtml.includes('nearby entries'));
+        assert.ok(repairHtml.includes('Nearby entries'));
         assert.ok(repairHtml.includes('concept-page-b2__evidence'));
         assert.ok(repairHtml.includes('Your draft'));
         assert.ok(repairHtml.includes('concept-page-b2__evidence--compact'));
         assert.ok(!repairHtml.includes('Missing piece'));
         assert.ok(!repairHtml.includes('repair hinge'));
         assert.ok(repairHtml.includes('Sodium just rushes in.'));
-        assert.ok(repairHtml.includes('Name that voltage-gated sodium channels open at threshold.'));
+        assert.ok(repairHtml.includes('Your draft names sodium flow but does not name the voltage-gated channel opening.'));
+        assert.ok(!repairHtml.includes('The learner correctly identifies'));
         assert.ok(repairHtml.includes('concept-page-b2__repair'));
         assert.ok(repairHtml.includes('Repair'));
         assert.ok(repairHtml.includes('Missing link'));
-        assert.ok(repairHtml.includes('Name that voltage-gated sodium channels open at threshold.'));
+        assert.ok(repairHtml.includes('Your draft names sodium flow but does not name the voltage-gated channel opening.'));
         assert.ok(repairHtml.includes('data-repair-entry-id="repair"'));
         assert.ok(!repairHtml.includes('Put it in your words'));
         assert.ok(!repairHtml.includes('1 missing link to repair'));
@@ -2324,7 +2423,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(repairHtml.includes('Write the missing link.'));
         assert.ok(repairHtml.includes('Use your words. One or two sentences is enough.'));
         assert.ok(repairHtml.includes('Save repair'));
-        assert.ok(repairHtml.includes('Study note tucked away while you repair.'));
+        assert.ok(repairHtml.includes('Study note stays hidden while you repair.'));
         assert.ok(repairHtml.includes('Show study note'));
         const fallbackRepairHtml = renderActiveEntryHtml(
           { label: 'Fallback repair', study_note: 'Study the unnamed entry.' },
@@ -2385,13 +2484,131 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(!repairedHtml.includes('repair the gap entry 1 of 1'));
         assert.ok(!repairedHtml.includes('Write it again'));
         assert.ok(repairedHtml.includes('Repair saved'));
-        assert.ok(repairedHtml.includes('Try this entry again from memory.'));
+        assert.ok(repairedHtml.includes('Pressure-check the repaired link.'));
         assert.ok(repairedHtml.includes('concept-page-b2__repair'));
         assert.ok(repairedHtml.includes('Pressure-check this link'));
         assert.ok(repairedHtml.includes('data-active-entry-action="drill-gap"'));
         assert.ok(!repairedHtml.includes('concept-page-b2__repair-input'));
         assert.ok(!repairedHtml.includes('concept-page-b2__repair-save'));
         assert.ok(!repairedHtml.includes('Save this repair before you try from memory again.'));
+
+        const checkedRepairHtml = renderActiveEntryHtml(
+          { id: 'repair', label: 'Repair' },
+          0,
+          [{ id: 'repair', label: 'Repair' }],
+          {},
+          { metadata: {} },
+          {
+            node_records: {
+              repair: {
+                attempts: [{
+                  id: 'rp1',
+                  kind: 'cold',
+                  at: '2026-05-15T10:00:00.000Z',
+                  user_text: 'Sodium just rushes in.',
+                  classification: 'thin',
+                  gaps: [{ mechanism: 'channel gate', correction: 'Name the gate.' }],
+                  grader_version: 'qa',
+                }],
+                study_revealed_at: '2026-05-15T10:05:00.000Z',
+                repairs: [{
+                  id: 'rr1',
+                  at: '2026-05-15T10:10:00.000Z',
+                  text: 'Voltage-gated channels open at threshold.',
+                }],
+              },
+            },
+          },
+          { repairCheckedThisSession: true }
+        );
+        assert.ok(checkedRepairHtml.includes('Repair checked'));
+        assert.ok(checkedRepairHtml.includes('Repair checked for now.'));
+        assert.ok(checkedRepairHtml.includes('Study note stays hidden for later reconstruction.'));
+        assert.ok(checkedRepairHtml.includes('Rate this moment'));
+        assert.ok(checkedRepairHtml.includes('data-feedback-rating'));
+        assert.ok(checkedRepairHtml.includes('data-feedback-moment="repair checked"'));
+        assert.ok(!checkedRepairHtml.includes('Pressure-check this link'));
+        assert.ok(!checkedRepairHtml.includes('Study note stays hidden while you repair.'));
+
+        const checkedRepairWithNextHtml = renderActiveEntryHtml(
+          { id: 'repair', label: 'Repair' },
+          0,
+          [{ id: 'repair', label: 'Repair' }, { id: 'next-entry', label: 'Next entry' }],
+          {},
+          { metadata: {} },
+          {
+            node_records: {
+              repair: {
+                attempts: [{
+                  id: 'rp1',
+                  kind: 'cold',
+                  at: '2026-05-15T10:00:00.000Z',
+                  user_text: 'Sodium just rushes in.',
+                  classification: 'thin',
+                  gaps: [{ mechanism: 'channel gate', correction: 'Name the gate.' }],
+                  grader_version: 'qa',
+                }],
+                study_revealed_at: '2026-05-15T10:05:00.000Z',
+                repairs: [{
+                  id: 'rr1',
+                  at: '2026-05-15T10:10:00.000Z',
+                  text: 'Voltage-gated channels open at threshold.',
+                }],
+              },
+            },
+          },
+          { repairCheckedThisSession: true }
+        );
+        assert.ok(checkedRepairWithNextHtml.includes('Continue route'));
+        assert.ok(checkedRepairWithNextHtml.includes('data-active-entry-id="next-entry"'));
+        assert.ok(checkedRepairWithNextHtml.includes('data-active-entry-action="next-entry"'));
+        assert.ok(!checkedRepairWithNextHtml.includes('Nearby entries'));
+
+        const checkedNearbyHtml = renderActiveEntryHtml(
+          { id: 'next-entry', label: 'Next entry' },
+          1,
+          [{ id: 'repair', label: 'Repair' }, { id: 'next-entry', label: 'Next entry' }],
+          {},
+          { metadata: {} },
+          {
+            node_records: {
+              repair: {
+                attempts: [{
+                  id: 'rp1',
+                  kind: 'cold',
+                  at: '2026-05-15T10:00:00.000Z',
+                  user_text: 'Sodium just rushes in.',
+                  classification: 'thin',
+                  gaps: [{ mechanism: 'channel gate', correction: 'Name the gate.' }],
+                  grader_version: 'qa',
+                }],
+                study_revealed_at: '2026-05-15T10:05:00.000Z',
+                repairs: [{
+                  id: 'rr1',
+                  at: '2026-05-15T10:10:00.000Z',
+                  text: 'Voltage-gated channels open at threshold.',
+                }],
+              },
+              'next-entry': {
+                attempts: [{
+                  id: 'np1',
+                  kind: 'cold',
+                  at: '2026-05-15T10:20:00.000Z',
+                  user_text: 'Next draft.',
+                  classification: 'thin',
+                  gaps: [{ mechanism: 'next gap', correction: 'Repair next.' }],
+                  grader_version: 'qa',
+                }],
+                study_revealed_at: '2026-05-15T10:25:00.000Z',
+              },
+            },
+          },
+          { repairCheckedEntryIds: ['repair'] }
+        );
+        assert.ok(checkedNearbyHtml.includes('Nearby entries'));
+        const checkedNearbyCompactHtml = checkedNearbyHtml.split(/\\s+/).join(' ');
+        assert.ok(checkedNearbyCompactHtml.includes('<span>Repair</span> <span class="concept-page-b2__nearby-status">repair checked</span>'));
+        assert.ok(!checkedNearbyCompactHtml.includes('<span>Repair</span> <span class="concept-page-b2__nearby-status">needs repair</span>'));
 
         const stripHtml = renderConceptStripHtml(backbone, backbone[1], 1, training);
         assert.ok(stripHtml.includes('class="concept-strip"'));


### PR DESCRIPTION
Context & Intent
- What problem does this solve?
- The loop proxy exists, but the app did not safely expose a product entry point. This gates the visible Learning loop nav on LOOP_BACKEND_URL so users do not get sent to an unconfigured backend.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)?
- Codex productization pass for making the Socratink loop function present safely in socratink-app.

Implementation Details
- Adds loop_available to /api/me based on LOOP_BACKEND_URL.
- Reveals #nav-loop only when /api/me reports loop_available.
- Renames the nav copy from Source-less loop (beta) to Learning loop.
- Keeps the loop proxy behavior and compression-safety tests intact.
- Includes the first-session single-surface UX polish already proven locally: source-less sessions hide route/constellation chrome while preserving reconstruction evidence flow.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [x] Are there SSRF or error-leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce \"Generation Before Recognition\"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Verification
- bash scripts/doctor.sh
- bash scripts/preflight-deploy.sh
- .venv/bin/pytest -q tests/test_auth_router_supabase.py tests/test_loop_backend_proxy.py tests/test_frontend_app_helper_modules.py tests/test_extract_route_smallest.py
- Chrome local proof with LOOP_BACKEND_URL configured: Learning loop nav visible and /loop click-through succeeds.

Branch: feat/safe-learning-loop
Base: main