### PR TITLE
Fix Start Learning source guidance

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -305,7 +305,7 @@
           What are you trying to understand?
         </h1>
         <p class="ig-first-use" id="ignition-first-use">
-          Name what you want to understand. socratink will ask for your first model, then start the loop.
+          Name what you want to understand. Attach study material if you have it, or give your first model next.
         </p>
 
         <div class="ignition-cap-gate" id="ignition-cap-gate" hidden>

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -217,7 +217,7 @@ def test_first_run_guidance_is_inline_not_modal(clean_page: Page, base_url: str)
     expect(clean_page.locator(".first-run-welcome")).to_have_count(0)
     clean_page.locator("#nav-ignition").click()
     expect(clean_page.locator("#ignition-first-use")).to_have_text(
-        "Name what you want to understand. socratink will ask for your first model, then start the loop."
+        "Name what you want to understand. Attach study material if you have it, or give your first model next."
     )
 
 

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1047,6 +1047,8 @@ def test_new_concept_field_has_unique_accessible_label() -> None:
 
     assert '<h1 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
     assert "What are you trying to understand?" in index_html
+    assert "Attach study material if you have it, or give your first model next." in index_html
+    assert "socratink will ask for your first model" not in index_html
     assert 'id="hero-single-input-field"' in index_html
     assert 'aria-label="Learning goal"' in index_html
     assert 'aria-label="What do you want to explain?"' not in index_html


### PR DESCRIPTION
## What changed
- Clarifies the Start Learning helper copy so source-attached learners are not promised a first-model step.
- Adds focused helper and e2e assertions for the new copy.

## Why it matters
- The copy now matches the real branch: learners can attach study material, or give their first model next when they have no source.
- This is a small learner-trust correction with no SEDA core, auth, persistence, or styling changes.

## Checks run
- `git diff --check`
- `.venv/bin/pytest -q tests/test_frontend_app_helper_modules.py -k new_concept_field_has_unique_accessible_label`
- `SOCRATINK_BASE_URL=http://localhost:8019 .venv/bin/pytest -q tests/e2e/test_smoke.py -k first_run_guidance_is_inline_not_modal`
- Python Playwright visible-copy check on `http://localhost:8019`

## Known gap
- No full source-attached extraction smoke. Not needed for this copy-only fix.
