### PR TITLE
fix(shell): reconcile focused desk labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -441,10 +441,10 @@
   <div id="tooltip-root" aria-hidden="true"></div>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=166"></script>
+  <script type="module" src="/js/app.js?v=167"></script>
   <script src="/js/intro-particles.js?v=8"></script>
   <script type="module" src="/js/tooltips.js?v=4"></script>
-  <script type="module" src="/js/floating-room-label.js?v=7"></script>
+  <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3010,6 +3010,7 @@ const App = (() => {
     hidePrimaryViews();
     if (heroCard) heroCard.style.display = 'flex';
     renderDeskDate();
+    Bus.emit('dashboard:shown');
     if (window.innerWidth < 900) closeDrawer();
   }
 

--- a/public/js/floating-room-label.js
+++ b/public/js/floating-room-label.js
@@ -125,14 +125,22 @@ import { Bus } from './bus.js';
     return m ? Number(m[1]) : -1;
   }
 
-  function showForEvent(event) {
-    const tile = event.target?.closest?.('.tile-group');
+  function showForTile(tile) {
     const conceptIdx = conceptIndexForTile(tile);
-    if (!tile || conceptIdx < 0) return;
+    if (!tile || conceptIdx < 0 || !tile.getClientRects().length) return;
     const concept = loadConcepts()[conceptIdx];
     show(tile, concept
       ? { name: concept.name, action: 'Resume', kind: 'room' }
       : { name: 'Start learning', action: '', kind: 'empty' });
+  }
+
+  function showForEvent(event) {
+    showForTile(event.target?.closest?.('.tile-group'));
+  }
+
+  function showFocusedTile() {
+    const tile = document.activeElement?.closest?.('.tile-group');
+    showForTile(tile);
   }
 
   function hideForEvent(event) {
@@ -161,6 +169,10 @@ import { Bus } from './bus.js';
     }
     refresh();
     Bus.on('grid:rendered', refresh);
+    Bus.on('dashboard:shown', () => {
+      refresh();
+      requestAnimationFrame(showFocusedTile);
+    });
   }
 
   document.addEventListener('focusin', showForEvent);

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -3293,12 +3293,15 @@ def test_desk_iso_board_state_surface_and_room_labels(
     clean_page.reload()
     _wait_for_app_settled(clean_page)
     clean_page.locator("#nav-dashboard").click()
-    expect(clean_page.locator("#tile-8")).to_have_class(re.compile(r"\bempty\b"))
-    expect(clean_page.locator("#tile-8")).to_have_attribute(
+    empty_tile = clean_page.locator("#tile-8")
+    expect(empty_tile).to_be_visible()
+    expect(empty_tile).to_have_class(re.compile(r"\bempty\b"))
+    expect(empty_tile).to_have_attribute(
         "aria-label", "Start learning"
     )
 
-    clean_page.locator("#tile-8").focus()
+    empty_tile.focus()
+    clean_page.evaluate("App.showDashboard()")
     expect(clean_page.locator(".room-label")).to_contain_text("Start learning")
     assert captured["console_errors"] == []
     assert captured["failed_requests"] == []


### PR DESCRIPTION
Context & Intent
- What problem does this solve?
Production smoke still exposed a focused empty-tile label edge after PR #269: when a session route recovered back to Desk with focus already on the tile, the room label could remain absent because no new focus event fired.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)?
MVP stabilization / beta readiness deployment proof.
Implementation Details
- Brief overview of technical changes (files touched, key logic).
Adds a dashboard-shown bus event from public/js/app.js, has public/js/floating-room-label.js refresh labels and reconcile the currently focused visible tile, bumps app and label cache pins in public/index.html, and extends tests/e2e/test_smoke.py to cover the already-focused Desk path.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing).
Frontend shell interaction only; no backend, graph truth, SEDA runtime, auth, or deployment routing changes.
MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless?
- [x] Are there SSRF or error-leakage risks in new external calls?
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?
UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?
Branch: feat/live-smoke-board-visibility-wait
Base: main
Diff summary: public/index.html, public/js/app.js, public/js/floating-room-label.js, and tests/e2e/test_smoke.py; 24 insertions, 8 deletions. Verification: focused Playwright smoke passed; local qa-smoke passed; npm test passed; doctor passed; check-coverage passed.