### PR TITLE
[codex] Polish Door start learning surface

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -21,4 +21,4 @@
 
 @import '../styles.css?v=158'     layer(components);
 @import '../antigravity.css?v=37' layer(legacy);
-@import 'paper.css?v=13'          layer(paper);
+@import 'paper.css?v=15'          layer(paper);

--- a/public/css/paper.css
+++ b/public/css/paper.css
@@ -67,6 +67,11 @@
   isolation: isolate;
 }
 
+.ignition-view .composer-card {
+  max-width: 560px;
+  padding: clamp(var(--space-5), 4vw, var(--space-6));
+}
+
 .composer-card__field {
   display: block;
   width: 100%;
@@ -239,6 +244,213 @@
   overflow-wrap: anywhere;
 }
 
+.ig-boundary-line {
+  margin: var(--space-3) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+}
+
+/* ── Linear-style door (ignition only) ─────────────────────── */
+
+.ignition-view--linear .ignition-view__inner {
+  width: min(100%, 560px);
+  gap: var(--space-5);
+  align-items: stretch;
+}
+
+.ignition-view--linear .ig-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  text-align: left;
+}
+
+.ignition-view--linear .ig-eyebrow {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.ignition-view--linear .ig-title {
+  text-align: left;
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.ignition-view--linear .ig-first-use {
+  margin: 0;
+  max-width: none;
+  text-align: left;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.ignition-view--linear .composer-card--linear {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  box-shadow: none;
+  overflow: hidden;
+}
+
+.ignition-view--linear .composer-card__field--linear {
+  background: transparent;
+  min-height: 96px;
+  padding: 14px 16px;
+  line-height: 1.5;
+  font-size: var(--text-base);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ignition-view--linear .composer-card__field--linear::placeholder {
+  font-style: normal;
+  color: rgba(var(--ink-900-rgb), 0.42);
+}
+
+[data-theme="dark"] .ignition-view--linear .composer-card__field--linear::placeholder {
+  color: rgba(var(--cream-50-rgb), 0.38);
+}
+
+.ignition-view--linear .composer-card__field--linear:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--accent-primary);
+}
+
+.ignition-view--linear .composer-card__properties {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ignition-view--linear .ig-property {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 40px;
+  padding: 0 16px;
+  font-size: var(--text-sm);
+}
+
+.ignition-view--linear .ig-property__label {
+  flex: 0 0 4.5rem;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ignition-view--linear .ig-property__value {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text-strong);
+  font-style: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ignition-view--linear .ig-property__action {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background-color 120ms ease-out, color 120ms ease-out;
+}
+
+.ignition-view--linear .ig-property__action:hover {
+  background: var(--surface-nested);
+  color: var(--text-strong);
+}
+
+.ignition-view--linear .ig-property__action:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+}
+
+.ignition-view--linear .creation-source-panel {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border-top: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ignition-view--linear .composer-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 10px 12px 10px 16px;
+  background: var(--surface-nested);
+}
+
+.ignition-view--linear .composer-card__footer .ig-footnote {
+  margin: 0;
+  max-width: none;
+  padding: 0;
+  font-size: 11px;
+  line-height: var(--leading-snug);
+}
+
+.ignition-view--linear .composer-card__footer .ig-button--linear {
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.ignition-view--linear .composer-card__footer .ig-button--linear:hover:not(:disabled) {
+  transform: none;
+  box-shadow: none;
+}
+
+.ignition-view--linear .composer-card__footer .ig-button--linear:active:not(:disabled) {
+  transform: none;
+}
+
+.ignition-view--linear .composer-card__footer .ig-button--linear:focus-visible {
+  transform: none;
+  box-shadow: var(--accent-ring);
+}
+
+.ignition-view--linear .ig-error {
+  margin: 0;
+  padding: var(--space-2) var(--space-4) 0;
+}
+
+.ignition-view--linear .ig-error:empty {
+  padding: 0;
+}
+
+.ignition-view--linear .ignition-cap-gate {
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+@media (max-width: 520px) {
+  .ignition-view--linear .composer-card__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ignition-view--linear .composer-card__footer .ig-button--linear {
+    width: 100%;
+  }
+}
+
 .ig-error {
   margin: var(--space-3) 0 0;
   font-size: var(--text-xs);
@@ -261,8 +473,8 @@
   color: var(--text-muted);
 }
 .composer-card .journal-meta__key {
-  color: var(--primary-readable);
-  font-weight: 700;
+  color: var(--text-muted);
+  font-weight: 600;
 }
 .composer-card .journal-meta__value { font-style: italic; }
 .composer-card .journal-meta__sep { color: var(--text-muted); }

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=169">
+  <link rel="stylesheet" href="/css/index.css?v=171">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=13">
 </head>
 
@@ -295,21 +295,18 @@
     </section>
 
     <!-- Ignition View: door for new concept entry (paper system) -->
-    <section id="ignition-view" class="primary-view ignition-view"
+    <section id="ignition-view" class="primary-view ignition-view ignition-view--linear"
              aria-labelledby="ignition-title" hidden>
       <div class="ignition-view__inner">
-        <div class="witness-anchor" aria-hidden="true">
-          <svg viewBox="0 0 28 28" width="28" height="28">
-            <polygon class="witness-anchor__shape" points="14,2 26,14 14,26 2,14"/>
-          </svg>
-        </div>
-
-        <h1 class="ig-title" id="ignition-title" tabindex="-1">
-          What are you trying to understand?
-        </h1>
-        <p class="ig-first-use" id="ignition-first-use">
-          Name what you want to understand. Attach study material if you have it, or give your first model next.
-        </p>
+        <header class="ig-header">
+          <p class="ig-eyebrow">New session</p>
+          <h1 class="ig-title" id="ignition-title" tabindex="-1">
+            What are you trying to explain?
+          </h1>
+          <p class="ig-first-use" id="ignition-first-use">
+            Name a concept or question.
+          </p>
+        </header>
 
         <div class="ignition-cap-gate" id="ignition-cap-gate" hidden>
           <p class="ignition-cap-gate__message">
@@ -319,20 +316,23 @@
                   onclick="App.showLibrary()">Open library</button>
         </div>
 
-        <form class="composer-card" id="hero-single-input"
+        <form class="composer-card composer-card--linear" id="hero-single-input"
               onsubmit="return App.runHeroAction(event)" autocomplete="off">
-          <textarea class="composer-card__field" id="hero-single-input-field"
+          <textarea class="composer-card__field composer-card__field--linear"
+                    id="hero-single-input-field"
                     rows="2" maxlength="200"
                     placeholder="why vaccines create immune memory"
-                    aria-label="Learning goal"></textarea>
+                    aria-label="Learning goal"
+                    aria-describedby="ignition-boundary hero-door-error"></textarea>
 
-          <div class="journal-meta">
-            <span class="journal-meta__key">study material</span>
-            <span class="journal-meta__value" id="hero-source-value">optional</span>
-            <span class="journal-meta__sep" aria-hidden="true">—</span>
-            <button type="button" class="journal-meta__add"
-                    id="hero-source-attach" aria-expanded="false"
-                    aria-controls="hero-source-panel">attach</button>
+          <div class="composer-card__properties">
+            <div class="ig-property">
+              <span class="ig-property__label">Source</span>
+              <span class="ig-property__value" id="hero-source-value">Optional</span>
+              <button type="button" class="ig-property__action"
+                      id="hero-source-attach" aria-expanded="false"
+                      aria-controls="hero-source-panel">Attach</button>
+            </div>
           </div>
 
           <div class="creation-source-panel" id="hero-source-panel" hidden></div>
@@ -340,10 +340,13 @@
           <p class="ig-error" id="hero-door-error"
              role="status" aria-live="polite"></p>
 
-          <div class="composer-card__actions">
-            <button type="submit" class="ig-button" id="hero-door-submit"
-                    disabled aria-label="Start learning">Start</button>
-          </div>
+          <footer class="composer-card__footer">
+            <p class="ig-footnote" id="ignition-boundary">
+              Study stays hidden until you write first.
+            </p>
+            <button type="submit" class="ig-button ig-button--linear" id="hero-door-submit"
+                    disabled aria-label="Build draft route">Build draft route</button>
+          </footer>
         </form>
       </div>
     </section>
@@ -442,7 +445,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=186"></script>
+  <script type="module" src="/js/app.js?v=188"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -659,9 +659,9 @@ const App = (() => {
     const sourceValue = document.getElementById('hero-source-value');
     if (sourceAttachBtn) {
       sourceAttachBtn.setAttribute('aria-expanded', 'false');
-      sourceAttachBtn.textContent = 'attach';
+      sourceAttachBtn.textContent = 'Attach';
     }
-    if (sourceValue) sourceValue.textContent = 'optional';
+    if (sourceValue) sourceValue.textContent = 'Optional';
     if (sourcePanel) {
       sourcePanel.hidden = true;
       sourcePanel.innerHTML = '';
@@ -800,15 +800,15 @@ const App = (() => {
         panel.innerHTML = '';
         btn.setAttribute('aria-expanded', 'false');
         /* c8 ignore next 2 -- covered by the source picker contract; browser path only resets copy. */
-        btn.textContent = 'attach';
-        if (valueEl) valueEl.textContent = 'optional';
+        btn.textContent = 'Attach';
+        if (valueEl) valueEl.textContent = 'Optional';
         App._pendingDoorSource = null;
         _doorUpdateSubmitState();
       } else if (hasSource) {
         // Panel is closed and a source is attached — the button is the
         // "remove" affordance. Click clears the source without re-opening.
-        btn.textContent = 'attach';
-        if (valueEl) valueEl.textContent = 'optional';
+        btn.textContent = 'Attach';
+        if (valueEl) valueEl.textContent = 'Optional';
         App._pendingDoorSource = null;
         _doorUpdateSubmitState();
       } else {
@@ -827,7 +827,7 @@ const App = (() => {
             // Paper-style source-meta line: value span shows source ID,
             // button toggles to "remove" (matches the "attach" ↔ "remove"
             // affordance pattern persona-validated in Paper Wave 1).
-            btn.textContent = 'remove';
+            btn.textContent = 'Remove';
             const v = document.getElementById('hero-source-value');
             if (v) v.textContent = describeDoorSource(payload);
             _doorUpdateSubmitState();
@@ -836,9 +836,9 @@ const App = (() => {
             panel.hidden = true;
             panel.innerHTML = '';
             btn.setAttribute('aria-expanded', 'false');
-            btn.textContent = 'attach';
+            btn.textContent = 'Attach';
             const v = document.getElementById('hero-source-value');
-            if (v) v.textContent = 'optional';
+            if (v) v.textContent = 'Optional';
             App._pendingDoorSource = null;
             _doorUpdateSubmitState();
           },

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -49,13 +49,13 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
     clean_page.locator("#hero-source-panel .overlay-textarea").fill("source text")
     clean_page.locator("#hero-source-panel .creation-source-panel-attach").click()
     expect(clean_page.locator("#hero-source-value")).to_have_text("11 chars pasted")
-    expect(clean_page.locator("#hero-source-attach")).to_have_text("remove")
+    expect(clean_page.locator("#hero-source-attach")).to_have_text("Remove")
     clean_page.locator("#hero-source-attach").click()
     clean_page.locator("#hero-source-attach").click()
     expect(clean_page.locator("#hero-source-panel .overlay-textarea")).to_be_visible()
     clean_page.locator("#hero-source-panel .creation-source-panel-cancel").click()
-    expect(clean_page.locator("#hero-source-value")).to_have_text("optional")
-    expect(clean_page.locator("#hero-source-attach")).to_have_text("attach")
+    expect(clean_page.locator("#hero-source-value")).to_have_text("Optional")
+    expect(clean_page.locator("#hero-source-attach")).to_have_text("Attach")
 
     clean_page.evaluate(
         """() => {

--- a/tests/e2e/test_gestalt_hybrid_launch_qa.py
+++ b/tests/e2e/test_gestalt_hybrid_launch_qa.py
@@ -220,7 +220,7 @@ def test_source_less_launch_pad_end_to_end_qa(
     clean_page.evaluate("localStorage.clear(); sessionStorage.clear();")
 
     clean_page.locator("#nav-ignition").click()
-    expect(clean_page.locator("#ignition-title")).to_have_text("What are you trying to understand?")
+    expect(clean_page.locator("#ignition-title")).to_have_text("What are you trying to explain?")
     clean_page.locator("#hero-single-input-field").fill("Thermostat feedback loop")
     expect(clean_page.locator("#hero-door-submit")).to_be_enabled()
     clean_page.locator("#hero-door-submit").click()

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -217,7 +217,10 @@ def test_first_run_guidance_is_inline_not_modal(clean_page: Page, base_url: str)
     expect(clean_page.locator(".first-run-welcome")).to_have_count(0)
     clean_page.locator("#nav-ignition").click()
     expect(clean_page.locator("#ignition-first-use")).to_have_text(
-        "Name what you want to understand. Attach study material if you have it, or give your first model next."
+        "Name a concept or question."
+    )
+    expect(clean_page.locator("#ignition-boundary")).to_have_text(
+        "Study stays hidden until you write first."
     )
 
 

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1149,8 +1149,11 @@ def test_new_concept_field_has_unique_accessible_label() -> None:
     index_html = (REPO_ROOT / "public" / "index.html").read_text()
 
     assert '<h1 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
-    assert "What are you trying to understand?" in index_html
-    assert "Attach study material if you have it, or give your first model next." in index_html
+    assert "What are you trying to explain?" in index_html
+    assert "Name a concept or question." in index_html
+    assert "Study stays hidden until you write first." in index_html
+    assert 'id="ignition-boundary"' in index_html
+    assert 'class="ig-eyebrow">New session</p>' in index_html
     assert "socratink will ask for your first model" not in index_html
     assert 'id="hero-single-input-field"' in index_html
     assert 'aria-label="Learning goal"' in index_html


### PR DESCRIPTION
## Summary
- Reworks the Start learning Door into a left-aligned new-session composition with a Linear-style composer slab.
- Keeps the Door as concept/question capture, with source attach optional and study hidden until the learner writes.
- Updates source-row casing, cache pins, and focused Door/browser contracts.

## Checks run
- git diff --check
- .venv/bin/python scripts/check_frontend_cache_pins.py origin/main
- .venv/bin/pytest -q tests/test_frontend_app_helper_modules.py::test_new_concept_field_has_unique_accessible_label
- SOCRATINK_BASE_URL=http://127.0.0.1:8039 .venv/bin/pytest -q tests/e2e/test_app_helper_modules.py::test_app_helper_modules_preserve_browser_contracts tests/e2e/test_smoke.py::test_first_run_guidance_is_inline_not_modal tests/e2e/test_gestalt_hybrid_launch_qa.py::test_source_less_launch_pad_end_to_end_qa

## Taste gate
- Accepted direction: app-like Door surface, source row, continuity with sessions.
- Product guard applied: Door placeholder remains concept/question-shaped, not a Launch attempt sentence stem.

## Notes
- Preview was local at http://127.0.0.1:8039.
- Chrome DevTools MCP checkpoint was attempted earlier but blocked by a local profile conflict.