### PR TITLE
fix(ui): polish core-path contrast, focus ring, and evidence-honest copy

### DIFF
--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -335,7 +335,7 @@ body.antigravity-theme .library-card-cta {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: -0.005em;
-  color: var(--ag-violet);
+  color: var(--primary-readable, var(--ag-violet));
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -343,18 +343,9 @@ body.antigravity-theme .library-card-cta {
   transition: gap 0.25s ease, color 0.2s ease;
 }
 
-body.antigravity-theme .library-card-cta::after {
-  content: "→";
-  font-size: 14px;
-  transition: transform 0.25s ease;
-}
-
 body.antigravity-theme .library-card.library-card-vault:hover .library-card-cta {
-  gap: 10px;
-}
-
-body.antigravity-theme .library-card.library-card-vault:hover .library-card-cta::after {
-  transform: translateX(2px);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
 }
 
 body.antigravity-theme .library-empty {

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -599,6 +599,26 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   font-size:20px;
   pointer-events:none;
 }
+/* The icon font is not loaded, so the generic placeholder renders the
+   kebab as a rotated square — decoration, not a menu affordance. Draw a
+   real vertical ellipsis for this control instead. */
+.concept-actions .material-symbols-outlined::before {
+  content:"\22EE";
+  border:0;
+  transform:none;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:var(--text-sub);
+  font-size:18px;
+  font-weight:700;
+}
+.concept-actions:hover .material-symbols-outlined::before,
+.concept-actions:focus-visible .material-symbols-outlined::before,
+.concept-item.menu-open .concept-actions .material-symbols-outlined::before {
+  color:var(--primary-readable);
+}
 .concept-item:hover .concept-actions,
 .concept-item.active .concept-actions,
 .concept-item:focus-within .concept-actions,

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -960,7 +960,7 @@
   background: color-mix(in srgb, var(--surface) 88%, var(--accent-primary) 12%);
   box-shadow: 0 8px 20px rgba(44, 36, 61, 0.06);
   cursor: pointer;
-  color: var(--accent-primary);
+  color: var(--primary-readable);
   font: inherit;
   font-weight: 650;
 }

--- a/public/css/drill-chamber.css
+++ b/public/css/drill-chamber.css
@@ -134,6 +134,9 @@
   letter-spacing: -0.01em;
   line-height: 1.5;
   margin: 0 0 38px;
+  /* Prompts arrive with authored line breaks (title / instruction split).
+     Preserve them so the heading never fuses into one run-on sentence. */
+  white-space: pre-line;
   /* No italics. Gravity from weight + size. */
 }
 
@@ -344,11 +347,11 @@
 .drill-chamber__composer-foot { color: var(--text-muted, rgba(36, 32, 56, 0.55)); }
 .drill-chamber__hint { color: var(--text-muted, rgba(36, 32, 56, 0.55)); }
 .drill-chamber__send {
-  color: var(--accent-primary, #9067C6);
+  color: var(--primary-readable, #70529b);
   border-color: var(--accent-border-strong, rgba(144, 103, 198, 0.32));
 }
 .drill-chamber__voice-button {
-  color: var(--accent-primary, #9067C6);
+  color: var(--primary-readable, #70529b);
   border-color: var(--border-subtle, rgba(36, 32, 56, 0.16));
 }
 .drill-chamber__send:hover {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=152'     layer(components);
-@import '../antigravity.css?v=31' layer(legacy);
-@import 'paper.css?v=12'          layer(paper);
+@import '../styles.css?v=155'     layer(components);
+@import '../antigravity.css?v=32' layer(legacy);
+@import 'paper.css?v=13'          layer(paper);

--- a/public/css/paper.css
+++ b/public/css/paper.css
@@ -261,13 +261,13 @@
   color: var(--text-muted);
 }
 .composer-card .journal-meta__key {
-  color: var(--accent-primary);
+  color: var(--primary-readable);
   font-weight: 700;
 }
 .composer-card .journal-meta__value { font-style: italic; }
 .composer-card .journal-meta__sep { color: var(--text-muted); }
 .composer-card .journal-meta__add {
-  color: var(--accent-primary);
+  color: var(--primary-readable);
   font-weight: 700;
   text-decoration: underline;
   text-decoration-color: var(--accent-border);

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -51,7 +51,11 @@
   --accent-shadow-sm:   0 4px 10px rgba(var(--violet-600-rgb), 0.20);
   --accent-shadow-md:   0 6px 14px rgba(var(--violet-600-rgb), 0.28);
   --accent-shadow-lg:   0 10px 24px rgba(var(--violet-600-rgb), 0.18);
-  --accent-ring:        0 0 0 3px rgba(var(--violet-600-rgb), 0.14);
+  /* Keyboard focus ring. The soft violet halo alone blends into cream at
+     ~1.2:1, invisible to keyboard users; a 2px solid readable-violet line
+     (5.4:1 on cream) carries the WCAG non-text contrast, the halo keeps
+     the brand softness. */
+  --accent-ring:        0 0 0 2px var(--primary-fill-hover), 0 0 0 5px rgba(var(--violet-600-rgb), 0.16);
   --cursor-socratink: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cdefs%3E%3Cfilter%20id%3D%22s%22%20x%3D%22-40%25%22%20y%3D%22-30%25%22%20width%3D%22190%25%22%20height%3D%22190%25%22%3E%3CfeDropShadow%20dx%3D%221%22%20dy%3D%221.4%22%20stdDeviation%3D%220.7%22%20flood-color%3D%22%23242038%22%20flood-opacity%3D%220.30%22%2F%3E%3C%2Ffilter%3E%3ClinearGradient%20id%3D%22g%22%20x1%3D%227%22%20y1%3D%225%22%20x2%3D%2219%22%20y2%3D%2222%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23111118%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23050508%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Cpath%20d%3D%22M6.35%204.35%2021.1%2012.05%2015.05%2014.35%2018.28%2021.78%2014.64%2023.35%2011.35%2015.8%206.88%2020.05%206.35%204.35Z%22%20fill%3D%22none%22%20stroke%3D%22%23F7ECE1%22%20stroke-width%3D%222.05%22%20stroke-linejoin%3D%22round%22%20stroke-linecap%3D%22round%22%20filter%3D%22url%28%23s%29%22%2F%3E%3Cpath%20d%3D%22M6.35%204.35%2021.1%2012.05%2015.05%2014.35%2018.28%2021.78%2014.64%2023.35%2011.35%2015.8%206.88%2020.05%206.35%204.35Z%22%20fill%3D%22url%28%23g%29%22%20stroke%3D%22%23050508%22%20stroke-width%3D%220.75%22%20stroke-linejoin%3D%22round%22%20stroke-linecap%3D%22round%22%2F%3E%3Cpath%20d%3D%22M8.15%207.18%2017.95%2012.26%2013.58%2013.83%22%20fill%3D%22none%22%20stroke%3D%22%23FFFFFF%22%20stroke-opacity%3D%220.18%22%20stroke-width%3D%220.75%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E") 6 5, auto;
   --cursor-socratink-pointer: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cdefs%3E%3Cfilter%20id%3D%22s%22%20x%3D%22-40%25%22%20y%3D%22-30%25%22%20width%3D%22190%25%22%20height%3D%22190%25%22%3E%3CfeDropShadow%20dx%3D%221%22%20dy%3D%221.4%22%20stdDeviation%3D%220.7%22%20flood-color%3D%22%23242038%22%20flood-opacity%3D%220.30%22%2F%3E%3C%2Ffilter%3E%3ClinearGradient%20id%3D%22g%22%20x1%3D%227%22%20y1%3D%225%22%20x2%3D%2219%22%20y2%3D%2222%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23111118%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23050508%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Cpath%20d%3D%22M6.35%204.35%2021.1%2012.05%2015.05%2014.35%2018.28%2021.78%2014.64%2023.35%2011.35%2015.8%206.88%2020.05%206.35%204.35Z%22%20fill%3D%22none%22%20stroke%3D%22%23F7ECE1%22%20stroke-width%3D%222.05%22%20stroke-linejoin%3D%22round%22%20stroke-linecap%3D%22round%22%20filter%3D%22url%28%23s%29%22%2F%3E%3Cpath%20d%3D%22M6.35%204.35%2021.1%2012.05%2015.05%2014.35%2018.28%2021.78%2014.64%2023.35%2011.35%2015.8%206.88%2020.05%206.35%204.35Z%22%20fill%3D%22url%28%23g%29%22%20stroke%3D%22%23050508%22%20stroke-width%3D%220.75%22%20stroke-linejoin%3D%22round%22%20stroke-linecap%3D%22round%22%2F%3E%3Cpath%20d%3D%22M8.15%207.18%2017.95%2012.26%2013.58%2013.83%22%20fill%3D%22none%22%20stroke%3D%22%23FFFFFF%22%20stroke-opacity%3D%220.18%22%20stroke-width%3D%220.75%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E") 6 5, pointer;
 
@@ -486,7 +490,9 @@
   --accent-shadow-sm:     0 4px 10px rgba(var(--lavender-500-rgb), 0.28);
   --accent-shadow-md:     0 6px 14px rgba(var(--lavender-500-rgb), 0.34);
   --accent-shadow-lg:     0 10px 24px rgba(var(--lavender-500-rgb), 0.28);
-  --accent-ring:          0 0 0 3px rgba(var(--lavender-500-rgb), 0.20);
+  /* Dark focus ring: solid readable lavender line + soft halo, matching
+     the light-theme two-part ring. */
+  --accent-ring:          0 0 0 2px #b09ce0, 0 0 0 5px rgba(var(--lavender-500-rgb), 0.24);
 
   --border-subtle: rgba(var(--cream-50-rgb), 0.14);
   --border-strong: rgba(var(--cream-50-rgb), 0.22);

--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,8 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=156">
-  <link rel="stylesheet" href="/css/drill-chamber.css?v=11">
+  <link rel="stylesheet" href="/css/index.css?v=161">
+  <link rel="stylesheet" href="/css/drill-chamber.css?v=13">
 </head>
 
 <body>
@@ -439,7 +439,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=176"></script>
+  <script type="module" src="/js/app.js?v=177"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -46,7 +46,7 @@ import {
   persistPhaseBResumeState as persistStoredPhaseBResumeState,
   persistPhaseBSessionState as persistStoredPhaseBSessionState,
 } from './phase-b-session.js';
-import { buildLibraryHtml } from './library-view.js?v=3';
+import { buildLibraryHtml } from './library-view.js?v=4';
 import { createTrainingStore, TRAINING_SCHEMA_VERSION } from './training-store.js';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';

--- a/public/js/library-view.js
+++ b/public/js/library-view.js
@@ -117,7 +117,6 @@ export function buildLibraryHtml(concepts, trainingByConceptId = {}, options = {
             <p class="library-card-summary">${escHtml(meta.thesis)}</p>
             <div class="library-card-meta">
               ${meta.architecture ? `<span class="library-card-pill">${escHtml(meta.architecture)}</span>` : ''}
-              ${meta.difficulty ? `<span class="library-card-pill">${escHtml(meta.difficulty)}</span>` : ''}
               <span class="library-card-pill">${escHtml(`${meta.clusterCount} ${meta.clusterCount === 1 ? 'section' : 'sections'}`)}</span>
               <span class="library-card-pill">${escHtml(`${meta.subnodeCount} ${meta.subnodeCount === 1 ? 'entry' : 'entries'}`)}</span>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,9 +1,9 @@
-@import './css/variables.css?v=81';
+@import './css/variables.css?v=82';
 @import './css/base.css?v=73';
 @import './css/crystal.css?v=71';
-@import './css/components.css?v=101';
+@import './css/components.css?v=102';
 @import './css/layout.css?v=110';
 @import './css/board-first.css?v=4';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';
-@import './css/concept-page.css?v=44';
+@import './css/concept-page.css?v=45';


### PR DESCRIPTION
## Summary
Browser-audited UI polish pass on the core learner path (door → drill → Library), all findings verified against rendered contrast measurements:

- **Drill prompts:** preserve authored line breaks (`white-space: pre-line`) so title/instruction no longer collapse into a run-on heading.
- **AA contrast:** door helper links, drill send/voice buttons, "Need a cue?" button, and Library card CTA move from raw accent violet (~3.6–4.1:1) to the theme-aware `--primary-readable` token.
- **Focus ring:** replaced the near-invisible low-alpha halo with a 2px readable-violet line + soft halo in both themes for keyboard navigation.
- **Product truth:** removed the learner-visible "easy" difficulty pill from Library cards (evaluative label; `getLibraryConceptMeta` still returns the field) and the design-system-rejected SaaS CTA arrow on "Open concept".
- **Icon fix:** session-actions kebab now renders a real vertical ellipsis instead of the missing-icon-font placeholder diamond.

Cache pins bumped through the full import chain (`app.js` → 177 to account for the SEDA merge landing at 176).

## Test plan
- [x] `./scripts/check-coverage.sh`: 783 passed, diff coverage 100%, cache-pin check clean (run post-rebase onto current main)
- [x] `scripts/check_frontend_cache_pins.py origin/main` clean
- [x] Before/after screenshots captured in the audit session for each fix

Made with [Cursor](https://cursor.com)