### PR TITLE
[codex] Trace launch pad persistence failures

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=174"></script>
+  <script type="module" src="/js/app.js?v=175"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -84,7 +84,7 @@ import {
   buildPendingShellFromDoorInput,
   showLaunchPad as _showLaunchPad,
   runLaunchPadAction as _runLaunchPadAction,
-} from './launch-pad.js?v=2';
+} from './launch-pad.js?v=3';
 import { emitTelemetry } from './telemetry.js';
 
 import {

--- a/public/js/launch-pad.js
+++ b/public/js/launch-pad.js
@@ -359,6 +359,9 @@ export async function runLaunchPadAction(event, App) {
     // learner needs to retire a concept first. Surface a directive message
     // instead of the generic "try again" copy.
     const isBoardCap = err && err.code === 'board_at_capacity';
+    emitTelemetry('concept_create.launch_pad.persist_failed', {
+      reason: isBoardCap ? 'board_at_capacity' : 'local_persistence',
+    });
     const msg = isBoardCap
       ? 'The board holds nine concepts. Retire one in your library to start another.'
       : 'Could not save the concept locally. Try again.';

--- a/scripts/agent-lane-status.sh
+++ b/scripts/agent-lane-status.sh
@@ -207,6 +207,7 @@ def herdr_status(repo, branch):
         return {"available": False, "state": "unknown", "reason": "herdr unavailable", "duplicate_active_owner": False, "panes": []}
 
     attempts = [
+        ["herdr", "pane", "list"],
         ["herdr", "panes", "--json"],
         ["herdr", "list", "--json"],
         ["herdr", "ps", "--json"],
@@ -226,11 +227,24 @@ def herdr_status(repo, branch):
 
     text = result.stdout.strip()
     active_hits = []
-    repo_terms = {str(repo), repo.name}
-    for line in text.splitlines():
-        low = line.lower()
-        if branch in line and any(term in line for term in repo_terms) and any(word in low for word in ("active", "running", "busy")):
-            active_hits.append(line)
+    try:
+        data = json.loads(text)
+        panes = data.get("result", {}).get("panes", []) if isinstance(data, dict) else []
+    except json.JSONDecodeError:
+        panes = []
+    if panes:
+        repo_text = str(repo)
+        for pane in panes:
+            cwd = pane.get("foreground_cwd") or pane.get("cwd") or ""
+            status = pane.get("agent_status") or ""
+            if cwd.startswith(repo_text) and status in ("working", "running", "active", "busy"):
+                active_hits.append(json.dumps(pane, sort_keys=True))
+    else:
+        repo_terms = {str(repo), repo.name}
+        for line in text.splitlines():
+            low = line.lower()
+            if branch in line and any(term in line for term in repo_terms) and any(word in low for word in ("active", "running", "busy")):
+                active_hits.append(line)
     return {
         "available": True,
         "state": "ok",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -81,6 +81,8 @@ EXPECTED_ABORTED_BOOTSTRAP_PATHS: tuple[str, ...] = (
     "/login",
     "/fonts/Geom-VariableFont_wght.ttf",
     "/fonts/Inter-VariableFont_opsz,wght.ttf",
+    "/vendor/utils-0.2.1-dom.esm.js",
+    "/vendor/utils-0.2.1.esm.js",
 )
 
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1086,6 +1086,56 @@ def test_launch_pad_accepts_any_non_empty_sketch(
     )
 
 
+def test_launch_pad_persistence_failure_is_retryable(
+    page: Page, base_url: str
+) -> None:
+    """Board-capacity persistence failure leaves the launch sketch retryable."""
+    _enter_app_shell_as_guest(page, base_url)
+    page.wait_for_function("() => window.App?.showLaunchPad")
+
+    def fulfill_extract(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {},
+                    "backbone": [{"id": "b1", "principle": "First model", "dependent_clusters": []}],
+                    "clusters": [],
+                    "relationships": {"domain_mechanics": [], "learning_prerequisites": []},
+                    "frameworks": [],
+                },
+            }),
+        )
+
+    page.route("**/api/extract", fulfill_extract)
+    page.evaluate(
+        """(() => {
+            const concepts = Array.from({ length: 9 }, (_, index) => ({
+                id: `full-board-${index}`,
+                name: `Full board ${index + 1}`,
+                graphData: JSON.stringify({ metadata: {}, backbone: [], clusters: [] }),
+                createdAt: new Date().toISOString(),
+            }));
+            localStorage.setItem('learnops_concepts', JSON.stringify(concepts));
+            sessionStorage.setItem('socratink:pendingShell', JSON.stringify({
+                name: 'Persistence failure',
+                goal: '',
+                ts: Date.now(),
+            }));
+            window.App.showLaunchPad();
+        })()"""
+    )
+
+    page.locator("#launch-pad-input").fill("My rough first model.")
+    page.locator("#launch-pad-submit").click()
+
+    expect(page.locator("#launch-pad-validation")).to_have_text(
+        "The board holds nine concepts. Retire one in your library to start another."
+    )
+    assert page.evaluate("sessionStorage.getItem('socratink:pendingShell') !== null")
+
+
 def test_start_learning_enters_seda_loop_from_product_flow(
     page: Page, base_url: str
 ) -> None:

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -441,6 +441,90 @@ def test_launch_pad_action_sends_shell_goal_to_extract() -> None:
     assert result.returncode == 0, result.stderr
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_launch_pad_persistence_failure_emits_retry_telemetry() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { Bus } from './public/js/bus.js';
+        import { runLaunchPadAction } from './public/js/launch-pad.js';
+
+        const storage = new Map();
+        globalThis.sessionStorage = {
+          getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+          setItem(key, value) { storage.set(key, String(value)); },
+          removeItem(key) { storage.delete(key); },
+        };
+        globalThis.localStorage = {
+          getItem() { return null; },
+        };
+
+        const elements = {
+          'launch-pad-input': { value: 'My rough first model.' },
+          'launch-pad-submit': {
+            disabled: false,
+            textContent: 'Save first model',
+          },
+          'launch-pad-validation': { textContent: '' },
+          'launch-pad-form': {
+            dataset: {},
+            setAttribute(name, value) { this[name] = value; },
+            removeAttribute(name) { delete this[name]; },
+          },
+        };
+        globalThis.document = {
+          getElementById(id) { return elements[id] || null; },
+        };
+        globalThis.fetch = async () => new Response(JSON.stringify({
+          provisional_map: {
+            metadata: {},
+            backbone: [{ id: 'b1', principle: 'First model', dependent_clusters: [] }],
+            clusters: [],
+            relationships: { domain_mechanics: [], learning_prerequisites: [] },
+            frameworks: [],
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+
+        storage.set('socratink:pendingShell', JSON.stringify({
+          name: 'Persistence failure',
+          goal: '',
+          ts: Date.now(),
+        }));
+
+        const telemetry = [];
+        Bus.on('telemetry', (payload) => telemetry.push(payload));
+
+        const err = new Error('board full');
+        err.code = 'board_at_capacity';
+        const resultValue = await runLaunchPadAction({ preventDefault() {} }, {
+          persistCreatedConceptFromLaunchPad() { throw err; },
+          navigateToGraphViewFromLaunchPad() {
+            throw new Error('should not navigate after persistence failure');
+          },
+        });
+
+        assert.equal(resultValue, false);
+        assert.equal(storage.has('socratink:pendingShell'), true);
+        assert.equal(elements['launch-pad-submit'].disabled, false);
+        assert.equal(
+          elements['launch-pad-validation'].textContent,
+          'The board holds nine concepts. Retire one in your library to start another.'
+        );
+        assert.deepEqual(
+          telemetry.find((payload) => payload.event === 'concept_create.launch_pad.persist_failed'),
+          {
+            event: 'concept_create.launch_pad.persist_failed',
+            reason: 'board_at_capacity',
+          }
+        );
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_frontend_ai_calls_do_not_forward_browser_gemini_key() -> None:
     for rel_path in [
         "public/js/ai_service.js",


### PR DESCRIPTION
## What changed
- Emit concept_create.launch_pad.persist_failed when Launch Pad extraction succeeds but local persistence fails.
- Add a helper-level regression for the board-capacity persistence-failure path.
- Update agent lane status to use current Herdr pane-list output and parse JSON when available.

## Why it matters
- Failed local persistence after successful extraction is now reconstructable instead of silent.
- The agent-flow status helper now observes current Herdr panes correctly.

## Checks run
- bash scripts/doctor.sh
- .venv/bin/pytest -q --ignore=tests/e2e
- .venv/bin/pytest -q tests/test_frontend_syntax.py tests/test_frontend_app_helper_modules.py -k 'launch_pad or frontend_syntax'
- bash -n scripts/agent-lane-status.sh
- scripts/agent-lane-status.sh --json | .venv/bin/python -m json.tool >/dev/null
- git diff --check
- skill-audit /Users/jondev/.agents/skills/improve-the-repo/launch-agent-work

## Known gap
- No browser or hosted smoke run; this is helper/syntax/full non-e2e pytest proof only.