### PR TITLE
feat(library): refine empty state

### DIFF
--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -382,34 +382,96 @@ body.antigravity-theme .library-empty a:hover {
   border-bottom-color: var(--ag-violet);
 }
 
-/* Empty-state — emulates the new-concept (ignition) page:
-   centered witness-anchor crystal, display headline, helper line, ig-button.
-   No dashed border, no gradient pill, no glow. Paper-system rhythm. */
+/* Empty-state — library-owned reconstruction surface:
+   centered witness-anchor crystal over a faint route map, then the CTA. */
 body.antigravity-theme .library-empty.library-empty--ignition {
-  background: transparent;
+  position: relative;
+  isolation: isolate;
+  background:
+    linear-gradient(180deg, rgba(var(--paper-0-rgb), 0.72), rgba(var(--cream-50-rgb), 0.52)),
+    rgba(var(--paper-0-rgb), 0.38);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  border: 0;
-  border-radius: 0;
-  box-shadow: none;
-  padding: clamp(40px, 8vh, 72px) 24px;
-  margin: 8px auto 0;
-  max-width: 460px;
+  border: 1px solid rgba(var(--ink-900-rgb), 0.08);
+  border-radius: 8px;
+  box-shadow: 0 18px 54px rgba(var(--ink-900-rgb), 0.045);
+  padding: clamp(72px, 9vh, 112px) 24px 64px;
+  margin: 24px 0 0;
+  min-height: clamp(360px, 48vh, 520px);
+  max-width: none;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   text-align: center;
   gap: 14px;
+  overflow: hidden;
+}
+
+body.antigravity-theme .library-empty.library-empty--ignition::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  top: clamp(34px, 8vh, 76px);
+  left: 50%;
+  width: min(560px, 76vw);
+  height: 190px;
+  transform: translateX(-50%);
+  opacity: 0.72;
+  background:
+    radial-gradient(circle at 22% 72%, rgba(var(--lavender-500-rgb), 0.42) 0 5px, transparent 6px),
+    radial-gradient(circle at 36% 80%, rgba(var(--lavender-500-rgb), 0.42) 0 5px, transparent 6px),
+    radial-gradient(circle at 50% 67%, rgba(var(--lavender-500-rgb), 0.42) 0 5px, transparent 6px),
+    radial-gradient(circle at 63% 70%, rgba(var(--lavender-500-rgb), 0.42) 0 5px, transparent 6px),
+    radial-gradient(circle at 78% 58%, rgba(var(--lavender-500-rgb), 0.30) 0 5px, transparent 6px),
+    linear-gradient(158deg, transparent 18%, rgba(var(--lavender-500-rgb), 0.42) 18.4% 19%, transparent 19.4% 32%, rgba(var(--lavender-500-rgb), 0.38) 32.4% 33%, transparent 33.4% 49%, rgba(var(--lavender-500-rgb), 0.42) 49.4% 50%, transparent 50.4%),
+    linear-gradient(24deg, transparent 46%, rgba(var(--lavender-500-rgb), 0.38) 46.4% 47%, transparent 47.4%),
+    linear-gradient(30deg, transparent 0 42%, rgba(var(--ink-900-rgb), 0.10) 42.5% 43%, transparent 43.5%),
+    linear-gradient(150deg, transparent 0 42%, rgba(var(--ink-900-rgb), 0.08) 42.5% 43%, transparent 43.5%);
+  background-size:
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    92px 52px,
+    92px 52px;
+  mask-image: linear-gradient(90deg, transparent, #000 16%, #000 84%, transparent);
+}
+
+body.antigravity-theme .library-empty.library-empty--ignition::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  top: clamp(96px, 14vh, 150px);
+  left: 50%;
+  width: 116px;
+  height: 64px;
+  transform: translateX(-50%) skewX(-28deg) rotate(3deg);
+  border: 1px solid rgba(var(--violet-600-rgb), 0.34);
+  background: radial-gradient(circle at center, rgba(var(--violet-600-rgb), 0.20), transparent 48%);
+  box-shadow: 0 0 26px rgba(var(--violet-600-rgb), 0.16);
 }
 
 body.antigravity-theme .library-empty--ignition .witness-anchor {
-  margin: 0 0 4px;
+  width: 76px;
+  height: 104px;
+  margin: 0 0 2px;
+  transform: translateY(-12px);
+}
+
+body.antigravity-theme .library-empty--ignition .witness-anchor svg {
+  width: 64px;
+  height: 64px;
+  filter: drop-shadow(0 18px 18px rgba(var(--violet-600-rgb), 0.16));
 }
 
 body.antigravity-theme .library-empty--ignition .witness-anchor__shape {
-  fill: none;
+  fill: rgba(var(--lavender-500-rgb), 0.14);
   stroke: var(--ag-violet);
-  stroke-width: 1.4;
+  stroke-width: 1.2;
   vector-effect: non-scaling-stroke;
 }
 
@@ -434,6 +496,42 @@ body.antigravity-theme .library-empty-sub {
   font-weight: 300;
   line-height: 1.55;
   color: var(--text-muted);
+}
+
+body.antigravity-theme .library-empty--ignition .ig-button {
+  flex: none;
+  margin-top: 6px;
+}
+
+@media (max-width: 760px) {
+  body.antigravity-theme .library-empty.library-empty--ignition {
+    min-height: 340px;
+    padding: 56px 18px 44px;
+  }
+
+  body.antigravity-theme .library-empty.library-empty--ignition::before {
+    width: 520px;
+    opacity: 0.46;
+  }
+
+  body.antigravity-theme .library-empty--ignition .witness-anchor {
+    width: 60px;
+    height: 82px;
+  }
+
+  body.antigravity-theme .library-empty--ignition .witness-anchor svg {
+    width: 52px;
+    height: 52px;
+  }
+
+  body.antigravity-theme .library-empty-headline {
+    font-size: 24px;
+  }
+
+  body.antigravity-theme .library-empty-sub {
+    font-size: 16px;
+    max-width: 24ch;
+  }
 }
 
 /* Library-card state ribbon — quiet color cue per reconstruction phase.

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -20,5 +20,5 @@
 @layer components, legacy, paper;
 
 @import '../styles.css?v=149'     layer(components);
-@import '../antigravity.css?v=28' layer(legacy);
+@import '../antigravity.css?v=30' layer(legacy);
 @import 'paper.css?v=12'          layer(paper);

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=151">
+  <link rel="stylesheet" href="/css/index.css?v=155">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=10">
 </head>
 


### PR DESCRIPTION
Context & Intent
- What problem does this solve? The Library empty state looked sparse and unfinished; this turns it into an intentional reconstruction-start panel while keeping the same learner action.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Codex UI deployment slice / MVP stabilization.
Implementation Details
- Brief overview of technical changes (files touched, key logic). Updates public/antigravity.css for the new Library empty-state composition and bumps cache pins in public/css/index.css and public/index.html.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). CSS/app-shell only; no backend, drill routing, storage, or graph logic changed.
MVP / Deployment Risk Check
- [ ] Does this logic rely on local behavior that might fail in Vercel serverless? No; static CSS/HTML only.
- [ ] Are there SSRF or error-leakage risks in new external calls? No new external calls.
- [ ] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is untouched.
UX Framework Alignment (For UI/Drill changes)
- [ ] Does this strictly enforce "Generation Before Recognition"? The empty state still directs the learner to start a learning session rather than recognize saved content.
- [ ] Does the graph still tell the truth (no faking mastery)? No graph state or mastery projection changed.
- [ ] Is the active cognitive target explicitly clear to the user? Yes; the primary action remains Start learning.
Branch: feat/library-empty-redesign
Base: main
Diff summary: public/antigravity.css | 124 +++++++++++++++++++++++++++++++++++++++++++------; public/css/index.css | 2 +-; public/index.html | 2 +-; 3 files changed, 113 insertions(+), 15 deletions(-).