### PR TITLE
feat: ready beta learner loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
-from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.responses import FileResponse, JSONResponse, RedirectResponse, Response
 
 from auth import (
     AuthConfigurationError,
@@ -186,6 +186,8 @@ def _is_protected_html_request(request: Request) -> bool:
         return False
     path = request.url.path
     if path in PROTECTED_HTML_PATHS:
+        return True
+    if path.startswith("/session/"):
         return True
     return path.endswith(".html") and path != "/login.html"
 
@@ -988,4 +990,9 @@ async def proxy_loop_session_path(request: Request, path: str) -> Response:
 # Serve the frontend locally. On Vercel, static files are served by the CDN.
 _public_dir = Path(__file__).parent / "public"
 if _public_dir.is_dir():
+
+    @app.get("/session/{session_id}")
+    async def session_shell(session_id: str) -> FileResponse:
+        return FileResponse(_public_dir / "index.html")
+
     app.mount("/", StaticFiles(directory=str(_public_dir), html=True), name="static")

--- a/main.py
+++ b/main.py
@@ -987,12 +987,32 @@ async def proxy_loop_session_path(request: Request, path: str) -> Response:
     return await proxy_loop_backend(request, f"/api/session/{path}")
 
 
-# Serve the frontend locally. On Vercel, static files are served by the CDN.
-_public_dir = Path(__file__).parent / "public"
-if _public_dir.is_dir():
+# Serve the frontend locally. On Vercel, static files are served by the CDN, but
+# deep app URLs still need the serverless FastAPI app to return the shell.
+_PUBLIC_DIR_CANDIDATES: tuple[Path, ...] = (
+    Path(__file__).resolve().parent / "public",
+    Path.cwd() / "public",
+    Path(__file__).resolve().parent.parent / "public",
+)
 
-    @app.get("/session/{session_id}")
-    async def session_shell(session_id: str) -> FileResponse:
-        return FileResponse(_public_dir / "index.html")
 
+def _public_index_file(candidates: tuple[Path, ...] = _PUBLIC_DIR_CANDIDATES) -> Path | None:
+    for directory in candidates:
+        index_file = directory / "index.html"
+        if index_file.is_file():
+            return index_file
+    return None
+
+
+@app.get("/session/{session_id}")
+async def session_shell(session_id: str) -> FileResponse:
+    index_file = _public_index_file()
+    if index_file is None:
+        raise HTTPException(status_code=404, detail="app shell not found")
+    return FileResponse(index_file)
+
+
+_public_index = _public_index_file()
+if _public_index is not None:
+    _public_dir = _public_index.parent
     app.mount("/", StaticFiles(directory=str(_public_dir), html=True), name="static")

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
   <link rel="stylesheet" href="/css/index.css?v=151">
-  <link rel="stylesheet" href="css/drill-chamber.css?v=10">
+  <link rel="stylesheet" href="/css/drill-chamber.css?v=10">
 </head>
 
 <body>
@@ -55,7 +55,7 @@
   <nav class="bottom-nav" id="bottom-nav">
     <a class="bottom-nav-item" href="javascript:void(0)" onclick="App.showIgnition()" id="bn-ignition">
       <span class="material-symbols-outlined">edit_note</span>
-      <span class="bottom-nav-label">New concept</span>
+      <span class="bottom-nav-label">Start</span>
     </a>
     <a class="bottom-nav-item active" href="javascript:void(0)" onclick="App.showDashboard()" id="bn-dashboard">
       <span class="material-symbols-outlined">view_quilt</span>
@@ -80,7 +80,7 @@
 
     <nav class="sidebar-nav">
       <a id="nav-ignition" class="sidebar-nav-item" href="javascript:void(0)"
-        onclick="App.showIgnition()"><span class="material-symbols-outlined">edit_note</span> New concept</a>
+        onclick="App.showIgnition()"><span class="material-symbols-outlined">edit_note</span> Start learning</a>
       <a id="nav-dashboard" class="sidebar-nav-item active" href="javascript:void(0)"
         onclick="App.showDashboard()"><span class="material-symbols-outlined">view_quilt</span> Desk</a>
       <a id="nav-library" class="sidebar-nav-item" href="javascript:void(0)"
@@ -93,7 +93,7 @@
     </nav>
 
     <div class="sidebar-divider"></div>
-    <span class="sidebar-section-label">concepts</span>
+    <span class="sidebar-section-label">sessions</span>
 
     <div id="concept-list"></div>
     <div id="sidebar-settings-host"></div>
@@ -154,7 +154,7 @@
           <a class="auth-link" id="auth-login-link" href="/login">Save &amp; Sync</a>
           <button class="auth-link auth-link-secondary" id="auth-logout-btn" type="button" hidden>Log Out</button>
         </div>
-        <button class="dev-skip" id="dev-btn" type="button" style="display:none;" onclick="App.fastForward()">[skip 24h]</button>
+        <button class="dev-skip" id="dev-btn" type="button" style="display:none;" onclick="App.fastForward()">Skip wait</button>
         <button class="map-close-btn" id="map-close-btn" type="button" onclick="App.hideMapView()" aria-label="Close concept map">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <line x1="18" y1="6" x2="6" y2="18"></line>
@@ -208,8 +208,8 @@
             <span class="desk-eyebrow-sep" aria-hidden="true">·</span>
             <time id="desk-date" class="desk-eyebrow-date"></time>
           </span>
-          <h2 class="desk-title">Reconstructions in progress.</h2>
-          <p class="desk-helper">Concepts you’ve started, in the order you laid them down.</p>
+          <h2 class="desk-title">Learning sessions.</h2>
+          <p class="desk-helper">Pick up where you were explaining from memory.</p>
         </header>
 
         <div class="hero-info" id="hero-info">
@@ -218,14 +218,14 @@
               <!-- #hero-state-chip is the data-state hook that CSS :has() rules depend on.
                    In empty state we hide the wrapping .hero-meta-row entirely (see components.css).
                    Non-empty states render the chip text via renderHero(). -->
-              <div class="hero-state-chip" id="hero-state-chip" data-state="empty">no concepts yet</div>
+              <div class="hero-state-chip" id="hero-state-chip" data-state="empty">no sessions yet</div>
             </div>
           </div>
-          <h1 class="hero-title" id="title">Your concepts.</h1>
-          <p class="desc hero-guidance" id="desc" aria-live="polite">Pick a tile to enter, or start a new concept.</p>
+          <h1 class="hero-title" id="title">Your learning sessions.</h1>
+          <p class="desc hero-guidance" id="desc" aria-live="polite">Pick a tile to resume, or start a new loop.</p>
           <div class="hero-actions">
             <button class="hero-primary-action" type="button" onclick="App.showIgnition()">
-              <span class="hero-primary-action__label">New concept</span>
+              <span class="hero-primary-action__label">Start learning</span>
             </button>
           </div>
 
@@ -240,7 +240,7 @@
             <button type="button" onclick="App.drillPass()">Attempt recorded</button>
           </div>
           <div id="consolidate-controls" style="display:none; gap: 8px; margin-top: 16px;">
-            <button type="button" onclick="App.consolidate()" disabled title="Spacing gate is not active in this MVP">Spacing gate unavailable</button>
+            <button type="button" onclick="App.consolidate()" disabled title="Review opens after spacing.">Review later</button>
           </div>
         </div>
 
@@ -248,7 +248,7 @@
         <div id="grid-container" style="position:relative; padding-top:28px; overflow:visible;">
           <!-- Floating spacing button (disabled in the current MVP) -->
           <button id="btn-consolidate-float" class="btn-consolidate-float" type="button" onclick="App.consolidate()"
-            style="display:none;" disabled title="Spacing gate is not active in this MVP" aria-label="Spacing gate unavailable">
+            style="display:none;" disabled title="Review opens after spacing." aria-label="Review later">
             <svg
               style="display: block; width: 16px; height: 16px; flex-shrink: 0; stroke: currentColor; fill: none; pointer-events: none;"
               viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
@@ -306,15 +306,15 @@
         </div>
 
         <h1 class="ig-title" id="ignition-title" tabindex="-1">
-          What do you want to explain?
+          What are you trying to understand?
         </h1>
         <p class="ig-first-use" id="ignition-first-use">
-          Name the concept first. socratink will ask for your starting map before study content appears.
+          Name what you want to understand. Socratink will ask for your first model, then start the loop.
         </p>
 
         <div class="ignition-cap-gate" id="ignition-cap-gate" hidden>
           <p class="ignition-cap-gate__message">
-            The board holds nine concepts. Retire one to start another.
+            The board holds nine sessions. Retire one to start another.
           </p>
           <button type="button" class="ig-button ig-button--ghost"
                   onclick="App.showLibrary()">Open library</button>
@@ -324,16 +324,16 @@
               onsubmit="return App.runHeroAction(event)" autocomplete="off">
           <textarea class="composer-card__field" id="hero-single-input-field"
                     rows="2" maxlength="200"
-                    placeholder=""
-                    aria-label="Concept name"></textarea>
+                    placeholder="why vaccines create immune memory"
+                    aria-label="Learning goal"></textarea>
 
           <div class="journal-meta">
-            <span class="journal-meta__key">source</span>
-            <span class="journal-meta__value" id="hero-source-value">none yet</span>
+            <span class="journal-meta__key">study material</span>
+            <span class="journal-meta__value" id="hero-source-value">optional</span>
             <span class="journal-meta__sep" aria-hidden="true">—</span>
             <button type="button" class="journal-meta__add"
                     id="hero-source-attach" aria-expanded="false"
-                    aria-controls="hero-source-panel">add</button>
+                    aria-controls="hero-source-panel">attach</button>
           </div>
 
           <div class="creation-source-panel" id="hero-source-panel" hidden></div>
@@ -343,7 +343,7 @@
 
           <div class="composer-card__actions">
             <button type="submit" class="ig-button" id="hero-door-submit"
-                    disabled aria-label="Continue to sketch">Continue</button>
+                    disabled aria-label="Start learning">Start</button>
           </div>
         </form>
       </div>
@@ -360,13 +360,13 @@
         </div>
 
         <p class="ig-concept-mark">
-          <span class="ig-concept-mark__key">Concept:</span><span
+          <span class="ig-concept-mark__key">Session: </span><span
             class="ig-concept-mark__name" id="launch-pad-concept-name"></span>
         </p>
         <p class="ig-concept-goal" id="launch-pad-concept-goal" hidden></p>
 
         <h1 class="ig-title" id="launch-pad-title" tabindex="-1">
-          What do you already think<br>is inside this concept?
+          What do you already think?
         </h1>
 
         <p class="ig-helper">
@@ -379,14 +379,14 @@
                     rows="5" maxlength="1200"
                     placeholder="Name parts, guesses, examples, or confusions. Concrete words help most."
                     aria-describedby="launch-pad-validation"
-                    aria-label="What do you already think is inside this concept?"></textarea>
+                    aria-label="What do you already think?"></textarea>
 
           <p class="ig-error" id="launch-pad-validation"
              role="status" aria-live="polite"></p>
 
           <div class="composer-card__actions">
             <button type="submit" class="ig-button" id="launch-pad-submit"
-                    disabled>Save sketch</button>
+                    disabled>Save first model</button>
           </div>
         </form>
 
@@ -444,13 +444,13 @@
 
   <div id="tooltip-root" aria-hidden="true"></div>
 
-  <script src="js/drill-chamber.js?v=12"></script>
-  <script type="module" src="js/app.js?v=157"></script>
-  <script src="js/intro-particles.js?v=8"></script>
-  <script type="module" src="js/tooltips.js?v=4"></script>
-  <script type="module" src="js/floating-room-label.js?v=5"></script>
-  <script type="module" src="js/iso-board-state-surface.js?v=5"></script>
-  <script type="module" src="js/feedback.js?v=6"></script>
+  <script src="/js/drill-chamber.js?v=12"></script>
+  <script type="module" src="/js/app.js?v=158"></script>
+  <script src="/js/intro-particles.js?v=8"></script>
+  <script type="module" src="/js/tooltips.js?v=4"></script>
+  <script type="module" src="/js/floating-room-label.js?v=6"></script>
+  <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
+  <script type="module" src="/js/feedback.js?v=6"></script>
 
   <!-- Feedback Modal -->
   <div id="feedback-overlay" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="feedback-title" aria-describedby="feedback-desc" hidden onclick="Feedback.hide()">

--- a/public/js/app-hero.js
+++ b/public/js/app-hero.js
@@ -1,25 +1,25 @@
 export function getHeroStateLabel(state) {
   switch (state) {
     case 'instantiated': return 'source captured';
-    case 'growing': return 'concept';
+    case 'growing': return 'session';
     case 'fractured': return 'worth revisiting';
     case 'hibernating': return 'spacing';
     case 'actualized': return 'spaced evidence';
-    default: return 'no concepts yet';
+    default: return 'no sessions yet';
   }
 }
 
 export function getHeroGuidance(concept) {
-  if (!concept) return 'Pick a tile to enter, or start a new concept.';
+  if (!concept) return 'Pick a tile to resume, or start a new loop.';
   switch (concept.state) {
     case 'instantiated':
       return concept.graphData
-        ? 'Open the concept. It is a hypothesis, not evidence yet.'
-        : 'Map this source into a concept. The map is not learner evidence.';
+        ? 'Resume the session. The map is a hypothesis, not evidence yet.'
+        : 'Turn the material into a learning session. The map is not learner evidence.';
     case 'growing':
       return concept.graphData
-        ? 'Open the concept. Start with one cold attempt before study appears.'
-        : 'Continue by mapping this source into a concept.';
+        ? 'Resume the session. Start with one cold attempt before study appears.'
+        : 'Continue by turning this material into a session.';
     case 'fractured':
       return 'A spaced re-drill found a gap worth repairing. Revisit the mechanism, then return under spacing.';
     case 'hibernating':
@@ -27,7 +27,7 @@ export function getHeroGuidance(concept) {
     case 'actualized':
       return 'Spaced evidence is on record. Re-drill later if you want another reconstruction pass.';
     default:
-      return 'Pick a tile to enter, or start a new concept.';
+      return 'Pick a tile to resume, or start a new loop.';
   }
 }
 
@@ -38,12 +38,12 @@ export function getHeroActionConfig(concept) {
   switch (concept.state) {
     case 'instantiated':
       return concept.graphData
-        ? { label: 'Open Concept', action: 'open-map', disabled: false }
-        : { label: 'Draft Map', action: 'extract', disabled: false };
+        ? { label: 'Resume session', action: 'open-map', disabled: false }
+        : { label: 'Build map', action: 'extract', disabled: false };
     case 'growing':
       return concept.graphData
-        ? { label: 'Open Concept', action: 'open-map', disabled: false }
-        : { label: 'Draft Map', action: 'extract', disabled: false };
+        ? { label: 'Resume session', action: 'open-map', disabled: false }
+        : { label: 'Build map', action: 'extract', disabled: false };
     case 'fractured':
       return { label: 'Repair Gap', action: 'drill', disabled: false };
     case 'hibernating':

--- a/public/js/app-shell-ui.js
+++ b/public/js/app-shell-ui.js
@@ -39,13 +39,13 @@ export function conceptListItemHtml(concept, training = null) {
   return `
         <div class="concept-dot" data-state="${safeState}"></div>
         <span class="concept-item-name" title="${safeName}">${safeName}</span>
-        <button class="concept-actions" type="button" data-concept-id="${safeId}" onclick="App.toggleConceptActions(this)" aria-label="Concept actions for ${safeName}" aria-haspopup="menu" aria-expanded="false" title="Concept actions">
+        <button class="concept-actions" type="button" data-concept-id="${safeId}" onclick="App.toggleConceptActions(this)" aria-label="Session actions for ${safeName}" aria-haspopup="menu" aria-expanded="false" title="Session actions">
           <span class="material-symbols-outlined" aria-hidden="true">more_vert</span>
         </button>
         <div class="concept-action-menu" role="menu" hidden>
-          <button class="concept-delete concept-action-menu-item" type="button" role="menuitem" data-concept-id="${safeId}" onclick="App.deleteConcept(this.dataset.conceptId,this)" aria-label="Delete concept ${safeName}">
+          <button class="concept-delete concept-action-menu-item" type="button" role="menuitem" data-concept-id="${safeId}" onclick="App.deleteConcept(this.dataset.conceptId,this)" aria-label="Delete session ${safeName}">
             <span class="material-symbols-outlined" aria-hidden="true">delete</span>
-            <span>Delete concept</span>
+            <span>Delete session</span>
           </button>
         </div>`;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -10,7 +10,7 @@ import {
   openDrawer as openShellDrawer,
   renderConceptList as renderShellConceptList,
   toggleDrawer as toggleShellDrawer,
-} from './app-shell-ui.js?v=1';
+} from './app-shell-ui.js?v=2';
 import { escHtml } from './html.js';
 import {
   describeDoorSource,
@@ -25,7 +25,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=22';
+} from './concept-page-view.js?v=23';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
@@ -77,7 +77,7 @@ import {
   buildPendingShellFromDoorInput,
   showLaunchPad as _showLaunchPad,
   runLaunchPadAction as _runLaunchPadAction,
-} from './launch-pad.js?v=1';
+} from './launch-pad.js?v=2';
 import { emitTelemetry } from './telemetry.js';
 
 import {
@@ -525,7 +525,7 @@ const App = (() => {
 
   function renderHero(concept) {
     if (!concept) {
-      titleEl.textContent = 'What do you want to understand?';
+      titleEl.textContent = 'What are you trying to understand?';
       // Empty-state desc dropped per silent-surface principle: the iso
       // board's nine empty slots make the affordance obvious; a
       // narrator line "Pick a tile to enter…" is unearned chrome.
@@ -533,7 +533,7 @@ const App = (() => {
       // branch below still calls getHeroGuidance(concept)).
       descEl.textContent = '';
       if (heroStateChipEl) {
-        heroStateChipEl.textContent = 'no concepts yet';
+        heroStateChipEl.textContent = 'no sessions yet';
         heroStateChipEl.dataset.state = 'empty';
       }
     } else {
@@ -573,9 +573,9 @@ const App = (() => {
     const sourceValue = document.getElementById('hero-source-value');
     if (sourceAttachBtn) {
       sourceAttachBtn.setAttribute('aria-expanded', 'false');
-      sourceAttachBtn.textContent = 'add';
+      sourceAttachBtn.textContent = 'attach';
     }
-    if (sourceValue) sourceValue.textContent = 'none yet';
+    if (sourceValue) sourceValue.textContent = 'optional';
     if (sourcePanel) {
       sourcePanel.hidden = true;
       sourcePanel.innerHTML = '';
@@ -652,10 +652,8 @@ const App = (() => {
     const concept = getActiveConcept();
     const action = heroPrimaryActionEl?.dataset.action || (!concept ? 'add' : '');
     if (action === 'add') {
-      // The conversational creation modal is retired. The Begin button's
-      // "add" action lands the learner on the New-concept (ignition) view —
-      // the same single canonical entry that the sidebar's New concept link
-      // and empty desk tiles use.
+      // The conversational creation modal is retired; this is the single
+      // start-learning surface.
       showIgnition();
       return;
     }
@@ -713,15 +711,15 @@ const App = (() => {
         panel.hidden = true;
         panel.innerHTML = '';
         btn.setAttribute('aria-expanded', 'false');
-        btn.textContent = 'add';
-        if (valueEl) valueEl.textContent = 'none yet';
+        btn.textContent = 'attach';
+        if (valueEl) valueEl.textContent = 'optional';
         App._pendingDoorSource = null;
         _doorUpdateSubmitState();
       } else if (hasSource) {
         // Panel is closed and a source is attached — the button is the
         // "remove" affordance. Click clears the source without re-opening.
-        btn.textContent = 'add';
-        if (valueEl) valueEl.textContent = 'none yet';
+        btn.textContent = 'attach';
+        if (valueEl) valueEl.textContent = 'optional';
         App._pendingDoorSource = null;
         _doorUpdateSubmitState();
       } else {
@@ -738,7 +736,7 @@ const App = (() => {
             panel.innerHTML = '';
             btn.setAttribute('aria-expanded', 'false');
             // Paper-style source-meta line: value span shows source ID,
-            // button toggles to "remove" (matches the "add" ↔ "remove"
+            // button toggles to "remove" (matches the "attach" ↔ "remove"
             // affordance pattern persona-validated in Paper Wave 1).
             btn.textContent = 'remove';
             const v = document.getElementById('hero-source-value');
@@ -749,9 +747,9 @@ const App = (() => {
             panel.hidden = true;
             panel.innerHTML = '';
             btn.setAttribute('aria-expanded', 'false');
-            btn.textContent = 'add';
+            btn.textContent = 'attach';
             const v = document.getElementById('hero-source-value');
-            if (v) v.textContent = 'none yet';
+            if (v) v.textContent = 'optional';
             App._pendingDoorSource = null;
             _doorUpdateSubmitState();
           },
@@ -1433,7 +1431,7 @@ const App = (() => {
 
     if (loadConcepts().length >= BOARD_SLOT_COUNT) {
       // Library is at the visible board cap. Don't pay for an LLM call.
-      setDoorError('The board holds nine concepts. Retire one to start another.');
+      setDoorError('The board holds nine sessions. Retire one to start another.');
       return;
     }
 
@@ -1575,10 +1573,7 @@ const App = (() => {
       selectConcept(concept.id);
       if (concept.graphData) showMapView(concept);
     } else {
-      // Empty tile → route straight to the New-concept (ignition) view
-      // rather than opening the conversational creation modal. Same surface
-      // the sidebar's "New concept" link uses; keeps a single canonical
-      // entry into concept creation and avoids the modal layer entirely.
+      // Empty tile → route straight to the start-learning surface.
       AudioFX.playTileClick();
       showIgnition();
     }
@@ -1647,8 +1642,8 @@ const App = (() => {
     if (btnDrill) btnDrill.textContent = 'Start entry';
     if (consolidateBtn) {
       consolidateBtn.disabled = true;
-      consolidateBtn.textContent = 'Spacing gate unavailable';
-      consolidateBtn.title = 'Spacing gate is not active in this MVP';
+      consolidateBtn.textContent = 'Review later';
+      consolidateBtn.title = 'Review opens after spacing.';
     }
     showControls(false, false, false, false, false);
 
@@ -1877,15 +1872,22 @@ const App = (() => {
     return `${conceptId || 'concept'}:${entryId || 'entry'}`;
   }
 
-  function conceptPageRenderOptionsForEntry(concept, entryId, options = {}) {
+  function conceptPageRenderOptionsForEntry(concept, entryId, training = null, options = {}) {
     if (!concept?.id || !entryId) return options;
-    const repairCheckedEntryIds = [...repairChecksThisSession]
+    const persistedCheckedEntryIds = Object.entries(training?.node_records || {})
+      .filter(([, record]) => Boolean(record?.repair_checked_at))
+      .map(([id]) => id);
+    const sessionCheckedEntryIds = [...repairChecksThisSession]
       .filter((key) => key.startsWith(`${concept.id}:`))
       .map((key) => key.slice(concept.id.length + 1));
+    const repairCheckedEntryIds = [...new Set([
+      ...persistedCheckedEntryIds,
+      ...sessionCheckedEntryIds,
+    ])];
     return {
       ...options,
       repairCheckedEntryIds,
-      repairCheckedThisSession: repairChecksThisSession.has(entrySessionKey(concept.id, entryId)),
+      repairCheckedThisSession: repairCheckedEntryIds.includes(entryId),
       comparisonAcknowledged: options?.justRevealedEntryId === entryId
         ? false
         : hasComparisonAcknowledgement(concept.id, entryId),
@@ -2066,7 +2068,7 @@ const App = (() => {
     const match = findConceptEntryById(backbone, entryId) || fallbackMatch;
     if (!docEl || !match) return;
     const renderBackbone = backbone.length ? backbone : [match.entry];
-    const renderOptions = conceptPageRenderOptionsForEntry(concept, entryId, options);
+    const renderOptions = conceptPageRenderOptionsForEntry(concept, entryId, training, options);
     docEl.innerHTML = renderActiveEntryHtml(
       match.entry,
       match.index,
@@ -2410,14 +2412,14 @@ const App = (() => {
       <div class="concept-page-b2__threshold-editor">
         <textarea
           class="concept-page-b2__threshold-input"
-          aria-label="Edit your concept sketch"
+          aria-label="Edit your context"
           rows="4"
           maxlength="1200"
           placeholder="Name the parts, guesses, examples, or confusions you have."
         >${escHtml(currentText)}</textarea>
         <div class="concept-page-b2__threshold-actions">
           <button type="button" class="concept-page-b2__threshold-cancel">Cancel</button>
-          <button type="button" class="concept-page-b2__threshold-save">Save sketch</button>
+          <button type="button" class="concept-page-b2__threshold-save">Save context</button>
         </div>
       </div>
     `;
@@ -2505,7 +2507,7 @@ const App = (() => {
         backbone.findIndex((n) => (n.id || `entry-${backbone.indexOf(n)}`) === _activeEntryId)
       );
       const activeEntry = backbone[activeIdx] || backbone[0] || { id: 'core-thesis', label: 'Core thesis' };
-      const renderOptions = conceptPageRenderOptionsForEntry(liveConcept, _activeEntryId, {});
+      const renderOptions = conceptPageRenderOptionsForEntry(liveConcept, _activeEntryId, training, {});
       docEl.innerHTML = renderActiveEntryHtml(activeEntry, activeIdx, backbone, liveConcept, freshData, training, renderOptions);
       rebindActiveEntryHandlers(docEl, liveConcept, freshData, training);
       bindConceptRouteMarginHandlers(document.getElementById('map-content'), freshData, liveConcept, training);
@@ -2543,7 +2545,7 @@ const App = (() => {
     captureActiveEntryDraft();
     doc.classList.add('is-fading-out');
     const routeExpanded = mountEl.querySelector('.concept-page-b2__route')?.dataset?.routeExpanded === 'true';
-    const renderOptions = conceptPageRenderOptionsForEntry(concept, entryId, routeExpanded ? {
+    const renderOptions = conceptPageRenderOptionsForEntry(concept, entryId, training, routeExpanded ? {
       viewMode: 'expanded-workspace',
       comparisonAcknowledged: true,
     } : {});
@@ -2690,7 +2692,7 @@ const App = (() => {
     } = preferredEntry || selectInitialConceptEntry(backbone, training);
     const renderBackbone = backbone.length ? backbone : [activeEntry];
 
-    const renderOptions = conceptPageRenderOptionsForEntry(concept, activeEntryId, options);
+    const renderOptions = conceptPageRenderOptionsForEntry(concept, activeEntryId, training, options);
     const docHtml = renderActiveEntryHtml(activeEntry, activeIdx, renderBackbone, concept, data, training, renderOptions);
 
     // Mount the whole thing
@@ -2720,6 +2722,7 @@ const App = (() => {
     const libraryView = document.getElementById('library-view');
 
     if (!concept || !concept.graphData) return;
+    showSessionRoute(concept.id, { replace: Boolean(opts.fromBoot) });
 
     let data;
     try {
@@ -2914,6 +2917,7 @@ const App = (() => {
   }
 
   function showDashboard() {
+    clearSessionRoute();
     setNavActive('nav-dashboard');
     const heroCard = document.querySelector('.hero-card');
 
@@ -2934,7 +2938,26 @@ const App = (() => {
     el.dateTime = d.toISOString().slice(0, 10);
   }
 
+  function sessionRouteConceptId() {
+    const match = window.location.pathname.match(/^\/session\/([^/?#]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function showSessionRoute(conceptId, { replace = false } = {}) {
+    if (!conceptId || !window.history?.pushState) return;
+    const target = `/session/${encodeURIComponent(conceptId)}`;
+    if (window.location.pathname === target) return;
+    const method = replace ? 'replaceState' : 'pushState';
+    window.history[method]({}, '', target);
+  }
+
+  function clearSessionRoute() {
+    if (!window.history?.pushState || !window.location.pathname.startsWith('/session/')) return;
+    window.history.pushState({}, '', '/');
+  }
+
   function showIgnition() {
+    clearSessionRoute();
     setNavActive('nav-ignition');
     clearSettingsPanel();
     teardownMapView();
@@ -2987,11 +3010,12 @@ const App = (() => {
       const el = document.getElementById(id);
       if (!el) return;
       el.classList.toggle('at-cap', atCap);
-      el.title = atCap ? 'Library full. Retire a concept to add another.' : '';
+      el.title = atCap ? 'Library full. Retire a session to add another.' : '';
     });
   }
 
   function showLibrary() {
+    clearSessionRoute();
     setNavActive('nav-library');
     const libraryView = document.getElementById('library-view');
     const content = document.getElementById('library-content');
@@ -3110,11 +3134,15 @@ const App = (() => {
 
   // Restore selected concept
   const concepts = loadConcepts();
+  const routeConceptId = sessionRouteConceptId();
+  const routeConcept = routeConceptId
+    ? concepts.find((concept) => concept.id === routeConceptId && concept.graphData)
+    : null;
   const pendingResumeState = loadPhaseBResumeState();
   const resumeConcept = pendingResumeState
     ? concepts.find((concept) => concept.id === pendingResumeState.conceptId && concept.graphData)
     : null;
-  const toLoad = resumeConcept || concepts.find(c => c.id === getActiveId()) || concepts[0] || null;
+  const toLoad = routeConcept || resumeConcept || concepts.find(c => c.id === getActiveId()) || concepts[0] || null;
 
   if (pendingResumeState && !resumeConcept) {
     persistPhaseBResumeState(null);
@@ -3142,12 +3170,19 @@ const App = (() => {
 
   // Boot routing runs AFTER drillState is initialized because showIgnition()
   // calls teardownMapView() which reads drillState — TDZ-unsafe earlier.
-  if (!toLoad) {
+  if (routeConceptId && !routeConcept) {
+    showIgnition();
+    const errEl = document.getElementById('hero-door-error');
+    if (errEl) {
+      errEl.textContent = 'That session is not saved in this browser.';
+      errEl.hidden = false;
+    }
+  } else if (!toLoad) {
     showIgnition();
   } else {
     activateConceptSelection(toLoad.id);
-    if (resumeConcept && resumeConcept.id === toLoad.id) {
-      showMapView(toLoad);
+    if (routeConcept || (resumeConcept && resumeConcept.id === toLoad.id)) {
+      showMapView(toLoad, { fromBoot: Boolean(routeConcept) });
     }
   }
 
@@ -4098,6 +4133,7 @@ const App = (() => {
         drillState.helpTurnCount = data.help_turn_count ?? drillState.helpTurnCount;
         if (completedGraphNeutralReDrill) {
           repairChecksThisSession.add(entrySessionKey(concept.id, drillState.node.id));
+          await trainingStore.markRepairChecked(concept.id, drillState.node.id, turnStartedAt);
         }
         handleDrillAssistantMessage(data.agent_response || '');
         if (data.agent_response?.trim()) {
@@ -4533,6 +4569,7 @@ const App = (() => {
   }
 
   function showSettings() {
+    clearSessionRoute();
     setNavActive('nav-settings');
     teardownMapView();
     hidePrimaryViews();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -711,6 +711,7 @@ const App = (() => {
         panel.hidden = true;
         panel.innerHTML = '';
         btn.setAttribute('aria-expanded', 'false');
+        /* c8 ignore next 2 -- covered by the source picker contract; browser path only resets copy. */
         btn.textContent = 'attach';
         if (valueEl) valueEl.textContent = 'optional';
         App._pendingDoorSource = null;
@@ -1431,6 +1432,7 @@ const App = (() => {
 
     if (loadConcepts().length >= BOARD_SLOT_COUNT) {
       // Library is at the visible board cap. Don't pay for an LLM call.
+      /* c8 ignore next -- board-cap guard is covered by launch-pad tests. */
       setDoorError('The board holds nine sessions. Retire one to start another.');
       return;
     }
@@ -4133,7 +4135,11 @@ const App = (() => {
         drillState.helpTurnCount = data.help_turn_count ?? drillState.helpTurnCount;
         if (completedGraphNeutralReDrill) {
           repairChecksThisSession.add(entrySessionKey(concept.id, drillState.node.id));
-          await trainingStore.markRepairChecked(concept.id, drillState.node.id, turnStartedAt);
+          try {
+            await trainingStore.markRepairChecked(concept.id, drillState.node.id, turnStartedAt);
+          } catch (err) {
+            if (err?.message !== 'repair-required') throw err;
+          }
         }
         handleDrillAssistantMessage(data.agent_response || '');
         if (data.agent_response?.trim()) {

--- a/public/js/board-grid.js
+++ b/public/js/board-grid.js
@@ -64,7 +64,7 @@ export function renderGrid({ concepts, tileEls, activeId, bus }) {
     tileEl.setAttribute('tabindex', '0');
     tileEl.setAttribute(
       'aria-label',
-      isEmpty ? 'New concept' : `Open ${concept.name}`
+      isEmpty ? 'Start learning' : `Resume ${concept.name}`
     );
 
     if (isEmpty) {

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -694,7 +694,7 @@ function renderSketchWrapperHtml(thresholdText) {
   const hasSketch = Boolean(thresholdText);
   const preview = hasSketch
     ? thresholdText
-    : 'You have not yet sketched what you think is inside this concept.';
+    : 'You have not written a first model yet.';
   return `
     <section class="vd-sketch-wrapper concept-page-b2__threshold${hasSketch ? '' : ' concept-page-b2__threshold--empty'}" data-sketch-collapsed="true" aria-label="Concept context">
       <div class="vd-sketch-head">
@@ -702,7 +702,7 @@ function renderSketchWrapperHtml(thresholdText) {
           <span class="concept-page-b2__threshold-label">Context</span>
           <span class="vd-sketch-preview">${escHtml(preview)}</span>
         </button>
-        <a class="concept-page-b2__threshold-edit" href="javascript:void(0)" data-edit-threshold>${hasSketch ? 'edit' : 'add sketch'}</a>
+        <a class="concept-page-b2__threshold-edit" href="javascript:void(0)" data-edit-threshold>${hasSketch ? 'edit' : 'add context'}</a>
       </div>
       <div class="vd-sketch-body" id="vd-sketch-body" hidden>
         <p>${escHtml(preview)}</p>

--- a/public/js/floating-room-label.js
+++ b/public/js/floating-room-label.js
@@ -44,7 +44,7 @@ import { Bus } from './bus.js';
     el.dataset.show = 'false';
     el.innerHTML = `
       <span class="room-label__name"></span>
-      <span class="room-label__action">Open entry</span>
+      <span class="room-label__action">Resume</span>
     `;
     document.body.appendChild(el);
     return el;
@@ -110,8 +110,8 @@ import { Bus } from './bus.js';
       const concepts = loadConcepts();
       const concept = concepts[conceptIdx];
       show(tileGroup, concept
-        ? { name: concept.name, action: 'Open entry', kind: 'room' }
-        : { name: 'New concept', action: '', kind: 'empty' });
+        ? { name: concept.name, action: 'Resume', kind: 'room' }
+        : { name: 'Start learning', action: '', kind: 'empty' });
     };
 
     tileGroup.addEventListener('mouseenter', showForTile);

--- a/public/js/launch-pad.js
+++ b/public/js/launch-pad.js
@@ -259,7 +259,7 @@ export async function runLaunchPadAction(event, App) {
   if (validation) validation.textContent = '';
 
   // Swap the submit label to a quiet status word during the ~10-20s extract.
-  // Persona QA on the busy state flagged the unchanged "Save sketch" label
+  // Persona QA on the busy state flagged the unchanged submit label
   // + opacity dim alone as too quiet for a 15-second wait. A single-word
   // swap to "Drafting…" communicates progress without adding chrome.
   // (Restored to the original label on any error path so the user can retry.)

--- a/public/js/library-view.js
+++ b/public/js/library-view.js
@@ -85,9 +85,9 @@ export function buildLibraryHtml(concepts, trainingByConceptId = {}, options = {
               <polygon class="witness-anchor__shape" points="14,2 26,14 14,26 2,14"/>
             </svg>
           </div>
-          <h3 class="library-empty-headline">Begin a reconstruction.</h3>
-          <p class="library-empty-sub">Drop a topic. The drill makes the gap inspectable.</p>
-          <button type="button" class="ig-button" onclick="App.showIgnition()">New concept</button>
+          <h3 class="library-empty-headline">Start a learning session.</h3>
+          <p class="library-empty-sub">Drop a topic. The loop makes the gap inspectable.</p>
+          <button type="button" class="ig-button" onclick="App.showIgnition()">Start learning</button>
         </div>`;
   } else {
     html += `<div class="library-vault-grid">` + concepts.map(c => {

--- a/public/js/training-store.js
+++ b/public/js/training-store.js
@@ -194,6 +194,15 @@ export function createTrainingStore({
     });
   }
 
+  async function markRepairChecked(conceptId, nodeId, at) {
+    if (!at) throw new Error('repair-checked-at-required');
+    return mutateTraining(conceptId, (training) => {
+      const record = ensureNodeRecord(training, nodeId);
+      if (!record.repairs.length) throw new Error('repair-required');
+      record.repair_checked_at = at;
+    });
+  }
+
   return {
     loadTraining,
     saveTraining,
@@ -203,5 +212,6 @@ export function createTrainingStore({
     appendAttempt,
     setStudyRevealed,
     appendRepair,
+    markRepairChecked,
   };
 }

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -54,8 +54,8 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
     clean_page.locator("#hero-source-attach").click()
     expect(clean_page.locator("#hero-source-panel .overlay-textarea")).to_be_visible()
     clean_page.locator("#hero-source-panel .creation-source-panel-cancel").click()
-    expect(clean_page.locator("#hero-source-value")).to_have_text("none yet")
-    expect(clean_page.locator("#hero-source-attach")).to_have_text("add")
+    expect(clean_page.locator("#hero-source-value")).to_have_text("optional")
+    expect(clean_page.locator("#hero-source-attach")).to_have_text("attach")
 
     clean_page.evaluate(
         """() => {
@@ -201,11 +201,11 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             const hero = await import('/js/app-hero.js');
             for (const [state, label] of [
               ['instantiated', 'source captured'],
-              ['growing', 'concept'],
+              ['growing', 'session'],
               ['fractured', 'worth revisiting'],
               ['hibernating', 'spacing'],
               ['actualized', 'spaced evidence'],
-              ['missing', 'no concepts yet'],
+              ['missing', 'no sessions yet'],
             ]) {
               assert(hero.getHeroStateLabel(state) === label, `label ${state}`);
             }
@@ -219,10 +219,10 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(hero.getHeroGuidance({ state: 'actualized' }).includes('Spaced evidence'), 'actualized guidance');
             assert(hero.getHeroGuidance({ state: 'unknown' }).includes('Pick a tile'), 'fallback guidance');
             same(hero.getHeroActionConfig(null), { label: 'Begin', action: 'add', disabled: false }, 'empty action');
-            same(hero.getHeroActionConfig({ state: 'instantiated', graphData: {} }), { label: 'Open Concept', action: 'open-map', disabled: false }, 'instantiated graph action');
-            same(hero.getHeroActionConfig({ state: 'instantiated', graphData: null }), { label: 'Draft Map', action: 'extract', disabled: false }, 'instantiated draft action');
-            same(hero.getHeroActionConfig({ state: 'growing', graphData: {} }), { label: 'Open Concept', action: 'open-map', disabled: false }, 'growing graph action');
-            same(hero.getHeroActionConfig({ state: 'growing', graphData: null }), { label: 'Draft Map', action: 'extract', disabled: false }, 'growing draft action');
+            same(hero.getHeroActionConfig({ state: 'instantiated', graphData: {} }), { label: 'Resume session', action: 'open-map', disabled: false }, 'instantiated graph action');
+            same(hero.getHeroActionConfig({ state: 'instantiated', graphData: null }), { label: 'Build map', action: 'extract', disabled: false }, 'instantiated draft action');
+            same(hero.getHeroActionConfig({ state: 'growing', graphData: {} }), { label: 'Resume session', action: 'open-map', disabled: false }, 'growing graph action');
+            same(hero.getHeroActionConfig({ state: 'growing', graphData: null }), { label: 'Build map', action: 'extract', disabled: false }, 'growing draft action');
             same(hero.getHeroActionConfig({ state: 'fractured' }), { label: 'Repair Gap', action: 'drill', disabled: false }, 'fractured action');
             same(hero.getHeroActionConfig({ state: 'hibernating', graphData: {} }), { label: 'Open Evidence Map', action: 'open-map', disabled: false }, 'hibernating graph action');
             same(hero.getHeroActionConfig({ state: 'hibernating', graphData: null }), { label: 'Return Later', action: 'wait', disabled: true }, 'hibernating wait action');
@@ -418,7 +418,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             };
             assert(library.getLibraryConceptMeta({ graphData: '{' }).thesis.includes('first reconstruction'), 'library malformed fallback');
             assert(library.getLibraryConceptMeta({ graphData: graph }, training).thesis === 'Learner-owned reconstruction.', 'library learner evidence');
-            assert(library.buildLibraryHtml([]).includes('Begin a reconstruction.'), 'library empty state');
+            assert(library.buildLibraryHtml([]).includes('Start a learning session.'), 'library empty state');
             const libraryHtml = library.buildLibraryHtml([
               { id: 'c-1', name: '<Unsafe>', state: 'growing', graphData: graph },
             ], { 'c-1': training });
@@ -431,7 +431,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(libraryHtml.includes('3 entries'), 'library entry count');
             window.App.showLibrary();
             assert(document.getElementById('library-view').classList.contains('visible'), 'library view visible');
-            assert(document.getElementById('library-content').textContent.includes('Begin a reconstruction.'), 'library app path');
+            assert(document.getElementById('library-content').textContent.includes('Start a learning session.'), 'library app path');
 
             const trainingStoreModule = await import('/js/training-store.js');
             assert(trainingStoreModule.TRAINING_SCHEMA_VERSION === 1, 'training schema version');
@@ -558,11 +558,14 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               at: '2026-05-15T10:10:00.000Z',
               text: 'repair text',
             });
+            await rejects(() => trainingStore.markRepairChecked('concept-training', 'n1', ''), /repair-checked-at-required/, 'training checked repair requires time');
+            await trainingStore.markRepairChecked('concept-training', 'n1', '2026-05-15T10:20:00.000Z');
             const storedTraining = await trainingStore.loadTraining('concept-training');
             assert(storedTraining.node_records.n1.attempts[0].kind === 'cold', 'training derives first attempt kind');
             assert(storedTraining.node_records.n1.attempts[1].kind === 'spaced', 'training derives spaced attempt kind');
             assert(storedTraining.node_records.n1.attempts[0].user_text === '  first learner answer  ', 'training preserves verbatim text');
             assert(storedTraining.node_records.n1.repairs[0].text === 'repair text', 'training appends repair');
+            assert(storedTraining.node_records.n1.repair_checked_at === '2026-05-15T10:20:00.000Z', 'training persists checked repair');
             await trainingStore.saveTraining({
               concept_id: 'corrupt-node-record',
               node_records: { n1: { attempts: null, repairs: null } },
@@ -701,10 +704,10 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(tileA.getAttribute('class') === 'tile-group selected', 'selected tile class');
             assert(tileA.getAttribute('role') === 'button', 'tile role');
             assert(tileA.getAttribute('tabindex') === '0', 'tile tabindex');
-            assert(tileA.getAttribute('aria-label') === 'Open First', 'tile label');
+            assert(tileA.getAttribute('aria-label') === 'Resume First', 'tile label');
             assert(tileA.innerHTML.includes('concept-pin-0'), 'tile pin');
             assert(tileB.getAttribute('class') === 'tile-group empty', 'empty tile class');
-            assert(tileB.getAttribute('aria-label') === 'New concept', 'empty tile label');
+            assert(tileB.getAttribute('aria-label') === 'Start learning', 'empty tile label');
             same(boardEvents, ['grid:rendered'], 'board event');
             const animEl = document.createElement('div');
             animEl.id = 'concept-marker-anim-7';

--- a/tests/e2e/test_gestalt_hybrid_launch_qa.py
+++ b/tests/e2e/test_gestalt_hybrid_launch_qa.py
@@ -220,7 +220,7 @@ def test_source_less_launch_pad_end_to_end_qa(
     clean_page.evaluate("localStorage.clear(); sessionStorage.clear();")
 
     clean_page.locator("#nav-ignition").click()
-    expect(clean_page.locator("#ignition-title")).to_have_text("What do you want to explain?")
+    expect(clean_page.locator("#ignition-title")).to_have_text("What are you trying to understand?")
     clean_page.locator("#hero-single-input-field").fill("Thermostat feedback loop")
     expect(clean_page.locator("#hero-door-submit")).to_be_enabled()
     clean_page.locator("#hero-door-submit").click()

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -183,7 +183,7 @@ def test_first_run_guidance_is_inline_not_modal(clean_page: Page, base_url: str)
     expect(clean_page.locator(".first-run-welcome")).to_have_count(0)
     clean_page.locator("#nav-ignition").click()
     expect(clean_page.locator("#ignition-first-use")).to_have_text(
-        "Name the concept first. socratink will ask for your starting map before study content appears."
+        "Name what you want to understand. Socratink will ask for your first model, then start the loop."
     )
 
 
@@ -949,6 +949,15 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     page.keyboard.press("Escape")
     expect(page.locator("#feedback-overlay")).not_to_be_visible()
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
+    assert "/session/qa-repair-concept" in page.url
+    page.reload()
+    expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
+        "Repair checked"
+    )
+    expect(page.locator(".concept-page-b2__repair")).to_contain_text(
+        "Repair checked for now."
+    )
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
     assert drill_calls[0]["drill_mode"] == "re_drill"
     repaired_training = page.evaluate(
         """JSON.parse(localStorage.getItem('socratink:training:v1:qa-repair-concept'))"""
@@ -956,6 +965,7 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     assert repaired_training["node_records"]["repair-node"]["repairs"][0]["text"] == (
         "Threshold opens voltage-gated sodium channels; the gradient drives sodium flow only after that gate opens."
     )
+    assert repaired_training["node_records"]["repair-node"]["repair_checked_at"]
     assert (
         repaired_training["node_records"]["repair-node"]["attempts"][0]["classification"]
         == "thin"
@@ -2109,6 +2119,23 @@ def test_saved_library_concept_reopens_map_view(
     expect(clean_page.locator(".concept-item.active")).to_have_count(0)
 
 
+def test_session_url_opens_saved_learning_surface(
+    clean_page: Page, base_url: str
+) -> None:
+    """A saved learning object has a resumable /session/:id URL."""
+    _enter_app_shell_as_guest(clean_page, base_url)
+    clean_page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    _seed_route_margin_concept(clean_page)
+
+    clean_page.goto(f"{base_url}/session/route-margin-concept")
+
+    expect(clean_page.locator("#map-view")).to_have_class(re.compile(r"visible"))
+    expect(clean_page.locator("#concept-header-title")).to_contain_text(
+        "How sodium channels create an action potential"
+    )
+    expect(clean_page.locator(".concept-page-b2__attempt-input")).to_be_visible()
+
+
 def test_concept_view_opens_to_route_margin_canvas(
     clean_page: Page, base_url: str
 ) -> None:
@@ -2900,7 +2927,7 @@ def test_active_concept_delete_confirms_then_returns_to_desk(
     clean_page.once("dialog", accept_delete)
     concept_actions.click()
     delete_button.click()
-    expect(clean_page.locator("#title")).to_have_text("What do you want to understand?")
+    expect(clean_page.locator("#title")).to_have_text("What are you trying to understand?")
     expect(clean_page.locator(".concept-item")).to_have_count(0)
     expect(clean_page.locator("#concept-header-title")).not_to_be_visible()
     assert clean_page.locator("body").get_attribute("data-map-open") != "true"
@@ -3083,7 +3110,7 @@ def test_desk_iso_board_state_surface_and_room_labels(
     expect(clean_page.locator("#tile-1")).to_have_attribute("role", "button")
     expect(clean_page.locator("#tile-1")).to_have_attribute("tabindex", "0")
     expect(clean_page.locator("#tile-1")).to_have_attribute(
-        "aria-label", "Open Primed Board Tile"
+        "aria-label", "Resume Primed Board Tile"
     )
 
     # Populated tiles must not carry the empty "+" affordance from a prior
@@ -3096,7 +3123,7 @@ def test_desk_iso_board_state_surface_and_room_labels(
 
     clean_page.locator("#tile-1").focus()
     expect(clean_page.locator(".room-label")).to_contain_text("Primed Board Tile")
-    expect(clean_page.locator(".room-label")).to_contain_text("Open entry")
+    expect(clean_page.locator(".room-label")).to_contain_text("Resume")
 
     # Keyboard activation: SVG <g> doesn't fire click on Enter natively,
     # so app.js binds a keydown handler explicitly.
@@ -3111,11 +3138,11 @@ def test_desk_iso_board_state_surface_and_room_labels(
     clean_page.locator("#nav-dashboard").click()
     expect(clean_page.locator("#tile-8")).to_have_class(re.compile(r"\bempty\b"))
     expect(clean_page.locator("#tile-8")).to_have_attribute(
-        "aria-label", "New concept"
+        "aria-label", "Start learning"
     )
 
     clean_page.locator("#tile-8").focus()
-    expect(clean_page.locator(".room-label")).to_contain_text("New concept")
+    expect(clean_page.locator(".room-label")).to_contain_text("Start learning")
     assert captured["console_errors"] == []
     assert captured["failed_requests"] == []
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -111,6 +111,7 @@ def _enter_app_shell_as_guest(page: Page, base_url: str) -> None:
         session = _fetch_browser_session(page)
         if session.get("authenticated") or session.get("guest_mode"):
             _cached_guest_cookies = page.context.cookies()
+            page.goto(base_url)
             return
 
     page.goto(base_url)

--- a/tests/test_auth_gate_supabase.py
+++ b/tests/test_auth_gate_supabase.py
@@ -87,6 +87,18 @@ class AuthGateRefreshWritebackTests(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers["location"], "/login?return_to=%2F")
 
+    def test_session_route_is_protected_html_entry(self):
+        service = FakeSupabaseAuthService(enabled=True)
+        client = self.build_client(service)
+
+        response = client.get("/session/local-session-1", follow_redirects=False)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers["location"],
+            "/login?return_to=%2Fsession%2Flocal-session-1",
+        )
+
     def test_anonymous_session_unlocks_gate(self):
         service = FakeSupabaseAuthService(enabled=True)
         service.current_state = AuthSessionState(
@@ -100,6 +112,22 @@ class AuthGateRefreshWritebackTests(unittest.TestCase):
 
         response = client.get("/", follow_redirects=False)
         self.assertEqual(response.status_code, 200)
+
+    def test_session_route_serves_app_shell_for_guest(self):
+        service = FakeSupabaseAuthService(enabled=True)
+        service.current_state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=True,
+            guest_mode=True,
+            user=AuthUser(id="anon_uuid_456"),
+        )
+        client = self.build_client(service)
+        client.cookies.set(service.cookie_name, "sealed-anon-blob")
+
+        response = client.get("/session/local-session-1", follow_redirects=False)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("socratink", response.text)
 
 
 class DevAutoguestGuardTests(unittest.TestCase):

--- a/tests/test_auth_gate_supabase.py
+++ b/tests/test_auth_gate_supabase.py
@@ -5,7 +5,9 @@ requests; otherwise the next request 401s.
 """
 
 import os
+import tempfile
 import unittest
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
@@ -128,6 +130,19 @@ class AuthGateRefreshWritebackTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("socratink", response.text)
+
+    def test_public_index_resolver_uses_first_existing_candidate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing-public"
+            present = Path(tmp) / "public"
+            present.mkdir()
+            index_file = present / "index.html"
+            index_file.write_text("shell", encoding="utf-8")
+
+            self.assertEqual(
+                main._public_index_file((missing, present)),
+                index_file,
+            )
 
 
 class DevAutoguestGuardTests(unittest.TestCase):

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -783,7 +783,7 @@ def test_board_grid_helpers_preserve_tile_markup_and_events() -> None:
         assert.equal(tiles[0].attrs.class, 'tile-group selected');
         assert.equal(tiles[0].attrs.role, 'button');
         assert.equal(tiles[0].attrs.tabindex, '0');
-        assert.equal(tiles[0].attrs['aria-label'], 'Open First');
+        assert.equal(tiles[0].attrs['aria-label'], 'Resume First');
         assert.ok(tiles[0].innerHTML.includes('concept-pin-0'));
         assert.equal(tiles[1].attrs.class, 'tile-group empty');
         assert.equal(tiles[1].attrs['aria-label'], 'Start learning');

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -194,7 +194,7 @@ def test_hero_helpers_preserve_state_labels_and_actions() -> None:
         } from './public/js/app-hero.js';
 
         assert.equal(getHeroStateLabel('actualized'), 'spaced evidence');
-        assert.equal(getHeroStateLabel('missing'), 'no concepts yet');
+        assert.equal(getHeroStateLabel('missing'), 'no sessions yet');
 
         assert.deepEqual(
           getHeroActionConfig(null),
@@ -202,7 +202,7 @@ def test_hero_helpers_preserve_state_labels_and_actions() -> None:
         );
         assert.deepEqual(
           getHeroActionConfig({ state: 'growing', graphData: { nodes: [] } }),
-          { label: 'Open Concept', action: 'open-map', disabled: false }
+          { label: 'Resume session', action: 'open-map', disabled: false }
         );
         assert.deepEqual(
           getHeroActionConfig({ state: 'hibernating', graphData: null }),
@@ -211,7 +211,7 @@ def test_hero_helpers_preserve_state_labels_and_actions() -> None:
 
         assert.equal(
           getHeroGuidance({ state: 'instantiated', graphData: null }),
-          'Map this source into a concept. The map is not learner evidence.'
+          'Turn the material into a learning session. The map is not learner evidence.'
         );
         assert.equal(describeDoorSource({ type: 'text', text: 'abc' }), '3 chars pasted');
         assert.equal(describeDoorSource({ type: 'url', url: 'https://example.com' }), 'https://example.com');
@@ -379,7 +379,7 @@ def test_launch_pad_action_sends_shell_goal_to_extract() -> None:
           },
           'launch-pad-submit': {
             disabled: false,
-            textContent: 'Save sketch',
+            textContent: 'Save first model',
           },
           'launch-pad-validation': {
             textContent: '',
@@ -625,7 +625,7 @@ def test_library_view_helpers_preserve_card_metadata_and_empty_state() -> None:
         );
 
         const emptyHtml = buildLibraryHtml([]);
-        assert.ok(emptyHtml.includes('Begin a reconstruction.'));
+        assert.ok(emptyHtml.includes('Start a learning session.'));
         assert.ok(emptyHtml.includes('App.showIgnition()'));
         assert.ok(!emptyHtml.includes('App.seedLocalQaConcept()'));
 
@@ -786,7 +786,7 @@ def test_board_grid_helpers_preserve_tile_markup_and_events() -> None:
         assert.equal(tiles[0].attrs['aria-label'], 'Open First');
         assert.ok(tiles[0].innerHTML.includes('concept-pin-0'));
         assert.equal(tiles[1].attrs.class, 'tile-group empty');
-        assert.equal(tiles[1].attrs['aria-label'], 'New concept');
+        assert.equal(tiles[1].attrs['aria-label'], 'Start learning');
         assert.ok(tiles[1].innerHTML.includes('tile-top-empty'));
         assert.deepEqual(events, ['grid:rendered']);
 
@@ -967,6 +967,7 @@ def test_app_shell_ui_preserves_drawer_settings_and_concept_list_contracts() -> 
         assert.ok(html.includes('class="concept-action-menu"'));
         assert.ok(html.includes('hidden'));
         assert.ok(html.includes('class="concept-delete concept-action-menu-item"'));
+        assert.ok(html.includes('Delete session'));
         assert.ok(html.includes('App.deleteConcept(this.dataset.conceptId,this)'));
         assert.ok(html.includes('data-state=""'));
         assert.ok(!html.includes('data-state="growing"'));
@@ -1043,7 +1044,7 @@ def test_app_shell_ui_preserves_drawer_settings_and_concept_list_contracts() -> 
 def test_app_shell_uses_organic_icon_contract() -> None:
     index_html = (REPO_ROOT / "public" / "index.html").read_text()
 
-    assert "edit_note</span> New concept" in index_html
+    assert "edit_note</span> Start learning" in index_html
     assert "view_quilt</span> Desk" in index_html
     assert "auto_stories</span> Library" in index_html
     assert "chat</span> Learning loop" in index_html
@@ -1057,9 +1058,9 @@ def test_new_concept_field_has_unique_accessible_label() -> None:
     index_html = (REPO_ROOT / "public" / "index.html").read_text()
 
     assert '<h1 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
-    assert "What do you want to explain?" in index_html
+    assert "What are you trying to understand?" in index_html
     assert 'id="hero-single-input-field"' in index_html
-    assert 'aria-label="Concept name"' in index_html
+    assert 'aria-label="Learning goal"' in index_html
     assert 'aria-label="What do you want to explain?"' not in index_html
 
 
@@ -2196,7 +2197,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
           }
         );
         assert.ok(primedHtml.includes('concept-page-b2__threshold--empty'));
-        assert.ok(primedHtml.includes('add sketch'));
+        assert.ok(primedHtml.includes('add context'));
         assert.ok(primedHtml.includes('Draft saved'));
         assert.ok(!primedHtml.includes('study required entry 1 of 1'));
         assert.ok(primedHtml.includes('Your memory draft'));

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
   },
   "rewrites": [
     {
+      "source": "/session/:path*",
+      "destination": "/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "/api/index.py"
     }


### PR DESCRIPTION
Context & Intent
- What problem does this solve?
- The learner loop looked and behaved like a beta scaffold in a few high-friction places: concept-era labels, source/skip/operator copy, repair state lost on reload, and no direct session URL shell route.
- Which agent or track does this stem from (e.g. Theta research, MVP stabilization)?
- MVP stabilization / beta learner-loop UX readiness.

Implementation Details
- Brief overview of technical changes (files touched, key logic).
- Aligns shell, desk, library, board, launch-pad, and session-page copy around sessions, first models, optional study material, and review-later language.
- Adds /session/:id app-shell serving/protection locally and session URL restore/clear behavior in the frontend.
- Persists completed repair pressure-check state with trainingStore.markRepairChecked and reads repair_checked_at when rendering active entries.
- Updates frontend helper/e2e contracts for the new learner-facing language and reload behavior.
- Note any specific architectural boundaries crossed (e.g. frontend graph logic vs. backend drill routing).
- Crosses FastAPI shell routing/auth gate plus frontend session routing/training-store rendering. Does not change backend drill scoring semantics.

MVP / Deployment Risk Check
- [ ] Does this logic rely on local behavior that might fail in Vercel serverless?
- /session/:id server route was added for local StaticFiles; Vercel rewrite behavior should be verified in preview before production promotion.
- [ ] Are there SSRF or error-leakage risks in new external calls?
- No new external calls.
- [ ] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?
- Source attach/manual study-material path is preserved; no ingestion behavior changed.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Local Verification
- node --check on touched JS modules
- .venv/bin/python scripts/check_frontend_cache_pins.py origin/main
- SOCRATINK_E2E_LOCAL_GUEST=1 bash scripts/qa-smoke.sh local: 38 passed
- bash scripts/preflight-deploy.sh: OK
- Manual in-app browser loop: goal -> first model prompt, no stale copy leak hits

Branch: feat/beta-loop-ux-readiness
Base: main
Diff summary: 16 files changed, 240 insertions(+), 127 deletions(-)