### PR TITLE
[codex] Project completed SEDA evidence into the training store

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=175"></script>
+  <script type="module" src="/js/app.js?v=176"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -63,6 +63,7 @@ import {
   runDrillTurn,
 } from './api-client.js?v=2';
 import { visibleSedaPromptFromResponse } from './seda-visible-prompt.js?v=2';
+import { projectCompletedSedaRecord } from './seda-evidence-projection.js';
 import {
   bootstrapAuthUi,
   buildLoginHref,
@@ -3315,6 +3316,29 @@ const App = (() => {
       latest: data,
       record: data.record || null,
     });
+    if (data.caseComplete && data.record) {
+      void projectSedaEvidence(concept, nodeContext, data);
+    }
+  }
+
+  // Reconstruction evidence must survive outside the chamber: project the
+  // completed session record into the training store the concept page,
+  // Library, and board read from.
+  async function projectSedaEvidence(concept, nodeContext, data) {
+    try {
+      const training = await trainingStore.loadTraining(concept.id);
+      const next = projectCompletedSedaRecord({
+        training,
+        conceptId: concept.id,
+        nodeId: nodeContext?.id || null,
+        record: data.record,
+        sessionId: data.sessionId,
+      });
+      if (next) await trainingStore.saveTraining(next);
+    } catch (err) {
+      /* c8 ignore next 2 -- defensive storage failure branch. */
+      console.warn('SEDA evidence projection unavailable.', err);
+    }
   }
 
   async function loadOrCreateSedaResponse(concept, nodeContext) {

--- a/public/js/seda-evidence-projection.js
+++ b/public/js/seda-evidence-projection.js
@@ -1,0 +1,116 @@
+// Projects a completed app-local SEDA session record into the learner-visible
+// training evidence store (socratink:training:v1:<conceptId>).
+//
+// Product truth: the SEDA loop simulates spacing with fixed timestamps
+// (lib/seda/constants.mjs), so copying backend attempt times verbatim would
+// let a single sitting derive solidified. Every projected attempt is
+// re-stamped to real wall-clock time so one sitting derives at most primed;
+// solidified stays gated on a real spaced return visit.
+
+export const TRAINING_SCHEMA_VERSION = 1;
+
+function sedaAttemptId(sessionId, index) {
+  return `seda-${sessionId}-${index}`;
+}
+
+// Select the single attempted backend node record. A SEDA session completes
+// exactly one node, so zero or several attempted records is unexpected; fail
+// closed rather than arbitrarily projecting whichever happens to be first.
+function attemptedNodeRecord(record) {
+  const nodeRecords = record?.training?.node_records;
+  if (!nodeRecords || typeof nodeRecords !== 'object') return null;
+  const attempted = Object.values(nodeRecords).filter(
+    (node) => node && Array.isArray(node.attempts) && node.attempts.length,
+  );
+  return attempted.length === 1 ? attempted[0] : null;
+}
+
+function restampedAttempts({ backendRecord, sessionId, now, offset }) {
+  return backendRecord.attempts.map((attempt, index) => ({
+    id: sedaAttemptId(sessionId, index),
+    at: now,
+    user_text: attempt.user_text,
+    classification: attempt.classification,
+    gaps: Array.isArray(attempt.gaps) ? attempt.gaps : [],
+    grader_version: attempt.grader_version || 'seda-loop',
+    // Positional provenance, matching training-store.js: projection re-stamps
+    // every attempt to one real sitting, so the backend's simulated cold/spaced
+    // timing is derived from position here, never copied verbatim (a backend
+    // "spaced" label would otherwise falsely imply a real spaced return).
+    kind: offset + index === 0 ? 'cold' : 'spaced',
+  }));
+}
+
+function restampedRepairs({ backendRecord, sessionId, now }) {
+  const repairs = Array.isArray(backendRecord.repairs) ? backendRecord.repairs : [];
+  return repairs.map((repair, index) => ({
+    id: `${sedaAttemptId(sessionId, index)}-repair`,
+    at: now,
+    text: repair.text,
+  }));
+}
+
+function baseTraining(training, conceptId) {
+  if (training) return training;
+  return {
+    concept_id: conceptId,
+    schema_version: TRAINING_SCHEMA_VERSION,
+    source_mode: 'source_less',
+    grounding: 'learner_sketch',
+    source_ref: null,
+    sketch: null,
+    node_records: {},
+  };
+}
+
+/**
+ * Returns the next training object to save, or null when there is nothing
+ * new to project (no completed record, no attempts, or already projected).
+ */
+export function projectCompletedSedaRecord({
+  training = null,
+  conceptId,
+  nodeId,
+  record,
+  sessionId,
+  now = new Date().toISOString(),
+} = {}) {
+  if (!conceptId || !nodeId || !sessionId) return null;
+  const backendRecord = attemptedNodeRecord(record);
+  if (!backendRecord) return null;
+
+  const next = baseTraining(training, conceptId);
+  const nodeRecords = next.node_records && typeof next.node_records === 'object'
+    ? next.node_records
+    : {};
+  const existing = nodeRecords[nodeId] || { attempts: [], repairs: [] };
+  const existingAttempts = Array.isArray(existing.attempts) ? existing.attempts : [];
+  if (existingAttempts.some((attempt) => attempt?.id === sedaAttemptId(sessionId, 0))) {
+    return null;
+  }
+
+  const projected = {
+    ...existing,
+    attempts: [
+      ...existingAttempts,
+      ...restampedAttempts({ backendRecord, sessionId, now, offset: existingAttempts.length }),
+    ],
+    repairs: [
+      ...(Array.isArray(existing.repairs) ? existing.repairs : []),
+      ...restampedRepairs({ backendRecord, sessionId, now }),
+    ],
+  };
+  if (backendRecord.study_revealed_at && !projected.study_revealed_at) {
+    projected.study_revealed_at = now;
+  }
+
+  return {
+    ...next,
+    concept_id: conceptId,
+    schema_version: TRAINING_SCHEMA_VERSION,
+    node_records: {
+      ...nodeRecords,
+      [nodeId]: projected,
+    },
+  };
+}

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1378,6 +1378,231 @@ def test_seda_start_failure_offers_retry_from_product_flow(
     assert session_attempts["count"] == 2
 
 
+def test_completed_seda_case_projects_visible_evidence(
+    page: Page, base_url: str
+) -> None:
+    """A completed SEDA case must surface as visible evidence, never solidified.
+
+    The SEDA loop simulates spacing with fixed timestamps 20h apart. Projection
+    must re-stamp attempts to real time so one sitting derives primed at most.
+    """
+    _enter_app_shell_as_guest(page, base_url)
+
+    def fulfill_extract(route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {"core_thesis": "Immune memory speeds the next response."},
+                    "backbone": [{"id": "b1", "principle": "Immune memory persists."}],
+                    "clusters": [{
+                        "id": "c1",
+                        "label": "Memory cells",
+                        "subnodes": [{
+                            "id": "c1_s1",
+                            "label": "Memory cells",
+                            "mechanism": "Memory cells persist after exposure.",
+                            "learner_scaffold": {
+                                "entry_prompt": "Why is the second exposure faster?",
+                                "task_cue": "Explain the role of memory cells.",
+                            },
+                        }],
+                    }],
+                },
+            }),
+        )
+
+    def fulfill_session(route) -> None:
+        route.fulfill(
+            status=201,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "projection-session-1",
+                "status": "awaiting_input",
+                "awaiting": {"key": "launch_attempt", "ctaText": "Try your first explanation."},
+                "learnerTranscript": [],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    # The completed record carries backend node ids and the fixed simulated
+    # timestamps (2026-05-15 cold, 2026-05-16 spaced) from lib/seda/constants.mjs.
+    completed_record = {
+        "sessionId": "projection-session-1",
+        "status": "complete",
+        "awaiting": None,
+        "learnerTranscript": [],
+        "caseComplete": True,
+        "record": {
+            "concept_id": "immune-memory-persists",
+            "training": {
+                "node_records": {
+                    "seda-node-1": {
+                        "attempts": [
+                            {
+                                "id": "cold-1",
+                                "at": "2026-05-15T10:00:00.000Z",
+                                "user_text": "Memory cells remain after the first exposure.",
+                                "classification": "strong",
+                                "gaps": [],
+                                "grader_version": "tui",
+                                "kind": "cold",
+                            },
+                            {
+                                "id": "spaced-1",
+                                "at": "2026-05-16T06:00:00.000Z",
+                                "user_text": "They respond faster on the next exposure.",
+                                "classification": "strong",
+                                "gaps": [],
+                                "grader_version": "tui",
+                                "kind": "spaced",
+                            },
+                        ],
+                        "repairs": [],
+                    },
+                },
+            },
+        },
+    }
+
+    def fulfill_turn(route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(completed_record),
+        )
+
+    page.route("**/api/extract", fulfill_extract)
+    page.route("**/api/session", fulfill_session)
+    page.route(re.compile(r".*/api/session/[^/]+/turn$"), fulfill_turn)
+
+    page.locator("#nav-ignition").click()
+    page.locator("#hero-single-input-field").fill(
+        "I want to explain why vaccines create immune memory."
+    )
+    page.locator("#hero-door-submit").click()
+    page.locator("#launch-pad-input").fill(
+        "The first exposure leaves cells that remember the pathogen."
+    )
+    page.locator("#launch-pad-submit").click()
+
+    expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
+    # Mirror the proven-stable SEDA choreography: wait until the launch_attempt
+    # turn is wired into localStorage before sending, so the turn cannot race.
+    page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
+          if (!key) return false;
+          const value = JSON.parse(localStorage.getItem(key) || 'null');
+          return value?.sessionId && value?.latest?.awaiting?.key === 'launch_attempt';
+        }""",
+        timeout=20_000,
+    )
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-hint")).to_have_text(
+        "Write a sentence before checking."
+    )
+    page.locator("#chamber-composer").fill(
+        "Memory cells remain after the first exposure and make the second response faster."
+    )
+    expect(page.locator("#chamber-hint")).to_have_text("A sentence is enough.")
+    page.locator("#chamber-send").click()
+
+    projected = page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:training:v1:${conceptId}` : null;
+          if (!key) return null;
+          const value = JSON.parse(localStorage.getItem(key) || 'null');
+          const record = value?.node_records?.['c1_s1'];
+          return record?.attempts?.length ? { attempts: record.attempts } : null;
+        }""",
+        timeout=20_000,
+    ).json_value()
+
+    attempts = projected["attempts"]
+    assert len(attempts) == 2
+    assert attempts[0]["user_text"] == "Memory cells remain after the first exposure."
+    # Product truth: re-stamped to real time, so the simulated ~20h gap is gone
+    # and a single sitting cannot clear the 18h spacing gate for solidified.
+    now_ms = page.evaluate("Date.now()")
+    for attempt in attempts:
+        stamped_ms = page.evaluate("(iso) => Date.parse(iso)", attempt["at"])
+        assert abs(now_ms - stamped_ms) < 5 * 60 * 1000
+
+    # Assert the projected *derived state* directly, not just the visible text:
+    # one re-stamped sitting must derive `primed`, never `solidified`.
+    derived_state = page.evaluate(
+        """async () => {
+          const { deriveNodeTraining } = await import('/js/training-derive.js');
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = `socratink:training:v1:${conceptId}`;
+          const training = JSON.parse(localStorage.getItem(key) || 'null');
+          return deriveNodeTraining(training.node_records['c1_s1']).state;
+        }"""
+    )
+    assert derived_state == "primed"
+
+    page.locator("#chamber-exit").click()
+    page.reload()
+    # The evidence artifact renders the strongest/latest reconstruction turn.
+    expect(page.locator(".concept-page-b2__evidence")).to_contain_text(
+        "They respond faster on the next exposure.", timeout=20_000
+    )
+    # Never solidified from one sitting.
+    expect(page.locator(".concept-page-b2__evidence")).not_to_contain_text(
+        "Solidified", timeout=20_000
+    )
+
+    # Exercise the pure projection contract across its remaining branches in the
+    # browser: fresh-training fallback, the study-reveal carry, and the
+    # per-session idempotency guard that stops resume from duplicating attempts.
+    contract = page.evaluate(
+        """async () => {
+          const { projectCompletedSedaRecord } =
+            await import('/js/seda-evidence-projection.js');
+          const record = {
+            training: {
+              node_records: {
+                'backend-node': {
+                  attempts: [{
+                    id: 'cold-1', at: '2026-05-15T10:00:00.000Z',
+                    user_text: 'a', classification: 'strong', gaps: [],
+                    grader_version: 'tui', kind: 'cold',
+                  }],
+                  repairs: [],
+                  study_revealed_at: '2026-05-15T10:12:00.000Z',
+                },
+              },
+            },
+          };
+          const now = new Date().toISOString();
+          const first = projectCompletedSedaRecord({
+            training: null, conceptId: 'c', nodeId: 'n', sessionId: 'sess-x', now, record,
+          });
+          const repeat = projectCompletedSedaRecord({
+            training: first, conceptId: 'c', nodeId: 'n', sessionId: 'sess-x', now, record,
+          });
+          const node = first.node_records['n'];
+          return {
+            builtFreshConcept: first.concept_id === 'c',
+            studyRevealedAt: node.study_revealed_at,
+            attemptAt: node.attempts[0].at,
+            now,
+            idempotent: repeat === null,
+          };
+        }"""
+    )
+    assert contract["builtFreshConcept"] is True
+    assert contract["idempotent"] is True
+    # study_revealed_at is re-stamped to real time, not the simulated constant.
+    assert contract["studyRevealedAt"] == contract["now"]
+    assert contract["attemptAt"] == contract["now"]
+
+
 def test_direct_loop_route_redirects_to_app_shell(
     page: Page, base_url: str
 ) -> None:

--- a/tests/test_seda_evidence_projection.py
+++ b/tests/test_seda_evidence_projection.py
@@ -1,0 +1,146 @@
+"""Contract for projecting completed SEDA records into visible evidence.
+
+Product truth: the SEDA loop simulates spacing with fixed timestamps
+(lib/seda/constants.mjs). Projection must re-stamp attempts to real time and
+re-key them to the frontend node id, so a single sitting derives at most
+`primed` and never `solidified`.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from tests._helpers.node_runner import run_node_module
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_projection_restamps_and_rekeys_to_frontend_node() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { projectCompletedSedaRecord } from './public/js/seda-evidence-projection.js';
+
+        const now = '2026-07-07T21:00:00.000Z';
+        const next = projectCompletedSedaRecord({
+          training: null,
+          conceptId: 'frontend-concept',
+          nodeId: 'frontend-node',
+          sessionId: 'sess-1',
+          now,
+          record: {
+            concept_id: 'backend-slug',
+            training: {
+              node_records: {
+                'backend-node': {
+                  attempts: [
+                    { id: 'cold-1', at: '2026-05-15T10:00:00.000Z', user_text: 'first', classification: 'strong', gaps: [], grader_version: 'tui', kind: 'cold' },
+                    { id: 'spaced-1', at: '2026-05-16T06:00:00.000Z', user_text: 'second', classification: 'strong', gaps: [], grader_version: 'tui', kind: 'spaced' },
+                  ],
+                  repairs: [],
+                },
+              },
+            },
+          },
+        });
+
+        assert.equal(next.concept_id, 'frontend-concept');
+        const record = next.node_records['frontend-node'];
+        assert.ok(record, 're-keyed to frontend node id');
+        assert.equal(Object.keys(next.node_records).length, 1);
+        assert.equal(record.attempts.length, 2);
+        assert.equal(record.attempts[0].user_text, 'first');
+        // Backend simulated timestamps must be discarded for real wall-clock time.
+        assert.equal(record.attempts[0].at, now);
+        assert.equal(record.attempts[1].at, now);
+        assert.equal(record.attempts[0].classification, 'strong');
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_projected_single_sitting_derives_primed_not_solidified() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { projectCompletedSedaRecord } from './public/js/seda-evidence-projection.js';
+        import { deriveNodeTraining } from './public/js/training-derive.js';
+
+        const now = '2026-07-07T21:00:00.000Z';
+        const next = projectCompletedSedaRecord({
+          training: null,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-1',
+          now,
+          record: {
+            training: {
+              node_records: {
+                'backend-node': {
+                  attempts: [
+                    { id: 'cold-1', at: '2026-05-15T10:00:00.000Z', user_text: 'a', classification: 'strong', gaps: [], grader_version: 'tui', kind: 'cold' },
+                    { id: 'spaced-1', at: '2026-05-16T06:00:00.000Z', user_text: 'b', classification: 'strong', gaps: [], grader_version: 'tui', kind: 'spaced' },
+                  ],
+                  repairs: [],
+                },
+              },
+            },
+          },
+        });
+
+        const derived = deriveNodeTraining(next.node_records['n'], { now });
+        assert.notEqual(derived.state, 'solidified', 'single sitting must not solidify');
+        assert.equal(derived.state, 'primed');
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_projection_is_idempotent_per_session() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { projectCompletedSedaRecord } from './public/js/seda-evidence-projection.js';
+
+        const record = {
+          training: {
+            node_records: {
+              'backend-node': {
+                attempts: [
+                  { id: 'cold-1', at: '2026-05-15T10:00:00.000Z', user_text: 'a', classification: 'strong', gaps: [], grader_version: 'tui', kind: 'cold' },
+                ],
+                repairs: [],
+              },
+            },
+          },
+        };
+
+        const first = projectCompletedSedaRecord({
+          training: null, conceptId: 'c', nodeId: 'n', sessionId: 'sess-1', now: '2026-07-07T21:00:00.000Z', record,
+        });
+        const second = projectCompletedSedaRecord({
+          training: first, conceptId: 'c', nodeId: 'n', sessionId: 'sess-1', now: '2026-07-07T21:05:00.000Z', record,
+        });
+        assert.equal(second, null, 'same session must not re-project');
+        assert.equal(first.node_records['n'].attempts.length, 1);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_projection_returns_null_without_completed_record() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { projectCompletedSedaRecord } from './public/js/seda-evidence-projection.js';
+
+        assert.equal(projectCompletedSedaRecord({ conceptId: 'c', nodeId: 'n', sessionId: 's', record: null }), null);
+        assert.equal(projectCompletedSedaRecord({ conceptId: 'c', nodeId: 'n', sessionId: 's', record: { training: { node_records: {} } } }), null);
+        assert.equal(projectCompletedSedaRecord({ conceptId: '', nodeId: 'n', sessionId: 's', record: { training: { node_records: { x: { attempts: [{}] } } } } }), null);
+        """
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What changed
- New `public/js/seda-evidence-projection.js`: projects a completed SEDA session record into the learner-visible training store (`socratink:training:v1:<conceptId>`), re-keyed to the frontend node id and re-stamped to real wall-clock time.
- `public/js/app.js`: on `caseComplete && record`, `projectSedaEvidence` saves the projected training (defensively wrapped); `app.js` pin bumped 175 -> 176.
- Tests: 4-part unit contract (`tests/test_seda_evidence_projection.py`) plus a full-flow e2e (`tests/e2e/test_smoke.py::test_completed_seda_case_projects_visible_evidence`) that asserts the projected derived state directly (`primed`, never `solidified`).

## Why it matters
Connects the missing product hop: completed SEDA reconstruction -> learner-visible evidence on return. The SEDA loop simulates spacing with fixed timestamps; copying them verbatim would let one sitting derive `solidified`. Re-stamping keeps `solidified` gated on a real spaced return, so graph truth stays honest.

Guardrails baked in:
- fails closed on zero/multiple attempted backend node records (no arbitrary first-record pick)
- `kind` is positional provenance matching `training-store.js`, never the backend's simulated "spaced" label
- idempotent per session id, so resume cannot duplicate evidence

## Checks run
- `.venv/bin/pytest -q --ignore=tests/e2e`: 711 passed
- `bash scripts/doctor.sh`: OK
- `SOCRATINK_BASE_URL=http://localhost:8041 ./scripts/check-coverage.sh`: 783 e2e passed, cache pins clean, diff coverage 100% (38/38 lines)

## Known gap
- Resting-window UX: after projection the entry shows `Review later` with no visible return date (`solidify_unlocks_at` is derived but not surfaced). Flagged in the UX loop spec as a separate slice.
- Maintenance/due-state behavior was deliberately excluded from this branch per slice review.

Made with [Cursor](https://cursor.com)