### PR TITLE
[codex] Learner-state sync and Linear Desk due surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,13 @@ gh pr list --state open
 ## Communication defaults
 - Keep responses concise and action-oriented.
 - Cite exact files and commands in changes and handoffs.
+
+## Learned User Preferences
+- During UI polish, show the live browser preview so the user can see what is being made.
+- Desk due/ready UX should stay board-centric (Linear-style Ready filter, due marks, selection strip), not a header inventory list of due nodes.
+- Give blunt honesty on whether desk UI captures metacognitive learning; do not praise-pad weak UX.
+- For Socratink implementation slices, follow `/socratink-agent-flow` when the user routes that way.
+
+## Learned Workspace Facts
+- Due/Ready desk state must come from real training evidence (`spaced_attempt` / spaced re-drill eligibility), never decorative mastery or fake progress chrome.
+- Iso board due marks: avoid CSS/SVG transform footguns on `.tile-group` when styling due tiles.

--- a/auth/service.py
+++ b/auth/service.py
@@ -35,6 +35,8 @@ class AuthSessionState:
     sealed_session: str | None = None
     should_clear_cookie: bool = False
     error_reason: str | None = None
+    # Server-only: never included in to_public_dict(). Used for PostgREST RLS.
+    access_token: str | None = None
 
     def to_public_dict(self) -> dict[str, Any]:
         return {
@@ -330,6 +332,7 @@ class SupabaseAuthService:
             user=user,
             guest_mode=True,
             sealed_session=sealed,
+            access_token=access_token,
         )
 
     def build_local_dev_guest_session(self) -> AuthSessionState:
@@ -403,6 +406,7 @@ class SupabaseAuthService:
             authenticated=True,
             user=_map_supabase_user(user),
             guest_mode=bool(claims.get("is_anonymous", False)),
+            access_token=tokens["access_token"],
         )
 
     def _refresh_session(self, refresh_token: str) -> AuthSessionState:
@@ -459,6 +463,7 @@ class SupabaseAuthService:
             user=_map_supabase_user(user) if authenticated else None,
             guest_mode=is_anon,
             sealed_session=sealed,
+            access_token=access_token if authenticated else None,
         )
 
 

--- a/auth/supabase_client.py
+++ b/auth/supabase_client.py
@@ -10,11 +10,27 @@ from supabase import ClientOptions, create_client
 from auth.service import AuthConfigurationError
 
 
-def build_supabase_client(supabase_url: str, publishable_key: str):
-    """Return a fresh Supabase client with persist_session and auto_refresh disabled."""
+def build_supabase_client(
+    supabase_url: str,
+    publishable_key: str,
+    *,
+    access_token: str | None = None,
+):
+    """Return a fresh Supabase client with persist_session and auto_refresh disabled.
+
+    When ``access_token`` is provided, PostgREST calls run as that user so
+    RLS policies that check ``auth.uid()`` can succeed.
+    """
     if not supabase_url:
         raise AuthConfigurationError("SUPABASE_URL is required.")
     if not publishable_key:
         raise AuthConfigurationError("SUPABASE_PUBLISHABLE_KEY is required.")
-    options = ClientOptions(persist_session=False, auto_refresh_token=False)
+    headers = {}
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    options = ClientOptions(
+        persist_session=False,
+        auto_refresh_token=False,
+        headers=headers,
+    )
     return create_client(supabase_url, publishable_key, options=options)

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,4 @@
+# SQL applied in the Supabase project (not auto-migrated by the app).
+
+- `feedback.sql` — public feedback capture
+- `learner_state.sql` — auth-bound concepts + training continuity blob

--- a/db/learner_state.sql
+++ b/db/learner_state.sql
@@ -1,0 +1,38 @@
+-- Auth-bound learner continuity: one JSONB blob per identified user.
+-- Packet 1 stores raw learnops_concepts + socratink:training:v1:* payloads.
+-- Due-for-spaced is derived client-side from training evidence (18h rule).
+
+CREATE TABLE IF NOT EXISTS public.learner_state (
+    user_id UUID PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    concepts JSONB NOT NULL DEFAULT '[]'::jsonb,
+    training JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.learner_state ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE ON public.learner_state TO authenticated;
+
+DROP POLICY IF EXISTS "learner_state_select_own" ON public.learner_state;
+DROP POLICY IF EXISTS "learner_state_insert_own" ON public.learner_state;
+DROP POLICY IF EXISTS "learner_state_update_own" ON public.learner_state;
+
+CREATE POLICY "learner_state_select_own"
+ON public.learner_state
+FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+CREATE POLICY "learner_state_insert_own"
+ON public.learner_state
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "learner_state_update_own"
+ON public.learner_state
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);

--- a/main.py
+++ b/main.py
@@ -814,7 +814,22 @@ def _require_identified_user(request: Request):
             status_code=401,
             detail="Identified login required to sync learner state.",
         )
+    if not session.access_token:
+        raise HTTPException(
+            status_code=401,
+            detail="Identified login required to sync learner state.",
+        )
     return session
+
+
+def _learner_state_client(session):
+    supabase_url = os.environ.get("SUPABASE_URL", "")
+    publishable_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
+    return build_supabase_client(
+        supabase_url,
+        publishable_key,
+        access_token=session.access_token,
+    )
 
 
 @app.post("/api/feedback")
@@ -859,11 +874,9 @@ class LearnerStatePayload(BaseModel):
 def get_learner_state(request: Request):
     """Return the authenticated user's synced concepts + training blob."""
     session = _require_identified_user(request)
-    supabase_url = os.environ.get("SUPABASE_URL", "")
-    publishable_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
 
     try:
-        client = build_supabase_client(supabase_url, publishable_key)
+        client = _learner_state_client(session)
         result = (
             client.table("learner_state")
             .select("schema_version,concepts,training,updated_at")
@@ -904,8 +917,6 @@ def put_learner_state(req: LearnerStatePayload, request: Request):
     if not isinstance(req.training, dict):
         raise HTTPException(status_code=400, detail="training must be an object.")
 
-    supabase_url = os.environ.get("SUPABASE_URL", "")
-    publishable_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
     payload = {
         "user_id": session.user.id,
         "schema_version": req.schema_version,
@@ -915,7 +926,7 @@ def put_learner_state(req: LearnerStatePayload, request: Request):
     }
 
     try:
-        client = build_supabase_client(supabase_url, publishable_key)
+        client = _learner_state_client(session)
         # Prefer server clock when client omits updated_at.
         if payload["updated_at"] is None:
             payload.pop("updated_at")

--- a/main.py
+++ b/main.py
@@ -147,6 +147,7 @@ PROTECTED_API_PATHS = frozenset(
         "/api/extract-url",
         "/api/repair-reps",
         "/api/session",
+        "/api/learner-state",
     }
 )
 
@@ -157,7 +158,7 @@ _cors_origins = os.environ.get(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[o.strip() for o in _cors_origins],
-    allow_methods=["GET", "POST"],
+    allow_methods=["GET", "POST", "PUT"],
     allow_headers=["*"],
 )
 
@@ -784,6 +785,38 @@ def _is_feedback_storage_unavailable(err: Exception) -> bool:
     )
 
 
+def _is_learner_state_storage_unavailable(err: Exception) -> bool:
+    if isinstance(err, AuthConfigurationError):
+        return True
+    err_msg = str(err)
+    normalized = err_msg.lower()
+    return (
+        "PGRST205" in err_msg
+        or ("learner_state" in normalized and "not found" in normalized)
+        or "permission denied for table learner_state" in normalized
+        or "permission denied for table users" in normalized
+        or "'code': '42501'" in err_msg
+        or '"code":"42501"' in err_msg
+        or '"code": "42501"' in err_msg
+    )
+
+
+def _require_identified_user(request: Request):
+    session = load_current_session_state(request)
+    if (
+        not session.auth_enabled
+        or not session.authenticated
+        or session.guest_mode
+        or not session.user
+        or not session.user.id
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail="Identified login required to sync learner state.",
+        )
+    return session
+
+
 @app.post("/api/feedback")
 def submit_feedback(req: FeedbackRequest, request: Request):
     """Securely capture user feedback and store in Supabase."""
@@ -810,6 +843,93 @@ def submit_feedback(req: FeedbackRequest, request: Request):
         logger.exception("Unexpected failure in /api/feedback")
         raise HTTPException(
             status_code=500, detail="Unexpected error while saving feedback."
+        ) from err
+
+    return {"status": "ok"}
+
+
+class LearnerStatePayload(BaseModel):
+    schema_version: int = Field(default=1, ge=1)
+    concepts: list = Field(default_factory=list)
+    training: dict = Field(default_factory=dict)
+    updated_at: str | None = None
+
+
+@app.get("/api/learner-state")
+def get_learner_state(request: Request):
+    """Return the authenticated user's synced concepts + training blob."""
+    session = _require_identified_user(request)
+    supabase_url = os.environ.get("SUPABASE_URL", "")
+    publishable_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
+
+    try:
+        client = build_supabase_client(supabase_url, publishable_key)
+        result = (
+            client.table("learner_state")
+            .select("schema_version,concepts,training,updated_at")
+            .eq("user_id", session.user.id)
+            .limit(1)
+            .execute()
+        )
+    except Exception as err:
+        if _is_learner_state_storage_unavailable(err):
+            logger.warning("Learner state storage unavailable: %s", err)
+            raise HTTPException(
+                status_code=503,
+                detail="Learner state storage is currently unavailable. Please try again later.",
+            )
+        logger.exception("Unexpected failure in GET /api/learner-state")
+        raise HTTPException(
+            status_code=500, detail="Unexpected error while loading learner state."
+        ) from err
+
+    rows = getattr(result, "data", None) or []
+    if not rows:
+        raise HTTPException(status_code=404, detail="No learner state stored yet.")
+    row = rows[0]
+    return {
+        "schema_version": row.get("schema_version") or 1,
+        "concepts": row.get("concepts") if isinstance(row.get("concepts"), list) else [],
+        "training": row.get("training") if isinstance(row.get("training"), dict) else {},
+        "updated_at": row.get("updated_at"),
+    }
+
+
+@app.put("/api/learner-state")
+def put_learner_state(req: LearnerStatePayload, request: Request):
+    """Upsert the authenticated user's concepts + training blob."""
+    session = _require_identified_user(request)
+    if not isinstance(req.concepts, list):
+        raise HTTPException(status_code=400, detail="concepts must be a list.")
+    if not isinstance(req.training, dict):
+        raise HTTPException(status_code=400, detail="training must be an object.")
+
+    supabase_url = os.environ.get("SUPABASE_URL", "")
+    publishable_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
+    payload = {
+        "user_id": session.user.id,
+        "schema_version": req.schema_version,
+        "concepts": req.concepts,
+        "training": req.training,
+        "updated_at": req.updated_at or None,
+    }
+
+    try:
+        client = build_supabase_client(supabase_url, publishable_key)
+        # Prefer server clock when client omits updated_at.
+        if payload["updated_at"] is None:
+            payload.pop("updated_at")
+        client.table("learner_state").upsert(payload, on_conflict="user_id").execute()
+    except Exception as err:
+        if _is_learner_state_storage_unavailable(err):
+            logger.warning("Learner state storage unavailable: %s", err)
+            raise HTTPException(
+                status_code=503,
+                detail="Learner state storage is currently unavailable. Please try again later.",
+            )
+        logger.exception("Unexpected failure in PUT /api/learner-state")
+        raise HTTPException(
+            status_code=500, detail="Unexpected error while saving learner state."
         ) from err
 
     return {"status": "ok"}

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -970,6 +970,238 @@ body.antigravity-theme .desk-helper {
   color: var(--text-muted);
 }
 
+/* ── Ready filter (Linear-style view chip) ─────────────────── */
+body.antigravity-theme .desk-ready-filter-host:empty {
+  display: none;
+}
+
+body.antigravity-theme .desk-ready-filter-host {
+  margin-top: 12px;
+}
+
+body.antigravity-theme .desk-ready-filter {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 5px 10px 5px 12px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 22%, transparent);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 220ms ease,
+    transform 180ms ease;
+}
+
+body.antigravity-theme .desk-ready-filter:hover {
+  color: var(--text-main);
+  border-color: color-mix(in srgb, var(--ag-violet) 35%, transparent);
+}
+
+body.antigravity-theme .desk-ready-filter:active {
+  transform: scale(0.97);
+}
+
+body.antigravity-theme .desk-ready-filter.is-active {
+  color: var(--ag-violet);
+  border-color: color-mix(in srgb, var(--ag-violet) 50%, transparent);
+  background: rgba(144, 103, 198, 0.12);
+  box-shadow:
+    0 0 0 3px rgba(144, 103, 198, 0.10),
+    0 1px 0 color-mix(in srgb, #fff 55%, transparent);
+}
+
+body.antigravity-theme .desk-ready-filter__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 12%, transparent);
+  color: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+body.antigravity-theme .desk-ready-filter.is-active .desk-ready-filter__count {
+  background: rgba(144, 103, 198, 0.22);
+}
+
+/* ── Due marks on the board ────────────────────────────────── */
+body.antigravity-theme .tile-group.is-due .tile-highlight {
+  stroke: var(--ag-violet);
+  stroke-width: 1.75;
+  opacity: 0.98;
+}
+
+body.antigravity-theme .concept-pin-due-ring {
+  fill: none;
+  stroke: rgba(144, 103, 198, 0.55);
+  stroke-width: 1.4;
+  opacity: 0.85;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: desk-due-ring 2.8s ease-in-out infinite;
+}
+
+body.antigravity-theme .tile-group.is-due .concept-pin-crystal {
+  animation: desk-due-breathe 2.8s ease-in-out infinite;
+}
+
+body.antigravity-theme .tile-group.is-due .cp-glow {
+  fill: rgba(144, 103, 198, 0.28);
+}
+
+body.antigravity-theme .tile-group.is-filtered-out {
+  opacity: 0.16;
+  filter: grayscale(0.45);
+  transition: opacity 260ms ease, filter 260ms ease;
+  pointer-events: none;
+}
+
+body.antigravity-theme .tile-group:not(.is-filtered-out) {
+  transition: opacity 260ms ease, filter 260ms ease;
+}
+
+body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due {
+  filter: drop-shadow(0 10px 18px rgba(144, 103, 198, 0.22));
+}
+
+@keyframes desk-due-breathe {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2.5px); }
+}
+
+@keyframes desk-due-ring {
+  0%, 100% {
+    opacity: 0.55;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.95;
+    transform: scale(1.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.antigravity-theme .tile-group.is-due .concept-pin-crystal,
+  body.antigravity-theme .concept-pin-due-ring {
+    animation: none;
+  }
+}
+
+/* ── Selection strip under the board ───────────────────────── */
+body.antigravity-theme .desk-due-selection-host:empty {
+  display: none;
+}
+
+body.antigravity-theme .desk-due-selection-host {
+  width: min(100%, 380px);
+  margin: 10px auto 0;
+}
+
+body.antigravity-theme .desk-due-selection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 14px 2px 4px;
+  border-top: 1px solid color-mix(in srgb, var(--text-muted) 14%, transparent);
+  animation: desk-due-selection-in 320ms cubic-bezier(0.2, 0.9, 0.2, 1) both;
+}
+
+@keyframes desk-due-selection-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.antigravity-theme .desk-due-selection {
+    animation: none;
+  }
+}
+
+body.antigravity-theme .desk-due-selection__copy {
+  min-width: 0;
+  text-align: left;
+}
+
+body.antigravity-theme .desk-due-selection__kicker {
+  margin: 0 0 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ag-violet) 72%, var(--text-muted));
+}
+
+body.antigravity-theme .desk-due-selection__node {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 560;
+  color: var(--text-main);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+body.antigravity-theme .desk-due-selection__meta {
+  display: block;
+  margin-top: 3px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+body.antigravity-theme .desk-due-selection__action {
+  appearance: none;
+  flex-shrink: 0;
+  margin: 0;
+  padding: 8px 14px !important;
+  border: 1px solid color-mix(in srgb, var(--ag-violet) 42%, transparent) !important;
+  background: rgba(144, 103, 198, 0.10) !important;
+  box-shadow: none !important;
+  min-height: 0 !important;
+  color: var(--ag-violet);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  border-radius: 999px !important;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+body.antigravity-theme .desk-due-selection__action:hover,
+body.antigravity-theme .desk-due-selection__action:focus-visible {
+  background: rgba(144, 103, 198, 0.18) !important;
+  border-color: color-mix(in srgb, var(--ag-violet) 62%, transparent) !important;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+body.antigravity-theme .desk-due-selection__action:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ag-violet) 55%, transparent);
+  outline-offset: 3px;
+}
+
 body.antigravity-theme .desk-legend {
   display: inline-flex;
   align-items: center;

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -1051,13 +1051,17 @@ body.antigravity-theme .concept-pin-due-ring {
   fill: none;
   stroke: rgba(144, 103, 198, 0.55);
   stroke-width: 1.4;
-  opacity: 0.85;
+  opacity: 0.7;
   transform-box: fill-box;
   transform-origin: center;
+}
+
+/* Motion is opt-in with the Due filter — ambient breathe/ring off by default. */
+body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-due-ring {
   animation: desk-due-ring 2.8s ease-in-out infinite;
 }
 
-body.antigravity-theme .tile-group.is-due .concept-pin-crystal {
+body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-crystal {
   animation: desk-due-breathe 2.8s ease-in-out infinite;
 }
 
@@ -1097,8 +1101,8 @@ body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  body.antigravity-theme .tile-group.is-due .concept-pin-crystal,
-  body.antigravity-theme .concept-pin-due-ring {
+  body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-crystal,
+  body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-due-ring {
     animation: none;
   }
 }

--- a/public/css/board-first.css
+++ b/public/css/board-first.css
@@ -21,6 +21,16 @@
   justify-content: center;
 }
 
+/* Mobile keeps a fixed frosted .main-header. layout.css clears it with
+   --chrome-h-top; this file must not wipe that padding or the desk
+   eyebrow slides under the scrim and looks cut off. Extra 28px clears
+   the backdrop-filter bloom past the header box. */
+@media (max-width: 899px) {
+  .hero-card {
+    padding: calc(var(--chrome-h-top) + 28px) 20px 80px;
+  }
+}
+
 /* Override the 2-column grid so the now-only child (the iso board) centers
    in a single column. */
 .hero-card .intro-content {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=157'     layer(components);
+@import '../styles.css?v=158'     layer(components);
 @import '../antigravity.css?v=37' layer(legacy);
 @import 'paper.css?v=13'          layer(paper);

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=155'     layer(components);
-@import '../antigravity.css?v=36' layer(legacy);
+@import '../styles.css?v=157'     layer(components);
+@import '../antigravity.css?v=37' layer(legacy);
 @import 'paper.css?v=13'          layer(paper);

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -20,5 +20,5 @@
 @layer components, legacy, paper;
 
 @import '../styles.css?v=155'     layer(components);
-@import '../antigravity.css?v=32' layer(legacy);
+@import '../antigravity.css?v=36' layer(legacy);
 @import 'paper.css?v=13'          layer(paper);

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -40,7 +40,7 @@
     pointer-events: auto !important;
   }
 
-  /* Main content — full remaining width */
+  /* Main content — full remaining width; own the vertical scroll when Desk grows */
   #card {
     flex: 1;
     max-width: none;
@@ -53,7 +53,12 @@
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    min-height: 100dvh;
+    max-height: 100vh;
+    max-height: 100dvh;
+    overflow-x: hidden;
     overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   /* Hide bottom nav on desktop */
@@ -145,7 +150,9 @@ body:not([data-map-open="true"]) .map-back-link {
 }
 .intro-page {
   position: relative;
-  overflow: hidden;
+  /* Visible so a tall due-for-spaced list can grow the desk and page-scroll.
+     Decorative bleed is handled by the card radius, not overflow clipping. */
+  overflow: visible;
 }
 .intro-content {
   position: relative;
@@ -204,7 +211,21 @@ body:not([data-map-open="true"]) .map-back-link {
 
 /* ─── Mobile (< 900px): centered-card layout ──────────────── */
 @media (max-width: 899px) {
-  body { flex-direction: column; align-items: center; justify-content: center; }
+  /* flex-start + margin-block:auto on #card: short desks stay centered,
+     tall desks (due list + board) start at the top and page-scroll.
+     justify-content:center clips overflow above the viewport. */
+  body {
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  #card {
+    margin-block: auto;
+    width: 100%;
+  }
 
   #launch-pad-view {
     max-height: 100dvh;

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=165">
+  <link rel="stylesheet" href="/css/index.css?v=168">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=13">
 </head>
 
@@ -442,7 +442,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=181"></script>
+  <script type="module" src="/js/app.js?v=183"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=161">
+  <link rel="stylesheet" href="/css/index.css?v=165">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=13">
 </head>
 
@@ -206,6 +206,7 @@
           </span>
           <h2 class="desk-title">Learning sessions.</h2>
           <p class="desk-helper">Pick up where you were explaining from memory.</p>
+          <div id="desk-ready-filter-host" class="desk-ready-filter-host"></div>
         </header>
 
         <div class="hero-info" id="hero-info">
@@ -272,6 +273,8 @@
             <g id="tile-8" class="tile-group" transform="translate(140,205)" onclick="App.selectTile(8)"></g>
           </svg>
         </div>
+
+        <div id="desk-due-selection-host" class="desk-due-selection-host" aria-live="polite"></div>
 
         <div class="desk-legend" role="list" aria-label="Tile-state legend">
           <span class="desk-legend-item" role="listitem" data-state="locked">
@@ -439,9 +442,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=177"></script>
+  <script type="module" src="/js/app.js?v=181"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
-  <script type="module" src="/js/iso-board-state-surface.js?v=5"></script>
+  <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>
 
   <!-- Feedback Modal -->

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=168">
+  <link rel="stylesheet" href="/css/index.css?v=169">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=13">
 </head>
 

--- a/public/index.html
+++ b/public/index.html
@@ -442,7 +442,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=183"></script>
+  <script type="module" src="/js/app.js?v=184"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -442,7 +442,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=184"></script>
+  <script type="module" src="/js/app.js?v=185"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -442,7 +442,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=185"></script>
+  <script type="module" src="/js/app.js?v=186"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -58,7 +58,7 @@ import {
   dueItemsForConcept,
   renderReadyFilterHtml,
   renderDueSelectionHtml,
-} from './due-for-spaced.js?v=5';
+} from './due-for-spaced.js?v=6';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';
 import {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5077,6 +5077,7 @@ const App = (() => {
     fastForward,
     hideMapView, setMapMode,
     showLibrary, hideLibrary, openLibraryConcept, seedLocalQaConcept, seedLocalRepairQaConcept, showDashboard, showIgnition, showSettings,
+    syncLearnerStateIfIdentified, pushLearnerStateIfIdentified,
     hidePrimaryViews,  // exposed for launch-pad.js to avoid enumerating view IDs directly
     toggleTheme, setTheme, runHeroAction,
     _readFile,  // exposed for concept-create.js's source-panel file uploader

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -47,7 +47,18 @@ import {
   persistPhaseBSessionState as persistStoredPhaseBSessionState,
 } from './phase-b-session.js';
 import { buildLibraryHtml } from './library-view.js?v=4';
-import { createTrainingStore, TRAINING_SCHEMA_VERSION } from './training-store.js';
+import { createTrainingStore, TRAINING_SCHEMA_VERSION, TRAINING_STORE_KEY_PREFIX } from './training-store.js';
+import {
+  hydrateAndSyncLearnerState,
+  pushLocalLearnerState,
+} from './learner-state-sync.js';
+import {
+  listDueForSpaced,
+  dueConceptIdSet,
+  dueItemsForConcept,
+  renderReadyFilterHtml,
+  renderDueSelectionHtml,
+} from './due-for-spaced.js?v=3';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';
 import {
@@ -76,7 +87,8 @@ import {
 } from './auth.js?v=5';
 import { prefersReducedMotion } from './motion.js';
 import {
-  STATES, generateId, loadConcepts, saveConcepts, normalizeGraphData,
+  STATES, generateId, loadConcepts, saveConcepts as persistConcepts,
+  normalizeGraphData,
   getActiveId, setActiveId, getActiveConcept,
   getActiveTileIdx, updateActiveConcept, contentStore
 } from './store.js';
@@ -108,6 +120,57 @@ const App = (() => {
   const LOCAL_REPAIR_QA_NODE_ID = 'repair-node';
   const DRILL_NODE_MECHANISM_MAX_CHARS = 10000;
   const trainingStore = createTrainingStore();
+  let learnerStatePushTimer = null;
+  let readyFilterActive = false;
+  let cachedDueItems = [];
+
+  function saveConcepts(arr) {
+    persistConcepts(arr);
+    scheduleLearnerStatePush();
+    renderDeskDueSurfaces();
+  }
+
+  function scheduleLearnerStatePush() {
+    if (learnerStatePushTimer) clearTimeout(learnerStatePushTimer);
+    learnerStatePushTimer = setTimeout(() => {
+      learnerStatePushTimer = null;
+      void pushLearnerStateIfIdentified();
+    }, 800);
+  }
+
+  const _appendAttempt = trainingStore.appendAttempt.bind(trainingStore);
+  const _setStudyRevealed = trainingStore.setStudyRevealed.bind(trainingStore);
+  const _appendRepair = trainingStore.appendRepair.bind(trainingStore);
+  const _setProvenance = trainingStore.setProvenance.bind(trainingStore);
+  const _setSketch = trainingStore.setSketch.bind(trainingStore);
+  trainingStore.appendAttempt = async (...args) => {
+    const result = await _appendAttempt(...args);
+    scheduleLearnerStatePush();
+    renderDeskDueSurfaces();
+    return result;
+  };
+  trainingStore.setStudyRevealed = async (...args) => {
+    const result = await _setStudyRevealed(...args);
+    scheduleLearnerStatePush();
+    renderDeskDueSurfaces();
+    return result;
+  };
+  trainingStore.appendRepair = async (...args) => {
+    const result = await _appendRepair(...args);
+    scheduleLearnerStatePush();
+    return result;
+  };
+  trainingStore.setProvenance = async (...args) => {
+    const result = await _setProvenance(...args);
+    scheduleLearnerStatePush();
+    return result;
+  };
+  trainingStore.setSketch = async (...args) => {
+    const result = await _setSketch(...args);
+    scheduleLearnerStatePush();
+    return result;
+  };
+
   let currentGraphController = null;
   let activeDrillNode = null;
   let repairRepsState = null;
@@ -828,7 +891,15 @@ const App = (() => {
 
   // ── 8. Grid rendering ──────────────────────────────────────
   function renderGrid(concepts = loadConcepts()) {
-    renderDeskGrid({ concepts, tileEls, activeId: getActiveId(), bus: Bus });
+    const dueIds = dueConceptIdSet(cachedDueItems);
+    renderDeskGrid({
+      concepts,
+      tileEls,
+      activeId: getActiveId(),
+      bus: Bus,
+      dueConceptIds: dueIds,
+      readyFilterActive,
+    });
   }
 
   function getSidebarActiveConceptId() {
@@ -1622,7 +1693,7 @@ const App = (() => {
 
     renderHero(concept);
     applyControlsForState(concept.state, concept);
-    renderGrid();
+    renderDeskDueSurfaces();
     renderConceptList();
     renderIgnitionGate();
     return concept;
@@ -3011,6 +3082,7 @@ const App = (() => {
     hidePrimaryViews();
     if (heroCard) heroCard.style.display = 'flex';
     renderDeskDate();
+    renderDeskDueSurfaces();
     Bus.emit('dashboard:shown');
     if (window.innerWidth < 900) closeDrawer();
   }
@@ -3022,6 +3094,105 @@ const App = (() => {
     const months = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
     el.textContent = `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
     el.dateTime = d.toISOString().slice(0, 10);
+  }
+
+  function collectTrainingByConceptId(concepts = loadConcepts()) {
+    const trainingByConceptId = {};
+    (Array.isArray(concepts) ? concepts : []).forEach((concept) => {
+      if (!concept?.id) return;
+      try {
+        const raw = localStorage.getItem(`${TRAINING_STORE_KEY_PREFIX}${concept.id}`);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+          trainingByConceptId[concept.id] = parsed;
+        }
+      } catch {
+        /* ignore corrupt training rows */
+      }
+    });
+    return trainingByConceptId;
+  }
+
+  function refreshDueCache(concepts = loadConcepts()) {
+    cachedDueItems = listDueForSpaced({
+      concepts,
+      trainingByConceptId: collectTrainingByConceptId(concepts),
+    });
+    if (!cachedDueItems.length) readyFilterActive = false;
+    return cachedDueItems;
+  }
+
+  function renderReadyFilter() {
+    const host = document.getElementById('desk-ready-filter-host');
+    if (!host) return;
+    host.innerHTML = renderReadyFilterHtml({
+      count: cachedDueItems.length,
+      active: readyFilterActive,
+    });
+    const button = host.querySelector('#desk-ready-filter');
+    if (!button) return;
+    button.addEventListener('click', () => {
+      readyFilterActive = !readyFilterActive;
+      renderDeskDueSurfaces();
+    });
+  }
+
+  function renderDueSelection() {
+    const host = document.getElementById('desk-due-selection-host');
+    if (!host) return;
+    const activeId = getActiveId();
+    const selectedDue = dueItemsForConcept(cachedDueItems, activeId);
+    host.innerHTML = renderDueSelectionHtml(selectedDue);
+    host.querySelectorAll('.desk-due-selection__action[data-concept-id]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const conceptId = button.getAttribute('data-concept-id');
+        if (!conceptId) return;
+        const concept = loadConcepts().find((c) => c.id === conceptId);
+        if (!concept) return;
+        selectConcept(conceptId);
+        if (concept.graphData) showMapView(concept);
+      });
+    });
+  }
+
+  function renderDeskDueSurfaces() {
+    refreshDueCache();
+    renderReadyFilter();
+    renderDueSelection();
+    renderGrid();
+    const grid = document.getElementById('grid-container');
+    if (!grid) return;
+    grid.classList.toggle('is-ready-filtered', readyFilterActive && cachedDueItems.length > 0);
+    if (cachedDueItems.length) {
+      grid.setAttribute('data-ready-count', String(cachedDueItems.length));
+    } else {
+      grid.removeAttribute('data-ready-count');
+    }
+  }
+
+  async function syncLearnerStateIfIdentified() {
+    try {
+      const session = await fetchAuthSession();
+      if (!isIdentifiedUserSession(session)) return false;
+      await hydrateAndSyncLearnerState({ isIdentified: true });
+      renderConceptList();
+      renderDeskDueSurfaces();
+      return true;
+    } catch (err) {
+      console.warn('Learner state sync unavailable.', err);
+      return false;
+    }
+  }
+
+  async function pushLearnerStateIfIdentified() {
+    try {
+      const session = await fetchAuthSession();
+      if (!isIdentifiedUserSession(session)) return;
+      await pushLocalLearnerState({ isIdentified: true });
+    } catch (err) {
+      console.warn('Learner state push unavailable.', err);
+    }
   }
 
   function sessionRouteConceptId() {
@@ -3205,10 +3376,11 @@ const App = (() => {
   void bootstrapAuthUi();
   void refreshDrawerFooter();
   bindMapModeControls();
-  renderGrid();
   renderConceptList();
+  renderDeskDueSurfaces();
   renderIgnitionGate();
   initHeroSingleInput();
+  void syncLearnerStateIfIdentified();
 
   // Restore selected concept
   const concepts = loadConcepts();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -51,14 +51,14 @@ import { createTrainingStore, TRAINING_SCHEMA_VERSION, TRAINING_STORE_KEY_PREFIX
 import {
   hydrateAndSyncLearnerState,
   pushLocalLearnerState,
-} from './learner-state-sync.js?v=2';
+} from './learner-state-sync.js?v=3';
 import {
   listDueForSpaced,
   dueConceptIdSet,
   dueItemsForConcept,
   renderReadyFilterHtml,
   renderDueSelectionHtml,
-} from './due-for-spaced.js?v=6';
+} from './due-for-spaced.js?v=7';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';
 import {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -8,7 +8,7 @@ import {
 import {
   playAnim,
   renderGrid as renderDeskGrid,
-} from './board-grid.js';
+} from './board-grid.js?v=2';
 import {
   clearSettingsPanel as clearShellSettingsPanel,
   closeDrawer as closeShellDrawer,
@@ -51,14 +51,14 @@ import { createTrainingStore, TRAINING_SCHEMA_VERSION, TRAINING_STORE_KEY_PREFIX
 import {
   hydrateAndSyncLearnerState,
   pushLocalLearnerState,
-} from './learner-state-sync.js';
+} from './learner-state-sync.js?v=2';
 import {
   listDueForSpaced,
   dueConceptIdSet,
   dueItemsForConcept,
   renderReadyFilterHtml,
   renderDueSelectionHtml,
-} from './due-for-spaced.js?v=3';
+} from './due-for-spaced.js?v=5';
 import { mountSourcePanel } from './source-panel.js?v=3';
 import { renderSettingsView as renderSettingsContent } from './settings-view.js?v=1';
 import {
@@ -1655,9 +1655,10 @@ const App = (() => {
         showDashboard();
         showEmptyState();
       }
-      renderGrid(concepts);
+      renderDeskDueSurfaces();
       renderConceptList(concepts);
       renderIgnitionGate();
+      scheduleLearnerStatePush();
     };
 
     if (item) {
@@ -1668,6 +1669,10 @@ const App = (() => {
   }
 
   function selectTile(tileIdx) {
+    const tileEl = tileEls[tileIdx];
+    if (tileEl?.classList.contains('is-filtered-out') || tileEl?.getAttribute('data-ready-filtered') === 'out') {
+      return;
+    }
     const concepts = loadConcepts();
     const concept = concepts[tileIdx];
     if (concept) {
@@ -3126,8 +3131,9 @@ const App = (() => {
   function renderReadyFilter() {
     const host = document.getElementById('desk-ready-filter-host');
     if (!host) return;
+    const dueSessionCount = dueConceptIdSet(cachedDueItems).size;
     host.innerHTML = renderReadyFilterHtml({
-      count: cachedDueItems.length,
+      count: dueSessionCount,
       active: readyFilterActive,
     });
     const button = host.querySelector('#desk-ready-filter');
@@ -3147,11 +3153,14 @@ const App = (() => {
     host.querySelectorAll('.desk-due-selection__action[data-concept-id]').forEach((button) => {
       button.addEventListener('click', () => {
         const conceptId = button.getAttribute('data-concept-id');
+        const nodeId = button.getAttribute('data-node-id');
         if (!conceptId) return;
         const concept = loadConcepts().find((c) => c.id === conceptId);
         if (!concept) return;
         selectConcept(conceptId);
-        if (concept.graphData) showMapView(concept);
+        if (!concept.graphData) return;
+        const opts = nodeId ? { activeEntryId: nodeId } : {};
+        showMapView(concept, opts);
       });
     });
   }
@@ -3163,9 +3172,10 @@ const App = (() => {
     renderGrid();
     const grid = document.getElementById('grid-container');
     if (!grid) return;
-    grid.classList.toggle('is-ready-filtered', readyFilterActive && cachedDueItems.length > 0);
-    if (cachedDueItems.length) {
-      grid.setAttribute('data-ready-count', String(cachedDueItems.length));
+    const dueSessionCount = dueConceptIdSet(cachedDueItems).size;
+    grid.classList.toggle('is-ready-filtered', readyFilterActive && dueSessionCount > 0);
+    if (dueSessionCount) {
+      grid.setAttribute('data-ready-count', String(dueSessionCount));
     } else {
       grid.removeAttribute('data-ready-count');
     }

--- a/public/js/board-grid.js
+++ b/public/js/board-grid.js
@@ -73,21 +73,25 @@ export function renderGrid({
       (isDue ? ' is-due' : '') +
       (isFilteredOut ? ' is-filtered-out' : ''));
 
-    tileEl.toggleAttribute('data-due', isDue);
+    if (isDue) tileEl.setAttribute('data-due', '');
+    else tileEl.removeAttribute('data-due');
     if (isFilteredOut) tileEl.setAttribute('data-ready-filtered', 'out');
     else tileEl.removeAttribute('data-ready-filtered');
 
     // Button semantics for keyboard + assistive-tech parity with the
     // SVG <g onclick> handler. tabindex is set here (not in the
     // floating-room-label experiment) so it survives every render.
+    // Filtered-out tiles stay in the DOM but leave the tab order.
     tileEl.setAttribute('role', 'button');
-    tileEl.setAttribute('tabindex', '0');
+    tileEl.setAttribute('tabindex', isFilteredOut ? '-1' : '0');
+    if (isFilteredOut) tileEl.setAttribute('aria-disabled', 'true');
+    else tileEl.removeAttribute('aria-disabled');
     tileEl.setAttribute(
       'aria-label',
       isEmpty
         ? 'Start learning'
         : isDue
-          ? `Resume ${concept.name}, ready after spacing`
+          ? `Resume ${concept.name}, due for spaced reconstruction`
           : `Resume ${concept.name}`
     );
 

--- a/public/js/board-grid.js
+++ b/public/js/board-grid.js
@@ -35,11 +35,15 @@ export const EMPTY_TILE = `
     <polygon class="tile-top-dash"  points="70,0 140,40 70,80 0,40"/>
     <polygon class="tile-hit"       points="70,0 140,40 70,80 0,40"/>`;
 
-export function conceptPinSVG(idx, state) {
+export function conceptPinSVG(idx, state, { isDue = false } = {}) {
+  const dueRing = isDue
+    ? `<ellipse class="concept-pin-due-ring" cx="70" cy="43" rx="22" ry="5.5" aria-hidden="true"/>`
+    : '';
   return `
     <g class="concept-marker-anim" id="concept-marker-anim-${idx}">
       <g class="concept-pin" id="concept-pin-${idx}" data-state="${state}" style="pointer-events:none;">
         <ellipse class="concept-pin-shadow" cx="70" cy="43" rx="17" ry="3.5"/>
+        ${dueRing}
         <line class="concept-pin-line" x1="70" y1="-15" x2="70" y2="38"/>
         <circle class="concept-pin-head" cx="70" cy="-15" r="8.5"/>
         <circle class="concept-pin-core" cx="70" cy="-15" r="3.1"/>
@@ -47,15 +51,31 @@ export function conceptPinSVG(idx, state) {
     </g>`;
 }
 
-export function renderGrid({ concepts, tileEls, activeId, bus }) {
+export function renderGrid({
+  concepts,
+  tileEls,
+  activeId,
+  bus,
+  dueConceptIds = null,
+  readyFilterActive = false,
+}) {
+  const dueIds = dueConceptIds instanceof Set ? dueConceptIds : new Set();
   tileEls.forEach((tileEl, idx) => {
     const concept = concepts[idx] || null;
     const isSelected = concept && concept.id === activeId;
     const isEmpty = !concept;
+    const isDue = Boolean(concept && dueIds.has(concept.id));
+    const isFilteredOut = readyFilterActive && (!concept || !isDue);
 
     tileEl.setAttribute('class', 'tile-group' +
       (isEmpty ? ' empty' : '') +
-      (isSelected ? ' selected' : ''));
+      (isSelected ? ' selected' : '') +
+      (isDue ? ' is-due' : '') +
+      (isFilteredOut ? ' is-filtered-out' : ''));
+
+    tileEl.toggleAttribute('data-due', isDue);
+    if (isFilteredOut) tileEl.setAttribute('data-ready-filtered', 'out');
+    else tileEl.removeAttribute('data-ready-filtered');
 
     // Button semantics for keyboard + assistive-tech parity with the
     // SVG <g onclick> handler. tabindex is set here (not in the
@@ -64,13 +84,17 @@ export function renderGrid({ concepts, tileEls, activeId, bus }) {
     tileEl.setAttribute('tabindex', '0');
     tileEl.setAttribute(
       'aria-label',
-      isEmpty ? 'Start learning' : `Resume ${concept.name}`
+      isEmpty
+        ? 'Start learning'
+        : isDue
+          ? `Resume ${concept.name}, ready after spacing`
+          : `Resume ${concept.name}`
     );
 
     if (isEmpty) {
       tileEl.innerHTML = EMPTY_TILE;
     } else {
-      tileEl.innerHTML = TILE_PLATFORM + conceptPinSVG(idx, concept.state);
+      tileEl.innerHTML = TILE_PLATFORM + conceptPinSVG(idx, concept.state, { isDue });
     }
   });
 

--- a/public/js/due-for-spaced.js
+++ b/public/js/due-for-spaced.js
@@ -1,0 +1,143 @@
+import { deriveNodeTraining } from './training-derive.js';
+
+function parseGraphData(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'object') return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function collectDrillableNodeIds(graphData) {
+  const ids = [];
+  if (!graphData || typeof graphData !== 'object') return ids;
+  if (graphData.metadata?.id) ids.push(graphData.metadata.id);
+  (graphData.backbone || []).forEach((item) => {
+    if (item?.id) ids.push(item.id);
+  });
+  (graphData.clusters || []).forEach((cluster) => {
+    (cluster?.subnodes || []).forEach((subnode) => {
+      if (subnode?.id) ids.push(subnode.id);
+    });
+  });
+  return ids;
+}
+
+function labelForNode(graphData, nodeId) {
+  if (graphData?.metadata?.id === nodeId) {
+    return graphData.metadata.label || graphData.metadata.name || 'Core thesis';
+  }
+  const backbone = (graphData?.backbone || []).find((item) => item?.id === nodeId);
+  if (backbone) return backbone.label || backbone.name || nodeId;
+  for (const cluster of graphData?.clusters || []) {
+    const sub = (cluster?.subnodes || []).find((item) => item?.id === nodeId);
+    if (sub) return sub.label || sub.name || nodeId;
+  }
+  return nodeId;
+}
+
+/**
+ * Due means deriveNodeTraining(...).next_action === 'spaced_attempt'.
+ * Oldest-due first.
+ */
+export function listDueForSpaced({
+  concepts = [],
+  trainingByConceptId = {},
+  now = new Date().toISOString(),
+} = {}) {
+  const due = [];
+  (Array.isArray(concepts) ? concepts : []).forEach((concept) => {
+    if (!concept?.id) return;
+    const graphData = parseGraphData(concept.graphData);
+    const training = trainingByConceptId[concept.id] || null;
+    const nodeRecords = training?.node_records && typeof training.node_records === 'object'
+      ? training.node_records
+      : {};
+    collectDrillableNodeIds(graphData).forEach((nodeId) => {
+      const derived = deriveNodeTraining(nodeRecords[nodeId] || null, { now });
+      if (derived.next_action !== 'spaced_attempt') return;
+      due.push({
+        concept_id: concept.id,
+        concept_name: concept.name || concept.title || 'Untitled concept',
+        node_id: nodeId,
+        node_label: labelForNode(graphData, nodeId),
+        last_attempt_at: derived.last_attempt_at,
+      });
+    });
+  });
+  return due.sort((a, b) => (Date.parse(a.last_attempt_at || '') || 0) - (Date.parse(b.last_attempt_at || '') || 0));
+}
+
+export function dueConceptIdSet(dueItems = []) {
+  return new Set(
+    (Array.isArray(dueItems) ? dueItems : [])
+      .map((item) => item?.concept_id)
+      .filter(Boolean),
+  );
+}
+
+export function dueItemsForConcept(dueItems = [], conceptId) {
+  if (!conceptId) return [];
+  return (Array.isArray(dueItems) ? dueItems : []).filter((item) => item.concept_id === conceptId);
+}
+
+/** Linear-style filter chip. Hidden when count is 0. */
+export function renderReadyFilterHtml({ count = 0, active = false } = {}) {
+  if (!count) return '';
+  return `
+    <button
+      type="button"
+      class="desk-ready-filter${active ? ' is-active' : ''}"
+      id="desk-ready-filter"
+      aria-pressed="${active ? 'true' : 'false'}"
+      data-ready-count="${count}"
+    >
+      <span class="desk-ready-filter__label">Ready</span>
+      <span class="desk-ready-filter__count">${count}</span>
+    </button>
+  `;
+}
+
+/**
+ * Selection strip under the board — one next reconstruction for the
+ * selected concept. Empty when the selection has nothing due.
+ */
+export function renderDueSelectionHtml(dueItems = []) {
+  if (!Array.isArray(dueItems) || dueItems.length === 0) return '';
+  const next = dueItems[0];
+  const meta = dueItems.length > 1
+    ? `${dueItems.length} nodes ready · oldest first`
+    : 'Spacing window open · reconstruct before study';
+
+  return `
+    <div class="desk-due-selection" data-concept-id="${escapeAttr(next.concept_id)}">
+      <div class="desk-due-selection__copy">
+        <p class="desk-due-selection__kicker">Up next from memory</p>
+        <p class="desk-due-selection__node">${escapeHtml(next.node_label)}</p>
+        <span class="desk-due-selection__meta">${meta}</span>
+      </div>
+      <button
+        type="button"
+        class="desk-due-selection__action"
+        data-concept-id="${escapeAttr(next.concept_id)}"
+        data-node-id="${escapeAttr(next.node_id)}"
+      >
+        Reconstruct
+      </button>
+    </div>
+  `;
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replaceAll("'", '&#39;');
+}

--- a/public/js/due-for-spaced.js
+++ b/public/js/due-for-spaced.js
@@ -1,4 +1,8 @@
 import { deriveNodeTraining } from './training-derive.js';
+import {
+  deriveConceptEntries,
+  getConceptEntryId,
+} from './concept-page-view.js';
 
 function parseGraphData(raw) {
   if (!raw) return null;
@@ -11,38 +15,27 @@ function parseGraphData(raw) {
 }
 
 /**
- * Drillable IDs must match concept-page route entries
- * (`deriveConceptEntries`): backbone/subnodes when present, else the
- * core-thesis fallback. Do not emit raw metadata.id — that is not an
- * activeEntryId the map view can focus.
+ * Drillable IDs must match concept-page route entries exactly
+ * (`deriveConceptEntries`). Never invent IDs the map cannot focus.
  */
 export function collectDrillableNodeIds(graphData) {
-  const ids = [];
-  if (!graphData || typeof graphData !== 'object') return ids;
-  (graphData.backbone || []).forEach((item) => {
-    if (item?.id) ids.push(item.id);
-  });
-  (graphData.clusters || []).forEach((cluster) => {
-    (cluster?.subnodes || []).forEach((subnode) => {
-      if (subnode?.id) ids.push(subnode.id);
-    });
-  });
-  if (!ids.length) ids.push('core-thesis');
-  return ids;
+  if (!graphData || typeof graphData !== 'object') return [];
+  const entries = deriveConceptEntries(graphData);
+  if (!entries.length) return ['core-thesis'];
+  return entries.map((entry, index) => getConceptEntryId(entry, index));
 }
 
 function labelForNode(graphData, nodeId) {
+  const entries = deriveConceptEntries(graphData || {});
+  const match = entries.find((entry, index) => getConceptEntryId(entry, index) === nodeId);
+  if (match) {
+    return match.label || match.name || nodeId;
+  }
   if (nodeId === 'core-thesis') {
     return graphData?.metadata?.label
       || graphData?.metadata?.name
       || graphData?.metadata?.source_title
       || 'Core thesis';
-  }
-  const backbone = (graphData?.backbone || []).find((item) => item?.id === nodeId);
-  if (backbone) return backbone.label || backbone.name || nodeId;
-  for (const cluster of graphData?.clusters || []) {
-    const sub = (cluster?.subnodes || []).find((item) => item?.id === nodeId);
-    if (sub) return sub.label || sub.name || nodeId;
   }
   return nodeId;
 }

--- a/public/js/due-for-spaced.js
+++ b/public/js/due-for-spaced.js
@@ -25,7 +25,7 @@ export function collectDrillableNodeIds(graphData) {
   return entries.map((entry, index) => getConceptEntryId(entry, index));
 }
 
-function labelForNode(graphData, nodeId) {
+export function labelForNode(graphData, nodeId) {
   const entries = deriveConceptEntries(graphData || {});
   const match = entries.find((entry, index) => getConceptEntryId(entry, index) === nodeId);
   if (match) {

--- a/public/js/due-for-spaced.js
+++ b/public/js/due-for-spaced.js
@@ -10,10 +10,15 @@ function parseGraphData(raw) {
   }
 }
 
+/**
+ * Drillable IDs must match concept-page route entries
+ * (`deriveConceptEntries`): backbone/subnodes when present, else the
+ * core-thesis fallback. Do not emit raw metadata.id — that is not an
+ * activeEntryId the map view can focus.
+ */
 export function collectDrillableNodeIds(graphData) {
   const ids = [];
   if (!graphData || typeof graphData !== 'object') return ids;
-  if (graphData.metadata?.id) ids.push(graphData.metadata.id);
   (graphData.backbone || []).forEach((item) => {
     if (item?.id) ids.push(item.id);
   });
@@ -22,12 +27,16 @@ export function collectDrillableNodeIds(graphData) {
       if (subnode?.id) ids.push(subnode.id);
     });
   });
+  if (!ids.length) ids.push('core-thesis');
   return ids;
 }
 
 function labelForNode(graphData, nodeId) {
-  if (graphData?.metadata?.id === nodeId) {
-    return graphData.metadata.label || graphData.metadata.name || 'Core thesis';
+  if (nodeId === 'core-thesis') {
+    return graphData?.metadata?.label
+      || graphData?.metadata?.name
+      || graphData?.metadata?.source_title
+      || 'Core thesis';
   }
   const backbone = (graphData?.backbone || []).find((item) => item?.id === nodeId);
   if (backbone) return backbone.label || backbone.name || nodeId;
@@ -83,18 +92,26 @@ export function dueItemsForConcept(dueItems = [], conceptId) {
   return (Array.isArray(dueItems) ? dueItems : []).filter((item) => item.concept_id === conceptId);
 }
 
-/** Linear-style filter chip. Hidden when count is 0. */
+/**
+ * Linear-style filter chip. Count is due *sessions* (concepts), matching
+ * board marks. Hidden when count is 0.
+ */
 export function renderReadyFilterHtml({ count = 0, active = false } = {}) {
   if (!count) return '';
+  const label = 'Due';
+  const ariaLabel = active
+    ? `Showing ${count} session${count === 1 ? '' : 's'} due for spaced reconstruction. Clear filter.`
+    : `Show only ${count} session${count === 1 ? '' : 's'} due for spaced reconstruction.`;
   return `
     <button
       type="button"
       class="desk-ready-filter${active ? ' is-active' : ''}"
       id="desk-ready-filter"
       aria-pressed="${active ? 'true' : 'false'}"
+      aria-label="${ariaLabel}"
       data-ready-count="${count}"
     >
-      <span class="desk-ready-filter__label">Ready</span>
+      <span class="desk-ready-filter__label">${label}</span>
       <span class="desk-ready-filter__count">${count}</span>
     </button>
   `;
@@ -108,8 +125,9 @@ export function renderDueSelectionHtml(dueItems = []) {
   if (!Array.isArray(dueItems) || dueItems.length === 0) return '';
   const next = dueItems[0];
   const meta = dueItems.length > 1
-    ? `${dueItems.length} nodes ready · oldest first`
+    ? `${dueItems.length} nodes due · oldest first`
     : 'Spacing window open · reconstruct before study';
+  const actionLabel = `Reconstruct ${next.node_label} from memory`;
 
   return `
     <div class="desk-due-selection" data-concept-id="${escapeAttr(next.concept_id)}">
@@ -123,6 +141,7 @@ export function renderDueSelectionHtml(dueItems = []) {
         class="desk-due-selection__action"
         data-concept-id="${escapeAttr(next.concept_id)}"
         data-node-id="${escapeAttr(next.node_id)}"
+        aria-label="${escapeAttr(actionLabel)}"
       >
         Reconstruct
       </button>

--- a/public/js/iso-board-state-surface.js
+++ b/public/js/iso-board-state-surface.js
@@ -118,8 +118,9 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
       if (pin) {
         pin.removeAttribute('data-source-state');
         pin.removeAttribute('data-state');
-        pin.querySelectorAll('.concept-pin-head, .concept-pin-core, .concept-pin-crystal')
-           .forEach((el) => el.remove());
+        pin.querySelectorAll(
+          '.concept-pin-head, .concept-pin-core, .concept-pin-crystal, .concept-pin-due-ring',
+        ).forEach((el) => el.remove());
         const line = pin.querySelector('.concept-pin-line');
         if (line) line.remove();
       }

--- a/public/js/learner-state-sync.js
+++ b/public/js/learner-state-sync.js
@@ -5,11 +5,10 @@ export const CONCEPTS_STORE_KEY = 'learnops_concepts';
 
 function defaultStorage() {
   try {
-    if (typeof localStorage !== 'undefined') return localStorage;
+    return localStorage;
   } catch {
     return null;
   }
-  return null;
 }
 
 function parseJson(raw, fallback) {

--- a/public/js/learner-state-sync.js
+++ b/public/js/learner-state-sync.js
@@ -1,0 +1,257 @@
+import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
+
+export const LEARNER_STATE_SCHEMA_VERSION = 1;
+export const CONCEPTS_STORE_KEY = 'learnops_concepts';
+
+function defaultStorage() {
+  try {
+    if (typeof localStorage !== 'undefined') return localStorage;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function parseJson(raw, fallback) {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+export function collectLocalTrainingMap(storage = defaultStorage(), keyPrefix = TRAINING_STORE_KEY_PREFIX) {
+  const out = {};
+  if (!storage || typeof storage.length !== 'number') {
+    // Memory-style Map/object storage used in tests may only implement getItem/setItem.
+    if (!storage?.getItem) return out;
+  }
+  if (typeof storage.length === 'number' && typeof storage.key === 'function') {
+    for (let i = 0; i < storage.length; i += 1) {
+      const key = storage.key(i);
+      if (!key || !key.startsWith(keyPrefix)) continue;
+      const conceptId = key.slice(keyPrefix.length);
+      const parsed = parseJson(storage.getItem(key), null);
+      if (parsed && typeof parsed === 'object') out[conceptId] = parsed;
+    }
+    return out;
+  }
+  return out;
+}
+
+export function writeLocalTrainingMap(trainingMap, storage = defaultStorage(), keyPrefix = TRAINING_STORE_KEY_PREFIX) {
+  if (!storage?.setItem || !trainingMap || typeof trainingMap !== 'object') return;
+  Object.entries(trainingMap).forEach(([conceptId, training]) => {
+    if (!conceptId || !training || typeof training !== 'object') return;
+    storage.setItem(`${keyPrefix}${conceptId}`, JSON.stringify(training));
+  });
+}
+
+function conceptRecency(concept) {
+  const candidates = [
+    concept?.updated_at,
+    concept?.updatedAt,
+    concept?.created_at,
+    concept?.createdAt,
+  ];
+  for (const value of candidates) {
+    const ms = Date.parse(value || '');
+    if (Number.isFinite(ms)) return ms;
+  }
+  return 0;
+}
+
+function mergeAttemptLists(localAttempts, remoteAttempts) {
+  const byId = new Map();
+  [...(Array.isArray(remoteAttempts) ? remoteAttempts : []), ...(Array.isArray(localAttempts) ? localAttempts : [])]
+    .forEach((attempt) => {
+      if (!attempt || typeof attempt !== 'object' || !attempt.id) return;
+      const existing = byId.get(attempt.id);
+      if (!existing) {
+        byId.set(attempt.id, attempt);
+        return;
+      }
+      const existingAt = Date.parse(existing.at || '') || 0;
+      const nextAt = Date.parse(attempt.at || '') || 0;
+      if (nextAt >= existingAt) byId.set(attempt.id, attempt);
+    });
+  return [...byId.values()].sort((a, b) => (Date.parse(a.at || '') || 0) - (Date.parse(b.at || '') || 0));
+}
+
+function mergeRepairLists(localRepairs, remoteRepairs) {
+  const byId = new Map();
+  [...(Array.isArray(remoteRepairs) ? remoteRepairs : []), ...(Array.isArray(localRepairs) ? localRepairs : [])]
+    .forEach((repair) => {
+      if (!repair || typeof repair !== 'object' || !repair.id) return;
+      byId.set(repair.id, repair);
+    });
+  return [...byId.values()].sort((a, b) => (Date.parse(a.at || '') || 0) - (Date.parse(b.at || '') || 0));
+}
+
+function earliestIso(a, b) {
+  const aMs = Date.parse(a || '');
+  const bMs = Date.parse(b || '');
+  if (!Number.isFinite(aMs)) return b || null;
+  if (!Number.isFinite(bMs)) return a || null;
+  return aMs <= bMs ? a : b;
+}
+
+export function mergeTrainingRecords(localTraining, remoteTraining) {
+  if (!localTraining) return remoteTraining || null;
+  if (!remoteTraining) return localTraining;
+
+  const localNodes = localTraining.node_records && typeof localTraining.node_records === 'object'
+    ? localTraining.node_records
+    : {};
+  const remoteNodes = remoteTraining.node_records && typeof remoteTraining.node_records === 'object'
+    ? remoteTraining.node_records
+    : {};
+  const nodeIds = new Set([...Object.keys(localNodes), ...Object.keys(remoteNodes)]);
+  const node_records = {};
+
+  nodeIds.forEach((nodeId) => {
+    const localNode = localNodes[nodeId] || {};
+    const remoteNode = remoteNodes[nodeId] || {};
+    node_records[nodeId] = {
+      attempts: mergeAttemptLists(localNode.attempts, remoteNode.attempts),
+      repairs: mergeRepairLists(localNode.repairs, remoteNode.repairs),
+      study_revealed_at: earliestIso(localNode.study_revealed_at, remoteNode.study_revealed_at),
+    };
+  });
+
+  return {
+    concept_id: localTraining.concept_id || remoteTraining.concept_id,
+    schema_version: localTraining.schema_version || remoteTraining.schema_version || LEARNER_STATE_SCHEMA_VERSION,
+    source_mode: localTraining.source_mode ?? remoteTraining.source_mode ?? null,
+    grounding: localTraining.grounding || remoteTraining.grounding || 'ungrounded',
+    source_ref: localTraining.source_ref ?? remoteTraining.source_ref ?? null,
+    sketch: localTraining.sketch || remoteTraining.sketch || null,
+    node_records,
+  };
+}
+
+export function mergeLearnerState(localState, remoteState) {
+  const localConcepts = Array.isArray(localState?.concepts) ? localState.concepts : [];
+  const remoteConcepts = Array.isArray(remoteState?.concepts) ? remoteState.concepts : [];
+  const byId = new Map();
+
+  remoteConcepts.forEach((concept) => {
+    if (concept?.id) byId.set(concept.id, concept);
+  });
+  localConcepts.forEach((concept) => {
+    if (!concept?.id) return;
+    const existing = byId.get(concept.id);
+    if (!existing) {
+      byId.set(concept.id, concept);
+      return;
+    }
+    byId.set(
+      concept.id,
+      conceptRecency(concept) >= conceptRecency(existing) ? concept : existing,
+    );
+  });
+
+  const localTraining = localState?.training && typeof localState.training === 'object'
+    ? localState.training
+    : {};
+  const remoteTraining = remoteState?.training && typeof remoteState.training === 'object'
+    ? remoteState.training
+    : {};
+  const trainingIds = new Set([...Object.keys(localTraining), ...Object.keys(remoteTraining)]);
+  const training = {};
+  trainingIds.forEach((conceptId) => {
+    const merged = mergeTrainingRecords(localTraining[conceptId], remoteTraining[conceptId]);
+    if (merged) training[conceptId] = merged;
+  });
+
+  return {
+    schema_version: LEARNER_STATE_SCHEMA_VERSION,
+    concepts: [...byId.values()],
+    training,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+export function readLocalLearnerState(storage = defaultStorage()) {
+  const concepts = parseJson(storage?.getItem?.(CONCEPTS_STORE_KEY), []);
+  return {
+    schema_version: LEARNER_STATE_SCHEMA_VERSION,
+    concepts: Array.isArray(concepts) ? concepts : [],
+    training: collectLocalTrainingMap(storage),
+    updated_at: null,
+  };
+}
+
+export function writeLocalLearnerState(state, storage = defaultStorage()) {
+  if (!storage?.setItem || !state) return;
+  storage.setItem(CONCEPTS_STORE_KEY, JSON.stringify(Array.isArray(state.concepts) ? state.concepts : []));
+  writeLocalTrainingMap(state.training || {}, storage);
+}
+
+export async function fetchRemoteLearnerState({
+  fetchImpl = fetch,
+} = {}) {
+  const response = await fetchImpl('/api/learner-state', {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`learner-state-get-failed:${response.status}`);
+  }
+  return response.json();
+}
+
+export async function putRemoteLearnerState(state, {
+  fetchImpl = fetch,
+} = {}) {
+  const response = await fetchImpl('/api/learner-state', {
+    method: 'PUT',
+    credentials: 'same-origin',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      schema_version: LEARNER_STATE_SCHEMA_VERSION,
+      concepts: Array.isArray(state?.concepts) ? state.concepts : [],
+      training: state?.training && typeof state.training === 'object' ? state.training : {},
+      updated_at: state?.updated_at || new Date().toISOString(),
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`learner-state-put-failed:${response.status}`);
+  }
+  return response.json();
+}
+
+export async function hydrateAndSyncLearnerState({
+  storage = defaultStorage(),
+  fetchImpl = fetch,
+  isIdentified = false,
+} = {}) {
+  if (!isIdentified) return { synced: false, reason: 'guest-or-anonymous' };
+
+  const local = readLocalLearnerState(storage);
+  const remote = await fetchRemoteLearnerState({ fetchImpl });
+  const merged = mergeLearnerState(local, remote || { concepts: [], training: {} });
+  writeLocalLearnerState(merged, storage);
+  await putRemoteLearnerState(merged, { fetchImpl });
+  return { synced: true, state: merged };
+}
+
+export async function pushLocalLearnerState({
+  storage = defaultStorage(),
+  fetchImpl = fetch,
+  isIdentified = false,
+} = {}) {
+  if (!isIdentified) return { pushed: false, reason: 'guest-or-anonymous' };
+  const local = readLocalLearnerState(storage);
+  local.updated_at = new Date().toISOString();
+  await putRemoteLearnerState(local, { fetchImpl });
+  return { pushed: true, state: local };
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,7 +3,7 @@
 @import './css/crystal.css?v=71';
 @import './css/components.css?v=102';
 @import './css/layout.css?v=110';
-@import './css/board-first.css?v=4';
+@import './css/board-first.css?v=6';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';
 @import './css/concept-page.css?v=45';

--- a/public/styles.css
+++ b/public/styles.css
@@ -2,7 +2,7 @@
 @import './css/base.css?v=73';
 @import './css/crystal.css?v=71';
 @import './css/components.css?v=102';
-@import './css/layout.css?v=110';
+@import './css/layout.css?v=111';
 @import './css/board-first.css?v=6';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -81,6 +81,8 @@ EXPECTED_ABORTED_BOOTSTRAP_PATHS: tuple[str, ...] = (
     "/login",
     "/fonts/Geom-VariableFont_wght.ttf",
     "/fonts/Inter-VariableFont_opsz,wght.ttf",
+    "/vendor/core-1.6.0.esm.js",
+    "/vendor/floating-ui-dom-1.6.3.esm.js",
     "/vendor/utils-0.2.1-dom.esm.js",
     "/vendor/utils-0.2.1.esm.js",
 )

--- a/tests/e2e/test_learner_state_due_desk.py
+++ b/tests/e2e/test_learner_state_due_desk.py
@@ -29,10 +29,24 @@ def test_learner_state_and_due_desk_browser_contracts(
     result = clean_page.evaluate(
         """async () => {
           const assert = (cond, msg) => { if (!cond) throw new Error(msg); };
-          const sync = await import('/js/learner-state-sync.js?v=2');
-          const due = await import('/js/due-for-spaced.js?v=6');
+          const sync = await import('/js/learner-state-sync.js?v=3');
+          const due = await import('/js/due-for-spaced.js?v=7');
+          const auth = await import('/js/auth.js?v=5');
 
-          // Storage helpers
+          // defaultStorage catch when localStorage access throws
+          const lsDesc = Object.getOwnPropertyDescriptor(window, 'localStorage');
+          Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            get() { throw new Error('storage-denied'); },
+          });
+          try {
+            const denied = sync.readLocalLearnerState();
+            assert(Array.isArray(denied.concepts) && denied.concepts.length === 0, 'denied storage');
+          } finally {
+            Object.defineProperty(window, 'localStorage', lsDesc);
+          }
+
+          // Storage helpers + parseJson catch + conceptRecency zero + collectLocalTrainingMap branches
           const mem = new Map();
           const storage = {
             getItem(key) { return mem.has(key) ? mem.get(key) : null; },
@@ -41,18 +55,12 @@ def test_learner_state_and_due_desk_browser_contracts(
             key(i) { return [...mem.keys()][i] || null; },
             get length() { return mem.size; },
           };
+          storage.setItem('learnops_concepts', '{not-json');
+          assert(sync.readLocalLearnerState(storage).concepts.length === 0, 'bad json concepts');
           storage.setItem('learnops_concepts', JSON.stringify([{
             id: 'c1',
             name: 'Thermostat',
-            updated_at: '2026-07-08T12:00:00.000Z',
-            graphData: JSON.stringify({
-              metadata: { id: 'core', label: 'Feedback loop' },
-              backbone: [
-                { id: 'sensor', label: 'Sensor reading' },
-                { id: 'actuator', label: 'Actuator' },
-              ],
-              clusters: [],
-            }),
+            // no date fields → conceptRecency returns 0
           }]));
           storage.setItem('socratink:training:v1:c1', JSON.stringify({
             concept_id: 'c1',
@@ -73,6 +81,13 @@ def test_learner_state_and_due_desk_browser_contracts(
               },
             },
           }));
+
+          assert(Object.keys(sync.collectLocalTrainingMap(null)).length === 0, 'null storage map');
+          assert(Object.keys(sync.collectLocalTrainingMap({})).length === 0, 'empty object map');
+          assert(
+            Object.keys(sync.collectLocalTrainingMap({ getItem() { return null; } })).length === 0,
+            'getItem-only storage falls through',
+          );
 
           const local = sync.readLocalLearnerState(storage);
           assert(local.concepts.length === 1, 'read local concepts');
@@ -106,6 +121,7 @@ def test_learner_state_and_due_desk_browser_contracts(
               },
             },
           };
+          // Local has no dates; remote has updated_at → remote wins on recency 0 vs finite
           const merged = sync.mergeLearnerState(local, remote);
           assert(merged.concepts.length === 2, 'merge concepts');
           assert(merged.training.c1.node_records.sensor.attempts.length === 2, 'union attempts');
@@ -136,6 +152,35 @@ def test_learner_state_and_due_desk_browser_contracts(
           });
           assert(hydrated.synced === true, 'identified hydrate');
           assert(putCount === 1, 'hydrate put once');
+
+          // GET 200 path + PUT/GET failure throws
+          const remoteOk = await sync.fetchRemoteLearnerState({
+            fetchImpl: async () => ({
+              status: 200,
+              ok: true,
+              async json() { return remote; },
+            }),
+          });
+          assert(remoteOk.concepts.length === 2, 'get 200 body');
+          let getFailed = false;
+          try {
+            await sync.fetchRemoteLearnerState({
+              fetchImpl: async () => ({ status: 500, ok: false, async json() { return {}; } }),
+            });
+          } catch (err) {
+            getFailed = String(err.message).includes('learner-state-get-failed:500');
+          }
+          assert(getFailed, 'get non-ok throws');
+          let putFailed = false;
+          try {
+            await sync.putRemoteLearnerState(merged, {
+              fetchImpl: async () => ({ status: 503, ok: false, async json() { return {}; } }),
+            });
+          } catch (err) {
+            putFailed = String(err.message).includes('learner-state-put-failed:503');
+          }
+          assert(putFailed, 'put non-ok throws');
+
           const pushed = await sync.pushLocalLearnerState({
             storage,
             fetchImpl,
@@ -149,7 +194,7 @@ def test_learner_state_and_due_desk_browser_contracts(
           });
           assert(skippedPush.pushed === false, 'guest push skipped');
 
-          // Due surfaces: route IDs only
+          // Due surfaces: route IDs + labelForNode fallbacks
           assert(
             JSON.stringify(due.collectDrillableNodeIds({
               metadata: { id: 'core' },
@@ -158,10 +203,7 @@ def test_learner_state_and_due_desk_browser_contracts(
             })) === JSON.stringify(['sn1']),
             'cluster scaffold wins',
           );
-          assert(
-            due.renderReadyFilterHtml({ count: 0 }) === '',
-            'filter hidden at zero',
-          );
+          assert(due.renderReadyFilterHtml({ count: 0 }) === '', 'filter hidden at zero');
           const filterHtml = due.renderReadyFilterHtml({ count: 1, active: true });
           assert(filterHtml.includes('Due'), 'Due label');
           assert(filterHtml.includes('is-active'), 'active filter');
@@ -169,6 +211,28 @@ def test_learner_state_and_due_desk_browser_contracts(
             due.collectDrillableNodeIds({ metadata: { label: 'Only core' }, backbone: [], clusters: [] })
               .join(',') === 'core-thesis',
             'empty graph falls back to core-thesis',
+          );
+          assert(
+            due.labelForNode({ metadata: { label: 'Thesis label' }, backbone: [], clusters: [] }, 'core-thesis')
+              === 'Thesis label',
+            'core-thesis label from metadata.label',
+          );
+          assert(
+            due.labelForNode({ metadata: { name: 'Thesis name' }, backbone: [], clusters: [] }, 'core-thesis')
+              === 'Thesis name',
+            'core-thesis label from metadata.name',
+          );
+          assert(
+            due.labelForNode({ metadata: {}, backbone: [], clusters: [] }, 'core-thesis') === 'Core thesis',
+            'core-thesis default label',
+          );
+          assert(due.labelForNode({ backbone: [], clusters: [] }, 'unknown-node') === 'unknown-node', 'unknown id');
+          assert(
+            due.listDueForSpaced({
+              concepts: [{ id: 'bad', graphData: '{not-json' }],
+              trainingByConceptId: {},
+            }).length === 0,
+            'parseGraphData catch',
           );
           const selection = due.renderDueSelectionHtml([{
             concept_id: 'c1',
@@ -218,12 +282,13 @@ def test_learner_state_and_due_desk_browser_contracts(
             },
           }));
           window.App.showDashboard();
-          return { ok: true };
+          return { ok: true, authReady: typeof auth.invalidateAuthSession === 'function' };
         }"""
     )
     assert result["ok"] is True
 
     expect(clean_page.locator("#desk-ready-filter")).to_be_visible()
+    expect(clean_page.locator("#grid-container .tile-group.is-due .concept-pin-due-ring")).to_be_attached()
     clean_page.locator("#desk-ready-filter").click()
     expect(clean_page.locator("#desk-ready-filter")).to_have_attribute("aria-pressed", "true")
     expect(clean_page.locator("#grid-container")).to_have_class(re.compile(r"is-ready-filtered"))
@@ -235,12 +300,111 @@ def test_learner_state_and_due_desk_browser_contracts(
     expect(clean_page.locator("#map-view")).to_be_visible()
     expect(clean_page.locator("#map-content h2").first).to_contain_text("Sensor reading")
 
-    # App sync wrappers (guest path + error path) for diff coverage.
+    # Return to desk, then clear concepts without renderGrid so iso syncTile
+    # removes the due-ring from a still-populated pin.
+    clean_page.evaluate(
+        """() => {
+          window.App.showDashboard();
+        }"""
+    )
+    expect(clean_page.locator("#desk-ready-filter")).to_be_visible()
+    clean_page.evaluate(
+        """() => {
+          localStorage.setItem('learnops_concepts', JSON.stringify([]));
+          localStorage.removeItem('learnops_active');
+          // Same-tab storage events do not fire; focus triggers iso refresh.
+          window.dispatchEvent(new Event('focus'));
+        }"""
+    )
+    expect(clean_page.locator("#grid-container .concept-pin-due-ring")).to_have_count(0)
+
+    # App sync wrappers: guest, identified success, identified error.
+    # Also hit saveConcepts / trainingStore hooks / deleteConcept due-refresh paths.
     clean_page.evaluate(
         """async () => {
+          const auth = await import('/js/auth.js?v=5');
           await window.App.syncLearnerStateIfIdentified();
           await window.App.pushLearnerStateIfIdentified();
+
           const originalFetch = window.fetch;
+          auth.invalidateAuthSession();
+          window.fetch = async (url, opts = {}) => {
+            const href = String(url);
+            if (href.includes('/api/me')) {
+              return {
+                ok: true,
+                status: 200,
+                async json() {
+                  return {
+                    auth_enabled: true,
+                    authenticated: true,
+                    guest_mode: false,
+                    user: { id: 'user-1', email: 'a@b.c' },
+                  };
+                },
+              };
+            }
+            if (href.includes('/api/learner-state')) {
+              if ((opts.method || 'GET') === 'PUT') {
+                return { ok: true, status: 200, async json() { return { status: 'ok' }; } };
+              }
+              return {
+                ok: true,
+                status: 200,
+                async json() {
+                  return { schema_version: 1, concepts: [], training: {}, updated_at: new Date().toISOString() };
+                },
+              };
+            }
+            return originalFetch(url, opts);
+          };
+          try {
+            const synced = await window.App.syncLearnerStateIfIdentified();
+            if (!synced) throw new Error('expected identified sync');
+            await window.App.pushLearnerStateIfIdentified();
+
+            // Keep the identified fetch mock while exercising saveConcepts /
+            // scheduleLearnerStatePush so the debounced PUT does not 401.
+            const conceptId = 'hook-c1';
+            localStorage.setItem('learnops_concepts', JSON.stringify([{
+              id: conceptId,
+              name: 'Hook Session',
+              state: 'solidified',
+              createdAt: Date.now(),
+              graphData: JSON.stringify({
+                metadata: { id: 'core', label: 'Core' },
+                backbone: [{ id: 'sensor', label: 'Sensor' }],
+                clusters: [],
+              }),
+            }]));
+            localStorage.setItem('learnops_active', conceptId);
+            window.App.showDashboard();
+            await window.App.seedLocalQaConcept();
+
+            const originalConfirm = window.confirm;
+            window.confirm = () => true;
+            try {
+              window.App.deleteConcept(conceptId);
+              localStorage.setItem('learnops_concepts', JSON.stringify([{
+                id: 'hook-c2',
+                name: 'Second',
+                state: 'primed',
+                createdAt: Date.now(),
+                graphData: JSON.stringify({ metadata: { label: 'X' }, backbone: [], clusters: [] }),
+              }]));
+              localStorage.setItem('learnops_active', 'hook-c2');
+              window.App.showDashboard();
+              window.App.deleteConcept('hook-c2');
+            } finally {
+              window.confirm = originalConfirm;
+            }
+            await new Promise((r) => setTimeout(r, 900));
+          } finally {
+            window.fetch = originalFetch;
+            auth.invalidateAuthSession();
+          }
+
+          auth.invalidateAuthSession();
           window.fetch = async (url) => {
             if (String(url).includes('/api/me')) {
               return {
@@ -263,11 +427,11 @@ def test_learner_state_and_due_desk_browser_contracts(
             await window.App.pushLearnerStateIfIdentified();
           } finally {
             window.fetch = originalFetch;
+            auth.invalidateAuthSession();
           }
         }"""
     )
 
-    # Empty-tile due-ring cleanup path in iso-board-state-surface.
     clean_page.evaluate(
         """() => {
           localStorage.setItem('learnops_concepts', JSON.stringify([]));

--- a/tests/e2e/test_learner_state_due_desk.py
+++ b/tests/e2e/test_learner_state_due_desk.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urljoin
+
+from playwright.sync_api import Page, expect
+
+
+def _enter_app_shell_as_guest(page: Page, base_url: str) -> None:
+    if os.getenv("SOCRATINK_E2E_LOCAL_GUEST"):
+        page.goto(urljoin(base_url + "/", "auth/e2e/guest?return_to=%2F"))
+    else:
+        page.goto(base_url)
+        if "/login" in page.url:
+            target_pattern = re.compile(r"^" + re.escape(base_url.rstrip("/")) + r"/?$")
+            with page.expect_navigation(url=target_pattern, timeout=15_000):
+                page.locator("#guest-continue-link").click()
+    page.wait_for_load_state("load")
+    expect(page.locator("#concept-list")).to_be_attached()
+
+
+def test_learner_state_and_due_desk_browser_contracts(
+    clean_page: Page, base_url: str, captured: dict
+) -> None:
+    """Exercise Linear Desk due surfaces + learner-state sync under V8 coverage."""
+    _enter_app_shell_as_guest(clean_page, base_url)
+
+    result = clean_page.evaluate(
+        """async () => {
+          const assert = (cond, msg) => { if (!cond) throw new Error(msg); };
+          const sync = await import('/js/learner-state-sync.js?v=2');
+          const due = await import('/js/due-for-spaced.js?v=6');
+
+          // Storage helpers
+          const mem = new Map();
+          const storage = {
+            getItem(key) { return mem.has(key) ? mem.get(key) : null; },
+            setItem(key, value) { mem.set(key, String(value)); },
+            removeItem(key) { mem.delete(key); },
+            key(i) { return [...mem.keys()][i] || null; },
+            get length() { return mem.size; },
+          };
+          storage.setItem('learnops_concepts', JSON.stringify([{
+            id: 'c1',
+            name: 'Thermostat',
+            updated_at: '2026-07-08T12:00:00.000Z',
+            graphData: JSON.stringify({
+              metadata: { id: 'core', label: 'Feedback loop' },
+              backbone: [
+                { id: 'sensor', label: 'Sensor reading' },
+                { id: 'actuator', label: 'Actuator' },
+              ],
+              clusters: [],
+            }),
+          }]));
+          storage.setItem('socratink:training:v1:c1', JSON.stringify({
+            concept_id: 'c1',
+            schema_version: 1,
+            grounding: 'ungrounded',
+            node_records: {
+              sensor: {
+                attempts: [{
+                  id: 'a1',
+                  at: '2026-07-07T00:00:00.000Z',
+                  user_text: 'strong',
+                  classification: 'strong',
+                  gaps: [],
+                  grader_version: 'test',
+                }],
+                repairs: [{ id: 'r1', at: '2026-07-07T00:05:00.000Z' }],
+                study_revealed_at: '2026-07-07T00:10:00.000Z',
+              },
+            },
+          }));
+
+          const local = sync.readLocalLearnerState(storage);
+          assert(local.concepts.length === 1, 'read local concepts');
+          assert(local.training.c1, 'read local training');
+
+          const remote = {
+            concepts: [{
+              id: 'c1',
+              name: 'Remote',
+              updated_at: '2026-07-07T12:00:00.000Z',
+            }, { id: 'c2', name: 'Only remote' }],
+            training: {
+              c1: {
+                concept_id: 'c1',
+                schema_version: 1,
+                grounding: 'ungrounded',
+                node_records: {
+                  sensor: {
+                    attempts: [{
+                      id: 'a-remote',
+                      at: '2026-07-06T00:00:00.000Z',
+                      user_text: 'remote',
+                      classification: 'partial',
+                      gaps: [],
+                      grader_version: 'test',
+                    }],
+                    repairs: [],
+                    study_revealed_at: '2026-07-06T00:10:00.000Z',
+                  },
+                },
+              },
+            },
+          };
+          const merged = sync.mergeLearnerState(local, remote);
+          assert(merged.concepts.length === 2, 'merge concepts');
+          assert(merged.training.c1.node_records.sensor.attempts.length === 2, 'union attempts');
+          sync.writeLocalLearnerState(merged, storage);
+
+          let putCount = 0;
+          const fetchImpl = async (url, opts = {}) => {
+            if (opts.method === 'GET' || !opts.method) {
+              return {
+                status: 404,
+                ok: false,
+                async json() { return {}; },
+              };
+            }
+            putCount += 1;
+            return { status: 200, ok: true, async json() { return { status: 'ok' }; } };
+          };
+          const guest = await sync.hydrateAndSyncLearnerState({
+            storage,
+            fetchImpl,
+            isIdentified: false,
+          });
+          assert(guest.synced === false, 'guest hydrate skipped');
+          const hydrated = await sync.hydrateAndSyncLearnerState({
+            storage,
+            fetchImpl,
+            isIdentified: true,
+          });
+          assert(hydrated.synced === true, 'identified hydrate');
+          assert(putCount === 1, 'hydrate put once');
+          const pushed = await sync.pushLocalLearnerState({
+            storage,
+            fetchImpl,
+            isIdentified: true,
+          });
+          assert(pushed.pushed === true, 'push local');
+          const skippedPush = await sync.pushLocalLearnerState({
+            storage,
+            fetchImpl,
+            isIdentified: false,
+          });
+          assert(skippedPush.pushed === false, 'guest push skipped');
+
+          // Due surfaces: route IDs only
+          assert(
+            JSON.stringify(due.collectDrillableNodeIds({
+              metadata: { id: 'core' },
+              backbone: [{ id: 'bb1' }],
+              clusters: [{ id: 'cl1', subnodes: [{ id: 'sn1', learner_scaffold: { task_label: 'S' } }] }],
+            })) === JSON.stringify(['sn1']),
+            'cluster scaffold wins',
+          );
+          assert(
+            due.renderReadyFilterHtml({ count: 0 }) === '',
+            'filter hidden at zero',
+          );
+          const filterHtml = due.renderReadyFilterHtml({ count: 1, active: true });
+          assert(filterHtml.includes('Due'), 'Due label');
+          assert(filterHtml.includes('is-active'), 'active filter');
+          assert(
+            due.collectDrillableNodeIds({ metadata: { label: 'Only core' }, backbone: [], clusters: [] })
+              .join(',') === 'core-thesis',
+            'empty graph falls back to core-thesis',
+          );
+          const selection = due.renderDueSelectionHtml([{
+            concept_id: 'c1',
+            node_id: 'sensor',
+            node_label: 'Sensor reading',
+            last_attempt_at: '2026-07-07T00:00:00.000Z',
+          }]);
+          assert(selection.includes('data-node-id="sensor"'), 'selection node id');
+          assert(selection.includes('Up next from memory'), 'selection kicker');
+          assert(due.renderDueSelectionHtml([]) === '', 'empty selection');
+
+          // Seed desk with due training and exercise UI handlers.
+          const now = Date.now();
+          const eighteenHoursAgo = new Date(now - 19 * 60 * 60 * 1000).toISOString();
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: 'due-c1',
+            name: 'Due Session',
+            state: 'solidified',
+            createdAt: now,
+            graphData: JSON.stringify({
+              metadata: { id: 'core', label: 'Feedback loop' },
+              backbone: [
+                { id: 'sensor', label: 'Sensor reading' },
+                { id: 'actuator', label: 'Actuator' },
+              ],
+              clusters: [],
+            }),
+          }]));
+          localStorage.setItem('learnops_active', 'due-c1');
+          localStorage.setItem('socratink:training:v1:due-c1', JSON.stringify({
+            concept_id: 'due-c1',
+            schema_version: 1,
+            grounding: 'ungrounded',
+            node_records: {
+              sensor: {
+                attempts: [{
+                  id: 'a-due',
+                  at: eighteenHoursAgo,
+                  user_text: 'strong spaced',
+                  classification: 'strong',
+                  gaps: [],
+                  grader_version: 'test',
+                }],
+                repairs: [],
+                study_revealed_at: eighteenHoursAgo,
+              },
+            },
+          }));
+          window.App.showDashboard();
+          return { ok: true };
+        }"""
+    )
+    assert result["ok"] is True
+
+    expect(clean_page.locator("#desk-ready-filter")).to_be_visible()
+    clean_page.locator("#desk-ready-filter").click()
+    expect(clean_page.locator("#desk-ready-filter")).to_have_attribute("aria-pressed", "true")
+    expect(clean_page.locator("#grid-container")).to_have_class(re.compile(r"is-ready-filtered"))
+
+    # Filtered empty tiles must no-op selectTile.
+    clean_page.evaluate("window.App.selectTile(8)")
+    expect(clean_page.locator("#desk-due-selection-host .desk-due-selection__action")).to_be_visible()
+    clean_page.locator("#desk-due-selection-host .desk-due-selection__action").click()
+    expect(clean_page.locator("#map-view")).to_be_visible()
+    expect(clean_page.locator("#map-content h2").first).to_contain_text("Sensor reading")
+
+    # App sync wrappers (guest path + error path) for diff coverage.
+    clean_page.evaluate(
+        """async () => {
+          await window.App.syncLearnerStateIfIdentified();
+          await window.App.pushLearnerStateIfIdentified();
+          const originalFetch = window.fetch;
+          window.fetch = async (url) => {
+            if (String(url).includes('/api/me')) {
+              return {
+                ok: true,
+                status: 200,
+                async json() {
+                  return {
+                    auth_enabled: true,
+                    authenticated: true,
+                    guest_mode: false,
+                    user: { id: 'user-1', email: 'a@b.c' },
+                  };
+                },
+              };
+            }
+            throw new Error('forced-sync-failure');
+          };
+          try {
+            await window.App.syncLearnerStateIfIdentified();
+            await window.App.pushLearnerStateIfIdentified();
+          } finally {
+            window.fetch = originalFetch;
+          }
+        }"""
+    )
+
+    # Empty-tile due-ring cleanup path in iso-board-state-surface.
+    clean_page.evaluate(
+        """() => {
+          localStorage.setItem('learnops_concepts', JSON.stringify([]));
+          localStorage.removeItem('learnops_active');
+          window.App.showDashboard();
+        }"""
+    )
+    expect(clean_page.locator("#desk-title")).to_be_attached()
+
+    assert captured["console_errors"] == []

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -856,6 +856,7 @@ def test_board_grid_helpers_preserve_tile_markup_and_events() -> None:
           attrs: {},
           innerHTML: '',
           setAttribute(name, value) { this.attrs[name] = value; },
+          removeAttribute(name) { delete this.attrs[name]; },
         });
         const tiles = [makeTile(), makeTile()];
         renderGrid({
@@ -874,6 +875,24 @@ def test_board_grid_helpers_preserve_tile_markup_and_events() -> None:
         assert.equal(tiles[1].attrs['aria-label'], 'Start learning');
         assert.ok(tiles[1].innerHTML.includes('tile-top-empty'));
         assert.deepEqual(events, ['grid:rendered']);
+
+        renderGrid({
+          concepts: [{ id: 'c1', name: 'First', state: 'growing' }],
+          tileEls: tiles,
+          activeId: 'c1',
+          bus: { emit(eventName) { events.push(eventName); } },
+          dueConceptIds: new Set(['c1']),
+          readyFilterActive: true,
+        });
+        assert.equal(tiles[0].attrs.class, 'tile-group selected is-due');
+        assert.equal(tiles[0].attrs['data-due'], '');
+        assert.equal(tiles[0].attrs.tabindex, '0');
+        assert.equal(tiles[0].attrs['aria-label'], 'Resume First, due for spaced reconstruction');
+        assert.equal(tiles[1].attrs.class, 'tile-group empty is-filtered-out');
+        assert.equal(tiles[1].attrs.tabindex, '-1');
+        assert.equal(tiles[1].attrs['aria-disabled'], 'true');
+        assert.equal(tiles[1].attrs['data-ready-filtered'], 'out');
+        assert.ok(tiles[0].innerHTML.includes('concept-pin-due-ring'));
 
         const classes = new Set(['anim-crack']);
         const animationEvents = {};

--- a/tests/test_learner_state_api.py
+++ b/tests/test_learner_state_api.py
@@ -50,11 +50,21 @@ class FakeLearnerStateTable:
 class FakeSupabaseClient:
     def __init__(self, table: FakeLearnerStateTable):
         self.learner_state_table = table
+        self.access_token = None
 
     def table(self, name: str):
         if name != "learner_state":
             raise AssertionError(f"unexpected table: {name}")
         return self.learner_state_table
+
+
+def _identified_state(user_id: str, *, access_token: str | None = "user-access-jwt") -> AuthSessionState:
+    return AuthSessionState(
+        auth_enabled=True,
+        authenticated=True,
+        user=AuthUser(id=user_id),
+        access_token=access_token,
+    )
 
 
 class LearnerStateApiTests(unittest.TestCase):
@@ -82,13 +92,14 @@ class LearnerStateApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_get_returns_404_when_empty(self):
-        state = AuthSessionState(
-            auth_enabled=True,
-            authenticated=True,
-            user=AuthUser(id="00000000-0000-0000-0000-000000000222"),
-        )
+        state = _identified_state("00000000-0000-0000-0000-000000000222")
         client = self._client(state)
         table = FakeLearnerStateTable(rows=[])
+        captured = {}
+
+        def fake_build(url, key, *, access_token=None):
+            captured["access_token"] = access_token
+            return FakeSupabaseClient(table)
 
         with (
             patch.dict(
@@ -98,22 +109,16 @@ class LearnerStateApiTests(unittest.TestCase):
                     "SUPABASE_PUBLISHABLE_KEY": "pk_test",
                 },
             ),
-            patch(
-                "main.build_supabase_client",
-                return_value=FakeSupabaseClient(table),
-            ),
+            patch("main.build_supabase_client", side_effect=fake_build),
         ):
             response = client.get("/api/learner-state")
 
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(captured["access_token"], "user-access-jwt")
 
     def test_put_and_get_round_trip(self):
         user_id = "00000000-0000-0000-0000-000000000333"
-        state = AuthSessionState(
-            auth_enabled=True,
-            authenticated=True,
-            user=AuthUser(id=user_id),
-        )
+        state = _identified_state(user_id)
         client = self._client(state)
         table = FakeLearnerStateTable(rows=[])
         payload = {
@@ -128,6 +133,11 @@ class LearnerStateApiTests(unittest.TestCase):
             },
             "updated_at": "2026-07-08T12:00:00.000Z",
         }
+        captured = {}
+
+        def fake_build(url, key, *, access_token=None):
+            captured["access_token"] = access_token
+            return FakeSupabaseClient(table)
 
         with (
             patch.dict(
@@ -137,10 +147,7 @@ class LearnerStateApiTests(unittest.TestCase):
                     "SUPABASE_PUBLISHABLE_KEY": "pk_test",
                 },
             ),
-            patch(
-                "main.build_supabase_client",
-                return_value=FakeSupabaseClient(table),
-            ),
+            patch("main.build_supabase_client", side_effect=fake_build),
         ):
             put_response = client.put("/api/learner-state", json=payload)
             get_response = client.get("/api/learner-state")
@@ -148,17 +155,26 @@ class LearnerStateApiTests(unittest.TestCase):
         self.assertEqual(put_response.status_code, 200)
         self.assertEqual(put_response.json(), {"status": "ok"})
         self.assertEqual(table.last_upsert["payload"]["user_id"], user_id)
+        self.assertEqual(captured["access_token"], "user-access-jwt")
         self.assertEqual(get_response.status_code, 200)
         body = get_response.json()
         self.assertEqual(body["concepts"], payload["concepts"])
         self.assertEqual(body["training"], payload["training"])
 
-    def test_missing_supabase_env_returns_503(self):
-        state = AuthSessionState(
-            auth_enabled=True,
-            authenticated=True,
-            user=AuthUser(id="00000000-0000-0000-0000-000000000444"),
+    def test_missing_access_token_returns_401(self):
+        state = _identified_state(
+            "00000000-0000-0000-0000-000000000555",
+            access_token=None,
         )
+        client = self._client(state)
+        response = client.put(
+            "/api/learner-state",
+            json={"schema_version": 1, "concepts": [], "training": {}},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_missing_supabase_env_returns_503(self):
+        state = _identified_state("00000000-0000-0000-0000-000000000444")
         client = self._client(state)
 
         with patch(

--- a/tests/test_learner_state_api.py
+++ b/tests/test_learner_state_api.py
@@ -1,0 +1,177 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+import main
+from auth.service import AuthConfigurationError, AuthSessionState, AuthUser
+
+
+class FakeAuthService:
+    def __init__(self, state: AuthSessionState):
+        self.cookie_name = "sb_session"
+        self.enabled = state.auth_enabled
+        self.state = state
+
+    def load_session(self, sealed_session: str | None):
+        return self.state
+
+
+class FakeLearnerStateTable:
+    def __init__(self, rows=None, execute_error: Exception | None = None):
+        self.rows = list(rows or [])
+        self.execute_error = execute_error
+        self.last_upsert = None
+        self.filters = []
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, key, value):
+        self.filters.append((key, value))
+        return self
+
+    def limit(self, *_args, **_kwargs):
+        return self
+
+    def upsert(self, payload, **kwargs):
+        self.last_upsert = {"payload": payload, "kwargs": kwargs}
+        self.rows = [payload]
+        return self
+
+    def execute(self):
+        if self.execute_error:
+            raise self.execute_error
+        result = MagicMock()
+        result.data = list(self.rows)
+        return result
+
+
+class FakeSupabaseClient:
+    def __init__(self, table: FakeLearnerStateTable):
+        self.learner_state_table = table
+
+    def table(self, name: str):
+        if name != "learner_state":
+            raise AssertionError(f"unexpected table: {name}")
+        return self.learner_state_table
+
+
+class LearnerStateApiTests(unittest.TestCase):
+    def setUp(self):
+        self.original_service = main.app.state.auth_service
+
+    def tearDown(self):
+        main.app.state.auth_service = self.original_service
+
+    def _client(self, state: AuthSessionState) -> TestClient:
+        main.app.state.auth_service = FakeAuthService(state)
+        client = TestClient(main.app)
+        client.cookies.set("sb_session", "sealed-session")
+        return client
+
+    def test_guest_cannot_read_learner_state(self):
+        state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=True,
+            guest_mode=True,
+            user=AuthUser(id="00000000-0000-0000-0000-000000000111"),
+        )
+        client = self._client(state)
+        response = client.get("/api/learner-state")
+        self.assertEqual(response.status_code, 401)
+
+    def test_get_returns_404_when_empty(self):
+        state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=True,
+            user=AuthUser(id="00000000-0000-0000-0000-000000000222"),
+        )
+        client = self._client(state)
+        table = FakeLearnerStateTable(rows=[])
+
+        with (
+            patch.dict(
+                main.os.environ,
+                {
+                    "SUPABASE_URL": "https://example.supabase.co",
+                    "SUPABASE_PUBLISHABLE_KEY": "pk_test",
+                },
+            ),
+            patch(
+                "main.build_supabase_client",
+                return_value=FakeSupabaseClient(table),
+            ),
+        ):
+            response = client.get("/api/learner-state")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_put_and_get_round_trip(self):
+        user_id = "00000000-0000-0000-0000-000000000333"
+        state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=True,
+            user=AuthUser(id=user_id),
+        )
+        client = self._client(state)
+        table = FakeLearnerStateTable(rows=[])
+        payload = {
+            "schema_version": 1,
+            "concepts": [{"id": "c1", "name": "Thermostat"}],
+            "training": {
+                "c1": {
+                    "concept_id": "c1",
+                    "schema_version": 1,
+                    "node_records": {},
+                }
+            },
+            "updated_at": "2026-07-08T12:00:00.000Z",
+        }
+
+        with (
+            patch.dict(
+                main.os.environ,
+                {
+                    "SUPABASE_URL": "https://example.supabase.co",
+                    "SUPABASE_PUBLISHABLE_KEY": "pk_test",
+                },
+            ),
+            patch(
+                "main.build_supabase_client",
+                return_value=FakeSupabaseClient(table),
+            ),
+        ):
+            put_response = client.put("/api/learner-state", json=payload)
+            get_response = client.get("/api/learner-state")
+
+        self.assertEqual(put_response.status_code, 200)
+        self.assertEqual(put_response.json(), {"status": "ok"})
+        self.assertEqual(table.last_upsert["payload"]["user_id"], user_id)
+        self.assertEqual(get_response.status_code, 200)
+        body = get_response.json()
+        self.assertEqual(body["concepts"], payload["concepts"])
+        self.assertEqual(body["training"], payload["training"])
+
+    def test_missing_supabase_env_returns_503(self):
+        state = AuthSessionState(
+            auth_enabled=True,
+            authenticated=True,
+            user=AuthUser(id="00000000-0000-0000-0000-000000000444"),
+        )
+        client = self._client(state)
+
+        with patch(
+            "main.build_supabase_client",
+            side_effect=AuthConfigurationError("SUPABASE_URL is required."),
+        ):
+            response = client.put(
+                "/api/learner-state",
+                json={"schema_version": 1, "concepts": [], "training": {}},
+            )
+
+        self.assertEqual(response.status_code, 503)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_learner_state_sync.py
+++ b/tests/test_learner_state_sync.py
@@ -94,7 +94,10 @@ def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
           name: 'Thermostat',
           graphData: JSON.stringify({
             metadata: { id: 'core', label: 'Feedback loop' },
-            backbone: [{ id: 'sensor', label: 'Sensor reading' }],
+            backbone: [
+              { id: 'sensor', label: 'Sensor reading' },
+              { id: 'actuator', label: 'Actuator' },
+            ],
             clusters: [],
           }),
         }];
@@ -103,11 +106,24 @@ def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
           c1: {
             concept_id: 'c1',
             node_records: {
+              // metadata.id is not a route entry — must not appear as due.
               core: {
+                attempts: [{
+                  id: 'a0',
+                  at: '2026-07-06T00:00:00.000Z',
+                  user_text: 'strong core',
+                  classification: 'strong',
+                  gaps: [],
+                  grader_version: 'test',
+                }],
+                repairs: [],
+                study_revealed_at: '2026-07-06T00:10:00.000Z',
+              },
+              sensor: {
                 attempts: [{
                   id: 'a1',
                   at: '2026-07-07T00:00:00.000Z',
-                  user_text: 'strong cold',
+                  user_text: 'strong sensor',
                   classification: 'strong',
                   gaps: [],
                   grader_version: 'test',
@@ -115,11 +131,11 @@ def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
                 repairs: [],
                 study_revealed_at: '2026-07-07T00:10:00.000Z',
               },
-              sensor: {
+              actuator: {
                 attempts: [{
                   id: 'a2',
                   at: '2026-07-07T01:00:00.000Z',
-                  user_text: 'strong sensor',
+                  user_text: 'strong actuator',
                   classification: 'strong',
                   gaps: [],
                   grader_version: 'test',
@@ -144,23 +160,27 @@ def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
           now: '2026-07-08T00:00:00.000Z',
         });
         assert.equal(due.length, 2);
-        assert.equal(due[0].node_id, 'core');
+        assert.equal(due[0].node_id, 'sensor');
+        assert.equal(due[0].node_label, 'Sensor reading');
         assert.deepEqual([...dueConceptIdSet(due)], ['c1']);
         assert.equal(dueItemsForConcept(due, 'c1').length, 2);
+        assert.ok(!due.some((item) => item.node_id === 'core'));
 
-        const filter = renderReadyFilterHtml({ count: 2, active: true });
+        const filter = renderReadyFilterHtml({ count: 1, active: true });
         assert.match(filter, /desk-ready-filter/);
-        assert.match(filter, /Ready/);
+        assert.match(filter, /Due/);
         assert.match(filter, /is-active/);
+        assert.match(filter, /spaced reconstruction/);
         assert.equal(renderReadyFilterHtml({ count: 0 }), '');
 
         const selection = renderDueSelectionHtml(dueItemsForConcept(due, 'c1'));
-        assert.match(selection, /Feedback loop/);
+        assert.match(selection, /Sensor reading/);
         assert.match(selection, /Up next from memory/);
         assert.match(selection, />\\s*Reconstruct\\s*</);
-        assert.match(selection, /2 nodes ready · oldest first/);
+        assert.match(selection, /2 nodes due · oldest first/);
+        assert.match(selection, /data-node-id="sensor"/);
+        assert.match(selection, /aria-label="Reconstruct Sensor reading from memory"/);
         assert.doesNotMatch(selection, /due-for-spaced__list/);
-        assert.doesNotMatch(selection, /Reconstruct from memory/);
         assert.doesNotMatch(selection, />RECONSTRUCT</);
         """
     )

--- a/tests/test_learner_state_sync.py
+++ b/tests/test_learner_state_sync.py
@@ -1,0 +1,167 @@
+"""Learner-state merge + Linear-style due desk surfaces."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from tests._helpers.node_runner import run_node_module
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_merge_learner_state_unions_evidence_without_dropping_attempts() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { mergeLearnerState } from './public/js/learner-state-sync.js';
+
+        const local = {
+          concepts: [{ id: 'c1', name: 'Local', updated_at: '2026-07-08T12:00:00.000Z' }],
+          training: {
+            c1: {
+              concept_id: 'c1',
+              schema_version: 1,
+              grounding: 'ungrounded',
+              node_records: {
+                n1: {
+                  attempts: [{
+                    id: 'a-local',
+                    at: '2026-07-08T10:00:00.000Z',
+                    user_text: 'local attempt',
+                    classification: 'strong',
+                    gaps: [],
+                    grader_version: 'test',
+                  }],
+                  repairs: [],
+                  study_revealed_at: '2026-07-08T10:05:00.000Z',
+                },
+              },
+            },
+          },
+        };
+
+        const remote = {
+          concepts: [{ id: 'c1', name: 'Remote', updated_at: '2026-07-07T12:00:00.000Z' }, { id: 'c2', name: 'Only remote' }],
+          training: {
+            c1: {
+              concept_id: 'c1',
+              schema_version: 1,
+              grounding: 'ungrounded',
+              node_records: {
+                n1: {
+                  attempts: [{
+                    id: 'a-remote',
+                    at: '2026-07-07T10:00:00.000Z',
+                    user_text: 'remote attempt',
+                    classification: 'partial',
+                    gaps: [],
+                    grader_version: 'test',
+                  }],
+                  repairs: [],
+                  study_revealed_at: '2026-07-07T10:05:00.000Z',
+                },
+              },
+            },
+          },
+        };
+
+        const merged = mergeLearnerState(local, remote);
+        assert.equal(merged.concepts.length, 2);
+        assert.equal(merged.concepts.find((c) => c.id === 'c1').name, 'Local');
+        assert.equal(merged.training.c1.node_records.n1.attempts.length, 2);
+        assert.equal(merged.training.c1.node_records.n1.study_revealed_at, '2026-07-07T10:05:00.000Z');
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import {
+          listDueForSpaced,
+          dueConceptIdSet,
+          dueItemsForConcept,
+          renderReadyFilterHtml,
+          renderDueSelectionHtml,
+        } from './public/js/due-for-spaced.js';
+
+        const concepts = [{
+          id: 'c1',
+          name: 'Thermostat',
+          graphData: JSON.stringify({
+            metadata: { id: 'core', label: 'Feedback loop' },
+            backbone: [{ id: 'sensor', label: 'Sensor reading' }],
+            clusters: [],
+          }),
+        }];
+
+        const trainingByConceptId = {
+          c1: {
+            concept_id: 'c1',
+            node_records: {
+              core: {
+                attempts: [{
+                  id: 'a1',
+                  at: '2026-07-07T00:00:00.000Z',
+                  user_text: 'strong cold',
+                  classification: 'strong',
+                  gaps: [],
+                  grader_version: 'test',
+                }],
+                repairs: [],
+                study_revealed_at: '2026-07-07T00:10:00.000Z',
+              },
+              sensor: {
+                attempts: [{
+                  id: 'a2',
+                  at: '2026-07-07T01:00:00.000Z',
+                  user_text: 'strong sensor',
+                  classification: 'strong',
+                  gaps: [],
+                  grader_version: 'test',
+                }],
+                repairs: [],
+                study_revealed_at: '2026-07-07T01:10:00.000Z',
+              },
+            },
+          },
+        };
+
+        const notDue = listDueForSpaced({
+          concepts,
+          trainingByConceptId,
+          now: '2026-07-07T10:00:00.000Z',
+        });
+        assert.equal(notDue.length, 0);
+
+        const due = listDueForSpaced({
+          concepts,
+          trainingByConceptId,
+          now: '2026-07-08T00:00:00.000Z',
+        });
+        assert.equal(due.length, 2);
+        assert.equal(due[0].node_id, 'core');
+        assert.deepEqual([...dueConceptIdSet(due)], ['c1']);
+        assert.equal(dueItemsForConcept(due, 'c1').length, 2);
+
+        const filter = renderReadyFilterHtml({ count: 2, active: true });
+        assert.match(filter, /desk-ready-filter/);
+        assert.match(filter, /Ready/);
+        assert.match(filter, /is-active/);
+        assert.equal(renderReadyFilterHtml({ count: 0 }), '');
+
+        const selection = renderDueSelectionHtml(dueItemsForConcept(due, 'c1'));
+        assert.match(selection, /Feedback loop/);
+        assert.match(selection, /Up next from memory/);
+        assert.match(selection, />\\s*Reconstruct\\s*</);
+        assert.match(selection, /2 nodes ready · oldest first/);
+        assert.doesNotMatch(selection, /due-for-spaced__list/);
+        assert.doesNotMatch(selection, /Reconstruct from memory/);
+        assert.doesNotMatch(selection, />RECONSTRUCT</);
+        """
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_learner_state_sync.py
+++ b/tests/test_learner_state_sync.py
@@ -85,6 +85,7 @@ def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
           listDueForSpaced,
           dueConceptIdSet,
           dueItemsForConcept,
+          collectDrillableNodeIds,
           renderReadyFilterHtml,
           renderDueSelectionHtml,
         } from './public/js/due-for-spaced.js';
@@ -182,6 +183,30 @@ def test_list_due_for_spaced_and_linear_desk_surfaces() -> None:
         assert.match(selection, /aria-label="Reconstruct Sensor reading from memory"/);
         assert.doesNotMatch(selection, /due-for-spaced__list/);
         assert.doesNotMatch(selection, />RECONSTRUCT</);
+
+        // Scaffolded clusters win over backbone — due IDs must match the page.
+        const clusterGraph = {
+          metadata: { id: 'core', label: 'Core' },
+          backbone: [{ id: 'bb1', label: 'Backbone only' }],
+          clusters: [{
+            id: 'cl1',
+            label: 'Cluster',
+            subnodes: [{
+              id: 'sn1',
+              label: 'Subnode one',
+              learner_scaffold: { task_label: 'Subnode one', task_cue: 'cue' },
+            }],
+          }],
+        };
+        assert.deepEqual(collectDrillableNodeIds(clusterGraph), ['sn1']);
+        assert.deepEqual(
+          collectDrillableNodeIds({
+            metadata: { id: 'core' },
+            backbone: [{ id: 'bb1', label: 'Backbone' }],
+            clusters: [{ id: 'cl1', subnodes: [{ id: 'sn1', label: 'Ignored sub' }] }],
+          }),
+          ['bb1'],
+        );
         """
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_supabase_client_factory.py
+++ b/tests/test_supabase_client_factory.py
@@ -36,6 +36,14 @@ class BuildSupabaseClientTests(unittest.TestCase):
         with self.assertRaises(AuthConfigurationError):
             build_supabase_client(URL, "")
 
+    def test_access_token_sets_authorization_header(self):
+        with patch("auth.supabase_client.create_client") as create:
+            build_supabase_client(URL, KEY, access_token="user.jwt")
+            _, kwargs = create.call_args
+            options = kwargs.get("options") or create.call_args[0][2]
+            headers = getattr(options, "headers", {}) or {}
+            self.assertEqual(headers.get("Authorization"), "Bearer user.jwt")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Persist identified-user concepts + training via `GET/PUT /api/learner-state` (user JWT for RLS) and client merge/hydrate.
- Replace Desk header due inventory with Linear board-centric Due filter, due marks, and selection Reconstruct strip.
- Harden Reconstruct honesty: due IDs match `deriveConceptEntries`, deep-link `activeEntryId`, session-count chip, filter a11y, opt-in motion, mobile chrome clearance.

## Test plan
- [x] `.venv/bin/pytest -q --ignore=tests/e2e` (721 passed)
- [x] Browser: Due filter dims tiles; Reconstruct opens Sensor reading entry
- [ ] Apply `db/learner_state.sql` in Supabase before relying on sync in prod
- [ ] CI checks green on this PR

## Known gaps
- Multi-device last-write-wins after hydrate (v1 acceptable).
- SQL must be applied manually (`db/README.md`).

Made with [Cursor](https://cursor.com)