### PR TITLE
Fix SEDA first question onboarding

### DIFF
--- a/lib/loop-server/http-prompt.mjs
+++ b/lib/loop-server/http-prompt.mjs
@@ -19,7 +19,10 @@ export function createHttpPrompt({ cache, askCounts, session, env = process.env 
       }
 
       let value = null;
-      if (session.pendingInput != null && session.pendingInput !== "") {
+      if (
+        session.pendingInput != null
+        && (session.pendingInput !== "" || key === "learner_goal")
+      ) {
         value = session.pendingInput;
         session.pendingInput = null;
       }

--- a/lib/loop-server/session.mjs
+++ b/lib/loop-server/session.mjs
@@ -41,9 +41,23 @@ export async function materializeSessionRecord(session) {
 export async function advanceSession(session, userText) {
   const transcript = [];
   const restore = captureConsole(transcript);
+  const trimmedUserText = userText == null ? "" : String(userText).trim();
+  const isOptionalLearnerGoalSkip =
+    trimmedUserText === ""
+    && (
+      session.awaiting?.key === "learner_goal"
+      || (
+        session.phase === "ignition"
+        && session.ctx?.learnerGoal === null
+        && session.ctx?.launchAttempt === null
+      )
+    );
 
-  if (userText != null && String(userText).trim() !== "") {
-    const trimmed = String(userText).trim();
+  if (
+    userText != null
+    && (trimmedUserText !== "" || isOptionalLearnerGoalSkip)
+  ) {
+    const trimmed = trimmedUserText;
     if (isFeedbackCommand(trimmed)) {
       await handleFeedbackCommand(trimmed, session);
       session.transcript.push(...transcript);

--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=171"></script>
+  <script type="module" src="/js/app.js?v=173"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=169"></script>
+  <script type="module" src="/js/app.js?v=171"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=171"></script>
+  <script type="module" src="/js/app.js?v=172"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3301,6 +3301,13 @@ const App = (() => {
     return visibleSedaPromptFromResponse(data);
   }
 
+  function drillPromptFromSedaResponse(data, nodeContext, concept) {
+    if (data?.awaiting?.key === 'launch_attempt') {
+      return drillQuestionForNodeContext(nodeContext, concept);
+    }
+    return sedaPromptFromResponse(data);
+  }
+
   function saveSedaResponse(concept, nodeContext, data) {
     if (!concept?.id || !data?.sessionId) return;
     persistSedaSessionState(concept.id, {
@@ -3328,8 +3335,8 @@ const App = (() => {
     if (data?.awaiting?.key === 'cmd') {
       data = await sendSedaTurn(data.sessionId, concept.name || 'Untitled concept');
     }
-    if (data?.awaiting?.key === 'learner_goal' && concept.learnerGoal) {
-      data = await sendSedaTurn(data.sessionId, concept.learnerGoal);
+    if (data?.awaiting?.key === 'learner_goal') {
+      data = await sendSedaTurn(data.sessionId, concept.learnerGoal || '');
     }
     saveSedaResponse(concept, nodeContext, data);
     return data;
@@ -4566,7 +4573,7 @@ const App = (() => {
           .then(async (data) => {
             if (drillState.sessionToken !== sedaStartToken || !drillState.sedaActive) return;
             drillState.sedaSessionId = data.sessionId;
-            const promptText = sedaPromptFromResponse(data);
+            const promptText = drillPromptFromSedaResponse(data, nodeContext, concept);
             chamberLastShownQuestion = promptText;
             window.DrillChamber.swapQuestion(promptText);
             window.DrillChamber.setLoading?.(false);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3302,10 +3302,9 @@ const App = (() => {
   }
 
   function drillPromptFromSedaResponse(data, nodeContext, concept) {
-    if (data?.awaiting?.key === 'launch_attempt') {
-      return drillQuestionForNodeContext(nodeContext, concept);
-    }
-    return sedaPromptFromResponse(data);
+    return data?.awaiting?.key === 'launch_attempt'
+      ? drillQuestionForNodeContext(nodeContext, concept)
+      : sedaPromptFromResponse(data);
   }
 
   function saveSedaResponse(concept, nodeContext, data) {
@@ -3320,8 +3319,9 @@ const App = (() => {
 
   async function loadOrCreateSedaResponse(concept, nodeContext) {
     const stored = loadSedaSessionState(concept.id);
+    const sameStoredNode = Boolean(stored?.nodeId && stored.nodeId === nodeContext?.id);
     let data = null;
-    if (stored?.sessionId && !stored?.latest?.caseComplete) {
+    if (stored?.sessionId && sameStoredNode && !stored?.latest?.caseComplete) {
       try {
         data = await getSedaSession(stored.sessionId);
       } catch {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3320,8 +3320,9 @@ const App = (() => {
 
   async function loadOrCreateSedaResponse(concept, nodeContext) {
     const stored = loadSedaSessionState(concept.id);
+    const sameStoredNode = Boolean(stored?.nodeId && stored.nodeId === nodeContext?.id);
     let data = null;
-    if (stored?.sessionId && !stored?.latest?.caseComplete) {
+    if (stored?.sessionId && sameStoredNode && !stored?.latest?.caseComplete) {
       try {
         data = await getSedaSession(stored.sessionId);
       } catch {

--- a/tests/e2e/test_gestalt_hybrid_launch_qa.py
+++ b/tests/e2e/test_gestalt_hybrid_launch_qa.py
@@ -237,7 +237,8 @@ def test_source_less_launch_pad_end_to_end_qa(
     expect(canvas).to_be_visible(timeout=10_000)
     expect(clean_page.locator("#drill-chamber-view")).to_be_visible(timeout=10_000)
     expect(clean_page.locator("#chamber-question")).to_contain_text(
-        "What do you want to explain?", timeout=20_000
+        "What do you think the thermostat checks before it calls for heat?",
+        timeout=20_000,
     )
     seda_state = clean_page.wait_for_function(
         """() => {

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1286,7 +1286,7 @@ def test_seda_start_failure_offers_retry_from_product_flow(
     expect(page.locator("#chamber-send")).to_have_text("Try again")
     page.locator("#chamber-send").click()
     expect(page.locator("#chamber-question")).to_contain_text(
-        "Try your first explanation.",
+        "Reconstruct Immune memory persists. from memory before checking the source.",
         timeout=20_000,
     )
     expect(page.locator("#chamber-composer")).to_be_enabled()

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1124,6 +1124,14 @@ def test_start_learning_enters_seda_loop_from_product_flow(
                                 "entry_prompt": "Why is the second exposure faster?",
                                 "task_cue": "Explain the role of memory cells.",
                             },
+                        }, {
+                            "id": "c1_s2",
+                            "label": "Memory persistence",
+                            "mechanism": "Memory cells stay available after the first exposure.",
+                            "learner_scaffold": {
+                                "entry_prompt": "What persists after the first exposure?",
+                                "task_cue": "Name what remains available.",
+                            },
                         }],
                     }],
                 },
@@ -1198,6 +1206,33 @@ def test_start_learning_enters_seda_loop_from_product_flow(
         timeout=20_000,
     ).json_value()
     assert reopened_state["sessionId"] == state["sessionId"]
+    page.locator("#chamber-exit").click()
+    page.evaluate(
+        """window.App.reopenStudy({
+          id: 'c1_s2',
+          label: 'Memory persistence',
+          fullLabel: 'Memory persistence',
+          learner_scaffold: {
+            entry_prompt: 'What persists after the first exposure?',
+            task_cue: 'Name what remains available.',
+          },
+        })"""
+    )
+    expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
+    expect(page.locator("#chamber-question")).to_contain_text(
+        "What persists after the first exposure?", timeout=20_000
+    )
+    different_node_state = page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
+          if (!key) return null;
+          const value = JSON.parse(localStorage.getItem(key));
+          return value?.nodeId === 'c1_s2' && value?.sessionId ? value : null;
+        }""",
+        timeout=20_000,
+    ).json_value()
+    assert different_node_state["sessionId"] != state["sessionId"]
     page.locator("#chamber-exit").click()
     page.reload()
     expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1143,7 +1143,7 @@ def test_start_learning_enters_seda_loop_from_product_flow(
 
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
     expect(page.locator("#chamber-question")).to_contain_text(
-        "Try your first explanation", timeout=20_000
+        "Why is the second exposure faster?", timeout=20_000
     )
     state = page.wait_for_function(
         """() => {
@@ -2904,7 +2904,8 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
     expect(canvas).to_be_visible(timeout=8_000)
     expect(clean_page.locator("#drill-chamber-view")).to_be_visible(timeout=10_000)
     expect(clean_page.locator("#chamber-question")).to_contain_text(
-        "What do you want to explain?", timeout=20_000
+        "What do you think the thermostat checks before it calls for heat?",
+        timeout=20_000,
     )
     seda_state = clean_page.wait_for_function(
         """() => {
@@ -2915,7 +2916,7 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
         }""",
         timeout=20_000,
     ).json_value()
-    assert seda_state["latest"]["awaiting"]["key"] in {"learner_goal", "launch_attempt"}
+    assert seda_state["latest"]["awaiting"]["key"] == "launch_attempt"
     clean_page.locator("#chamber-exit").click()
     expect(clean_page.locator("#drill-chamber-view")).to_be_hidden()
     expect(canvas).to_be_visible(timeout=8_000)

--- a/tests/test_app_local_seda_frontend_contract.py
+++ b/tests/test_app_local_seda_frontend_contract.py
@@ -150,6 +150,31 @@ def test_seda_session_client_uses_app_boundary() -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_http_session_accepts_blank_optional_learner_goal() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { createHttpPrompt } from './lib/loop-server/http-prompt.mjs';
+
+        const session = {
+          awaiting: { key: 'learner_goal' },
+          pendingInput: '',
+          events: [],
+        };
+        const value = await createHttpPrompt({
+          cache: new Map(),
+          askCounts: new Map(),
+          session,
+        }).ask('learner_goal', 'Learner goal (optional): ');
+
+        assert.equal(value, '');
+        assert.equal(session.pendingInput, null);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_auth_bootstrap_keeps_loop_out_of_primary_navigation() -> None:
     result = run_node_module(
         """


### PR DESCRIPTION
## Summary
- skip the optional SEDA learner-goal prompt for app-created sessions, even after session rehydration
- keep the generated route-node question visible for the first chamber answer instead of replacing it with generic launch copy
- update focused browser coverage for the new-customer beta path

## Verification
- .venv/bin/pytest tests/test_app_local_seda_frontend_contract.py::test_http_session_accepts_blank_optional_learner_goal -q
- SOCRATINK_BASE_URL=http://127.0.0.1:8023 .venv/bin/pytest tests/e2e/test_smoke.py::test_start_learning_enters_seda_loop_from_product_flow tests/e2e/test_smoke.py::test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop tests/e2e/test_gestalt_hybrid_launch_qa.py::test_source_less_launch_pad_end_to_end_qa -q
- Chrome DevTools live check: first chamber prompt is a concrete question, composer enables, no console errors
