### PR TITLE
[codex] Define git-golden state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file is the lightweight local operating guide for this repository.
 
 ## Core instruction source
-- `CLAUDE.md` is the primary entry file for agent-facing context and lint checks.
+- `AGENTS.md` is the primary entry file for agent-facing context and lint checks.
 - If this file is missing, use `README.md` and `.github/workflows/`.
 
 ## Scope
@@ -29,6 +29,27 @@ This file is the lightweight local operating guide for this repository.
 - For Herdr delegation, a short ask like `Use agent-work for nav icons` is enough; clarify only if scope is ambiguous, then run `agent-work launch "<task>"` from the home checkout.
 - Before publishing, rename or recreate the review branch as `feat/<slug>` so `scripts/agent-push.py` can authorize the push.
 - After merge, delete the merged `feat/<slug>` branch residue and remove the clean worktree with the repo cleanup helper.
+
+## Git-golden state
+Call the repo `git-golden` only when all of these are true:
+- `main` is checked out and matches `origin/main`.
+- The working tree is clean.
+- There are no stashes.
+- There are no extra linked worktrees; the primary checkout still appears in `git worktree list`.
+- There are no local feature or agent branches left over.
+- There are no remote feature or agent branches left over.
+- There are no open PRs for finished work.
+
+Proof commands:
+
+```bash
+git status --short --branch
+git worktree list --porcelain
+git branch --format='%(refname:short)'
+git branch -r --format='%(refname:short)'
+git stash list
+gh pr list --state open
+```
 
 ## Commands
 - Setup: `bash scripts/bootstrap-python.sh`


### PR DESCRIPTION
## Summary
- define `git-golden` in `AGENTS.md` as the clean repo end state
- make `AGENTS.md` the primary agent-facing instruction source
- include proof commands for status, worktrees, branches, stashes, and open PRs

## Checks
- `rg -n "git-golden|Git-golden|CLAUDE.md is the primary|AGENTS.md is the primary" AGENTS.md CLAUDE.md`
- `git diff --check`
- `bash scripts/doctor.sh`
