### PR TITLE
[codex] Improve Library card keyboard accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=168"></script>
+  <script type="module" src="/js/app.js?v=169"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -46,7 +46,7 @@ import {
   persistPhaseBResumeState as persistStoredPhaseBResumeState,
   persistPhaseBSessionState as persistStoredPhaseBSessionState,
 } from './phase-b-session.js';
-import { buildLibraryHtml } from './library-view.js?v=1';
+import { buildLibraryHtml } from './library-view.js?v=2';
 import { createTrainingStore, TRAINING_SCHEMA_VERSION } from './training-store.js';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';

--- a/public/js/library-view.js
+++ b/public/js/library-view.js
@@ -98,6 +98,7 @@ export function buildLibraryHtml(concepts, trainingByConceptId = {}, options = {
   } else {
     html += `<div class="library-vault-grid">` + concepts.map(c => {
       const conceptId = String(c?.id ?? '');
+      const conceptName = String(c?.name ?? '');
       const training = trainingByConceptId[conceptId] || null;
       const meta = getLibraryConceptMeta(c, training);
       const derivedState = deriveConceptBadge(c, training) || '';
@@ -105,11 +106,11 @@ export function buildLibraryHtml(concepts, trainingByConceptId = {}, options = {
         ? `<span class="library-card-state" data-state="${escHtml(derivedState)}">${escHtml(conceptStateLabel(derivedState))}</span>`
         : '';
       return `
-          <div class="library-card library-card-vault" data-state="${escHtml(derivedState)}" data-concept-id="${escHtml(conceptId)}" style="cursor:pointer;" onclick="App.openLibraryConcept(this.dataset.conceptId)">
+          <div class="library-card library-card-vault" role="button" tabindex="0" aria-label="Open concept ${escHtml(conceptName)}" data-state="${escHtml(derivedState)}" data-concept-id="${escHtml(conceptId)}" style="cursor:pointer;" onclick="App.openLibraryConcept(this.dataset.conceptId)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();App.openLibraryConcept(this.dataset.conceptId)}">
             <div class="library-card-header">
               <div>
                 <div class="library-card-kicker">${escHtml(meta.sourceLabel)}</div>
-                <span class="library-card-name">${escHtml(c.name)}</span>
+                <span class="library-card-name">${escHtml(conceptName)}</span>
               </div>
               ${stateBadge}
             </div>

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -423,7 +423,11 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               { id: 'c-1', name: '<Unsafe>', state: 'growing', graphData: graph },
             ], { 'c-1': training });
             assert(libraryHtml.includes('data-concept-id="c-1"'), 'library card id data attr');
+            assert(libraryHtml.includes('role="button"'), 'library card button role');
+            assert(libraryHtml.includes('tabindex="0"'), 'library card keyboard focus');
+            assert(libraryHtml.includes('aria-label="Open concept &lt;Unsafe&gt;"'), 'library card aria label');
             assert(libraryHtml.includes('App.openLibraryConcept(this.dataset.conceptId)'), 'library card onclick');
+            assert(libraryHtml.includes("event.key==='Enter'||event.key===' '"), 'library card keyboard activation');
             assert(libraryHtml.includes('&lt;Unsafe&gt;'), 'library escaped name');
             assert(libraryHtml.includes('Learner-owned reconstruction.'), 'library card learner evidence');
             assert(!libraryHtml.includes('This is the central claim.'), 'library card no AI thesis fallback');

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -636,7 +636,11 @@ def test_library_view_helpers_preserve_card_metadata_and_empty_state() -> None:
           { id: 'c-1', name: '<Unsafe>', state: 'growing', graphData: graph },
         ], { 'c-1': training });
         assert.ok(cardHtml.includes('data-concept-id="c-1"'));
+        assert.ok(cardHtml.includes('role="button"'));
+        assert.ok(cardHtml.includes('tabindex="0"'));
+        assert.ok(cardHtml.includes('aria-label="Open concept &lt;Unsafe&gt;"'));
         assert.ok(cardHtml.includes('onclick="App.openLibraryConcept(this.dataset.conceptId)"'));
+        assert.ok(cardHtml.includes("event.key==='Enter'||event.key===' '"));
         assert.ok(cardHtml.includes('&lt;Unsafe&gt;'));
         assert.ok(cardHtml.includes('The learner reconstructed the causal mechanism.'));
         assert.ok(!cardHtml.includes('This is the central claim.'));


### PR DESCRIPTION
## What changed
- Makes Library concept cards keyboard-focusable buttons with escaped accessible names.
- Activates Library cards with Enter or Space, matching the existing click behavior.
- Bumps frontend cache pins for app.js and library-view.js.

## Checks run
- git diff --check
- .venv/bin/python scripts/check_frontend_cache_pins.py
- .venv/bin/pytest -q tests/test_frontend_app_helper_modules.py::test_library_view_helpers_preserve_card_metadata_and_empty_state
- SOCRATINK_E2E_LOCAL_GUEST=1 .venv/bin/pytest -q tests/e2e/test_app_helper_modules.py::test_app_helper_modules_preserve_browser_contracts
- ad hoc Playwright keyboard smoke on local uvicorn: QA-seeded Library card opens with Enter and Space

## Notes
- The first e2e attempt failed under python -m http.server; rerun passed under uvicorn with the local e2e guest env.