### PR TITLE
fix(shell): stabilize room labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -444,7 +444,7 @@
   <script type="module" src="/js/app.js?v=166"></script>
   <script src="/js/intro-particles.js?v=8"></script>
   <script type="module" src="/js/tooltips.js?v=4"></script>
-  <script type="module" src="/js/floating-room-label.js?v=6"></script>
+  <script type="module" src="/js/floating-room-label.js?v=7"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>
 

--- a/public/js/floating-room-label.js
+++ b/public/js/floating-room-label.js
@@ -120,6 +120,27 @@ import { Bus } from './bus.js';
     tileGroup.addEventListener('blur', () => hide(tileGroup));
   }
 
+  function conceptIndexForTile(tile) {
+    const m = /^tile-(\d+)$/.exec(tile?.id || '');
+    return m ? Number(m[1]) : -1;
+  }
+
+  function showForEvent(event) {
+    const tile = event.target?.closest?.('.tile-group');
+    const conceptIdx = conceptIndexForTile(tile);
+    if (!tile || conceptIdx < 0) return;
+    const concept = loadConcepts()[conceptIdx];
+    show(tile, concept
+      ? { name: concept.name, action: 'Resume', kind: 'room' }
+      : { name: 'Start learning', action: '', kind: 'empty' });
+  }
+
+  function hideForEvent(event) {
+    const tile = event.target?.closest?.('.tile-group');
+    if (tile && event.relatedTarget && tile.contains(event.relatedTarget)) return;
+    if (tile) hide(tile);
+  }
+
   function refresh() {
     const svg = document.getElementById('grid-svg');
     if (!svg) return;
@@ -141,6 +162,11 @@ import { Bus } from './bus.js';
     refresh();
     Bus.on('grid:rendered', refresh);
   }
+
+  document.addEventListener('focusin', showForEvent);
+  document.addEventListener('focusout', hideForEvent);
+  document.addEventListener('mouseover', showForEvent);
+  document.addEventListener('mouseout', hideForEvent);
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', watch);


### PR DESCRIPTION
Context & Intent
- What problem does this solve?
Production smoke for the beta-readiness path reached the deployed SHA, but the room-label test could miss the label on focused empty board tiles after a rerender. This keeps the shell smoke gate from passing even though the SEDA learner path was green.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)?
MVP stabilization / beta readiness deployment proof.

Implementation Details
- Brief overview of technical changes (files touched, key logic).
public/js/floating-room-label.js adds delegated focus and hover recovery for .tile-group labels, using the tile id to resolve concept index when per-tile binding is missed. public/index.html bumps the floating-room-label cache pin from v=6 to v=7.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing).
Frontend shell behavior only. No backend, SEDA runtime, auth, or persistence boundary changes.

MVP / Deployment Risk Check
- [ ] Does this logic rely on local behavior that might fail in Vercel serverless?
- [ ] Are there SSRF or error-leakage risks in new external calls?
- [ ] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?

Branch: feat/beta-readiness-room-label-smoke
Base: main
Diff summary: public/index.html and public/js/floating-room-label.js; 27 insertions, 1 deletion.