### PR TITLE
[codex] Clarify spaced reconstruction labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -284,7 +284,7 @@
             <span class="desk-legend-facet" aria-hidden="true"></span>needs repair
           </span>
           <span class="desk-legend-item" role="listitem" data-state="solidified">
-            <span class="desk-legend-facet" aria-hidden="true"></span>spaced record
+            <span class="desk-legend-facet" aria-hidden="true"></span>solid spaced reconstruction
           </span>
         </div>
       </div>
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=173"></script>
+  <script type="module" src="/js/app.js?v=174"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=27';
+} from './concept-page-view.js?v=28';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
@@ -46,7 +46,7 @@ import {
   persistPhaseBResumeState as persistStoredPhaseBResumeState,
   persistPhaseBSessionState as persistStoredPhaseBSessionState,
 } from './phase-b-session.js';
-import { buildLibraryHtml } from './library-view.js?v=2';
+import { buildLibraryHtml } from './library-view.js?v=3';
 import { createTrainingStore, TRAINING_SCHEMA_VERSION } from './training-store.js';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -365,7 +365,7 @@ function activeEntryEyebrow({ isBlocked, attempted, state, nextAction, justRevea
   if (nextAction === 'study') return 'Draft saved';
   if (nextAction === 'repair') return 'Needs repair';
   if (state === 'needs repair' && nextAction === 'spaced_attempt') return 'Ready to reconstruct again';
-  if (state === 'solidified') return 'Spaced record';
+  if (state === 'solidified') return 'Solid spaced reconstruction';
   if (nextAction === 'spaced_attempt') return 'Ready to reconstruct again';
   if (nextAction === 'review') return 'Review later';
   if (state === 'needs repair') return 'Needs repair';

--- a/public/js/library-view.js
+++ b/public/js/library-view.js
@@ -16,7 +16,7 @@ const ATTEMPT_CLASSIFICATION_RANK = {
 
 function conceptStateLabel(state) {
   if (state === 'primed') return 'draft saved';
-  if (state === 'solidified') return 'spaced record';
+  if (state === 'solidified') return 'solid spaced reconstruction';
   return state;
 }
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1812,7 +1812,7 @@ def test_localhost_legacy_inline_redrill_keeps_spaced_semantics(
     )
     page.locator(".concept-page-b2__attempt-save").click()
 
-    expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Spaced record")
+    expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Solid spaced reconstruction")
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
     assert len(drill_calls) == 1
     assert drill_calls[0]["drill_mode"] == "re_drill"

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -684,7 +684,7 @@ def test_library_view_helpers_preserve_card_metadata_and_empty_state() -> None:
           { id: 'legacy-solid-node', name: 'Legacy Solid Node', state: 'growing', graphData: legacySolidGraph },
         ], {});
         assert.ok(legacySolidHtml.includes('data-state="solidified"'));
-        assert.ok(legacySolidHtml.includes('>spaced record<'));
+        assert.ok(legacySolidHtml.includes('>solid spaced reconstruction<'));
 
         const needsRepairTraining = {
           node_records: {


### PR DESCRIPTION
What changed:
- Renamed learner-facing solidified labels from `spaced record` to `solid spaced reconstruction`.
- Bumped frontend cache pins for the touched modules.
- Updated helper and browser smoke expectations.

Why it matters:
- Keeps evidence language closer to Socratink doctrine without implying mastery.

Checks run:
- `.venv/bin/pytest -q tests/test_frontend_app_helper_modules.py -q`
- `.venv/bin/python scripts/check_frontend_cache_pins.py`
- `.venv/bin/pytest -q tests/test_frontend_syntax.py -q`
- `SOCRATINK_BASE_URL=http://localhost:8017 .venv/bin/pytest -q tests/e2e/test_smoke.py::test_localhost_legacy_inline_redrill_keeps_spaced_semantics -q`

Known gap:
- No full `scripts/doctor.sh`, no full `scripts/qa-smoke.sh`, no hosted preview proof.