### PR TITLE
[codex] Document code work entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,17 @@ This file is the lightweight local operating guide for this repository.
 
 ## Safe change sequence
 - Confirm branch and dirty state before touching files.
+- For normal code work, start from the clean home checkout with `agent-work start <slug>` and do edits only in the printed sibling worktree.
 - Prefer docs/config edits before runtime commands for repo-level hygiene tasks.
 - Run the documented local checks before opening a PR.
+
+## Code-work entry point
+- Default to one task, one agent, one worktree, one branch.
+- Home checkout `/Users/jondev/dev/socratink/prod/socratink-app` stays on clean `main` for orientation, publish, and cleanup.
+- Agent prompt line: `Work only in <worktree-path>. Before editing, run /Users/jondev/bin/agent-work guard .`
+- For Herdr delegation, a short ask like `Use agent-work for nav icons` is enough; clarify only if scope is ambiguous, then run `agent-work launch "<task>"` from the home checkout.
+- Before publishing, rename or recreate the review branch as `feat/<slug>` so `scripts/agent-push.py` can authorize the push.
+- After merge, delete the merged `feat/<slug>` branch residue and remove the clean worktree with the repo cleanup helper.
 
 ## Commands
 - Setup: `bash scripts/bootstrap-python.sh`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ This file is the lightweight local operating guide for this repository.
 
 ## Code-work entry point
 - Default to one task, one agent, one worktree, one branch.
-- Home checkout `/Users/jondev/dev/socratink/prod/socratink-app` stays on clean `main` for orientation, publish, and cleanup.
-- Agent prompt line: `Work only in <worktree-path>. Before editing, run /Users/jondev/bin/agent-work guard .`
+- Home checkout stays on clean `main` for orientation, publish, and cleanup.
+- Agent prompt line: `Work only in <worktree-path>. Before editing, run agent-work guard .`
 - For Herdr delegation, a short ask like `Use agent-work for nav icons` is enough; clarify only if scope is ambiguous, then run `agent-work launch "<task>"` from the home checkout.
 - Before publishing, rename or recreate the review branch as `feat/<slug>` so `scripts/agent-push.py` can authorize the push.
 - After merge, delete the merged `feat/<slug>` branch residue and remove the clean worktree with the repo cleanup helper.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,14 @@ This repository is the primary source for AI-agent routing and safe editing inst
 ```
 
 ## How to start
-- Code work: from the home checkout, run `agent-work start <slug>`, then `cd ../socratink-app-<slug>`.
+- Code work: from the home checkout, run `agent-work start <slug>`, then `cd` into the printed sibling worktree.
 - Delegated Herdr work: for `Use agent-work for <task>`, clarify only if needed, then run `agent-work launch "<task>"`.
 - If you need reproducible local smoke checks, run `bash scripts/qa-smoke.sh`.
 
 ## Routing commands
 - Confirm working directory with `pwd` and repository root with `git rev-parse --show-toplevel`.
 - Confirm status and diff scope before touching files.
-- In agent worktrees, begin with `/Users/jondev/bin/agent-work guard .`.
+- In agent worktrees, begin with `agent-work guard .`.
 - Confirm test target and command with this file before every commit.
 
 ## Conditional loading guidance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This repository is the primary source for AI-agent routing and safe editing inst
 
 ## Session checklist
 - Before coding, read this file and `AGENTS.md`.
+- For normal code work, create an isolated task checkout first: `agent-work start <slug>`.
+- Work only inside the printed sibling worktree; keep the home checkout on clean `main`.
 - Verify runtime commands and dependency bootstraps before changes.
 - Run the documented local fast tests before opening a PR.
 - Keep edits scoped to the user request and avoid speculative refactors.
@@ -31,11 +33,14 @@ This repository is the primary source for AI-agent routing and safe editing inst
 ```
 
 ## How to start
+- Code work: from the home checkout, run `agent-work start <slug>`, then `cd ../socratink-app-<slug>`.
+- Delegated Herdr work: for `Use agent-work for <task>`, clarify only if needed, then run `agent-work launch "<task>"`.
 - If you need reproducible local smoke checks, run `bash scripts/qa-smoke.sh`.
 
 ## Routing commands
 - Confirm working directory with `pwd` and repository root with `git rev-parse --show-toplevel`.
 - Confirm status and diff scope before touching files.
+- In agent worktrees, begin with `/Users/jondev/bin/agent-work guard .`.
 - Confirm test target and command with this file before every commit.
 
 ## Conditional loading guidance
@@ -69,6 +74,7 @@ This repository is the primary source for AI-agent routing and safe editing inst
 - Preserve established route and agent boundaries.
 
 ## Commit workflow notes
+- Local task branches start as `agent/<slug>`; publishable review branches should be `feat/<slug>` for `scripts/agent-push.py`.
 - Keep task notes brief and link to evidence when reporting changes.
 - Log blockers and manual follow-ups in the task summary so the next session can continue.
 - Update `docs/project/state.md` for larger direction changes.


### PR DESCRIPTION
Summary:
- document agent-work as the default code-work entry point in AGENTS.md
- add the matching start, delegation, guard, and publish notes to CLAUDE.md

Checks:
- /Users/jondev/bin/agent-work guard .
- git diff --check
- bash scripts/doctor.sh

Known gaps:
- docs-only change; no browser smoke run