### PR TITLE
Polish concept page write-room copy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -445,7 +445,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=188"></script>
+  <script type="module" src="/js/app.js?v=189"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=28';
+} from './concept-page-view.js?v=29';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -189,7 +189,7 @@ function learnerGoalForConcept(concept, data) {
 }
 
 function attemptPlaceholderForScaffold(scaffold) {
-  if (!scaffold) return 'Draft what you can recall. Messy is useful.';
+  if (!scaffold) return 'Write what you can explain now. Messy is useful.';
   const starter = cleanScaffoldText(scaffold.sentence_starter);
   if (starter) return starter;
   return 'Write what you can explain right now.';
@@ -551,7 +551,7 @@ function renderAttemptPanelHtml(activeEntryId, activeEntry, options = {}) {
   const scaffold = options.useScaffold ? entryScaffold(activeEntry) : null;
   const learnerGoal = cleanScaffoldText(options.learnerGoal);
   const targetLabel = cleanScaffoldText(scaffold?.task_label) || cleanScaffoldText(activeEntry?.label) || 'this entry';
-  const heading = scaffold?.entry_prompt || 'Draft what you can recall';
+  const heading = scaffold?.entry_prompt || 'Write what you can explain now';
   const helperParts = [
     learnerGoal && scaffold
       ? `Goal: ${learnerGoal}. First make a starting guess for ${targetLabel}.`
@@ -844,7 +844,7 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     ? renderSketchWrapperHtml(thresholdText)
     : renderSketchWrapperHtml('');
   const sourceLessProvenanceHtml = '';
-  const contextDockLabel = 'Recall context';
+  const contextDockLabel = 'Concept context';
   const nextReady = (derived.next_action === 'review' || (derived.next_action === 'repair' && options?.repairCheckedThisSession))
     ? nextReadyEntry(backbone, activeIdx, training, options)
     : null;
@@ -862,6 +862,9 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
   const compareFeedbackHtml = isPostRevealComparison
     ? ' <button class="concept-page-b2__feedback-link" type="button" data-feedback-rating data-feedback-moment="compare notes">Rate this moment</button>'
     : '';
+  const truthNoteText = isAttempting
+    ? 'Study stays hidden until you save a draft. This is not a grade.'
+    : 'Your words shape the path. This is not a grade.';
 
   const activeEntryClass = [
     'concept-page-b2__active-entry',
@@ -879,7 +882,7 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
         ${repairPanelHtml}
         ${attemptPanelHtml}
         ${ctaButton}
-        <p class="concept-page-b2__truth-note">Your words shape the path. This is not a grade.${compareFeedbackHtml}</p>
+        <p class="concept-page-b2__truth-note">${escHtml(truthNoteText)}${compareFeedbackHtml}</p>
       `}
     </section>
   `;

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1548,7 +1548,8 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(coldHtml.includes('Context'));
         assert.ok(coldHtml.includes('I think nerves send electricity'));
         assert.ok(!coldHtml.includes('Write first. Compare after.'));
-        assert.ok(coldHtml.includes('aria-label="Recall context"'));
+        assert.ok(coldHtml.includes('aria-label="Concept context"'));
+        assert.ok(coldHtml.includes('Study stays hidden until you save a draft. This is not a grade.'));
         assert.ok(coldHtml.includes('What do you think makes the sodium channel open?'));
         assert.ok(coldHtml.includes('Sodium gate'));
         assert.ok(coldHtml.includes('Save draft'));
@@ -1570,7 +1571,7 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
           graphData,
           null
         );
-        assert.ok(coldWithoutTrainingHtml.includes('aria-label="Recall context"'));
+        assert.ok(coldWithoutTrainingHtml.includes('aria-label="Concept context"'));
         assert.ok(!coldWithoutTrainingHtml.includes('Shaped from your launch attempt, not verified against a source.'));
         assert.ok(coldWithoutTrainingHtml.includes('What do you think makes the sodium channel open?'));
         assert.ok(!coldWithoutTrainingHtml.includes('concept-page-b2__route-item'));
@@ -2059,7 +2060,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
             node_records: training.node_records,
           }
         );
-        assert.ok(sourceLessHtml.includes('aria-label="Recall context"'));
+        assert.ok(sourceLessHtml.includes('aria-label="Concept context"'));
         assert.ok(!sourceLessHtml.includes('Shaped from your launch attempt, not verified against a source.'));
         const sourceAttachedHtml = renderActiveEntryHtml(
           backbone[1],
@@ -2072,7 +2073,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
             node_records: training.node_records,
           }
         );
-        assert.ok(sourceAttachedHtml.includes('aria-label="Recall context"'));
+        assert.ok(sourceAttachedHtml.includes('aria-label="Concept context"'));
 
         const readyAttemptHtml = renderActiveEntryHtml(
           backbone[1],
@@ -2085,7 +2086,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         );
         assert.ok(readyAttemptHtml.includes('concept-page-b2__attempt'));
         assert.ok(readyAttemptHtml.includes('data-attempt-entry-id="entry-2"'));
-        assert.ok(readyAttemptHtml.includes('Draft what you can recall'));
+        assert.ok(readyAttemptHtml.includes('Write what you can explain now'));
         assert.ok(readyAttemptHtml.includes('Save draft'));
         assert.ok(!readyAttemptHtml.includes('concept-page-b2__entry-cta'));
 


### PR DESCRIPTION
## Summary
- Rename concept context dock from "Recall context" to "Concept context".
- Use explain-first attempt headings/placeholders instead of "Draft what you can recall".
- Show a draft-phase truth note: study stays hidden until the learner saves a draft.

Small, shippable UX polish recovered from the stale `agent/concept-view-write-room` worktree. Independent of first-session momentum slices B–D.

## Test plan
- [x] `.venv/bin/pytest -q tests/test_frontend_app_helper_modules.py -k "source_less_gestalt or concept_page_view_renders"`
- [ ] Browser smoke: cold attempt on concept page shows new copy and truth note


Made with [Cursor](https://cursor.com)