### PR TITLE
Polish first-session momentum flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -374,12 +374,14 @@ def _resolve_extract_path(req: "ExtractRequest") -> dict:
 def _fallback_smallest_route_from_sketch(
     *, concept: str, launch_attempt: str, learner_goal: str | None = None
 ) -> ProvisionalMap:
-    sketch_excerpt = launch_attempt.strip()[:160] or concept
+    raw_sketch = launch_attempt.strip()
+    sketch_excerpt = raw_sketch[:157].rstrip() + "..." if len(raw_sketch) > 160 else raw_sketch
+    sketch_excerpt = sketch_excerpt or concept
     anchor = "You named parts in your sketch; start by connecting two of them."
     if learner_goal:
         anchor = "Use your goal and sketch, then connect two named parts."
     entry_prompt = (
-        f'You wrote: "{sketch_excerpt}". '
+        f'You wrote: "{sketch_excerpt}" '
         "What do you think connects those parts?"
     )
     return ProvisionalMap(

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -434,6 +434,10 @@
 .concept-page-b2__gestalt--single-column {
   grid-template-columns: minmax(0, 1fr);
 }
+
+.concept-page-b2__gestalt:has(.concept-page-b2__active-entry--prompt-first) {
+  grid-template-columns: minmax(0, 1fr);
+}
 [data-theme="dark"] .concept-page-b2__gestalt {
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.055), rgba(144, 103, 198, 0.08)),
@@ -1404,6 +1408,10 @@
   margin: 4px auto 140px;
 }
 
+.concept-page-b2__doc:has(.concept-page-b2__active-entry--prompt-first) {
+  max-width: 1320px;
+}
+
 #map-view .map-view-shell {
   gap: 10px;
 }
@@ -1435,6 +1443,10 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.concept-page-b2__work:has(.concept-page-b2__active-entry--prompt-first) {
+  width: min(100%, 1100px);
 }
 
 .node-strip {
@@ -1721,6 +1733,11 @@
   box-shadow: none;
 }
 
+.concept-page-b2__active-entry--prompt-first {
+  max-width: 1100px;
+  padding-top: clamp(24px, 3vw, 38px);
+}
+
 .concept-page-b2__active-entry .concept-page-b2__entry-eyebrow {
   margin-bottom: 8px;
 }
@@ -1761,6 +1778,14 @@
   background: transparent;
 }
 
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt {
+  display: grid;
+  grid-template-columns: minmax(430px, 0.96fr) minmax(420px, 1.04fr);
+  column-gap: clamp(34px, 4.4vw, 64px);
+  row-gap: 14px;
+  align-items: start;
+}
+
 .concept-page-b2__active-entry .concept-page-b2__attempt-eyebrow {
   margin-bottom: 6px;
 }
@@ -1772,14 +1797,26 @@
 }
 
 .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt h3 {
-  font-size: clamp(30px, 4.6vw, 38px);
-  line-height: 1.08;
-  max-width: 22ch;
+  grid-column: 1;
+  margin: 0;
+  max-width: 23ch;
+  font-size: clamp(28px, 2.4vw, 36px);
+  line-height: 1.12;
+  letter-spacing: 0;
 }
 
 .concept-page-b2__active-entry .concept-page-b2__attempt-helper {
   margin: 0 0 4px;
   line-height: 1.42;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-helper {
+  grid-column: 1;
+  max-width: 34ch;
+  margin: 0;
+  color: rgba(var(--ink-900-rgb), 0.62);
+  font-size: 15px;
+  line-height: 1.5;
 }
 
 .concept-page-b2__active-entry .concept-page-b2__attempt-helper + .concept-page-b2__attempt-helper {
@@ -1796,14 +1833,73 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.70);
 }
 
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-input {
+  grid-column: 2;
+  grid-row: 1 / span 3;
+  min-height: clamp(300px, 36vh, 360px);
+  border: 1px solid rgba(var(--ink-900-rgb), 0.10);
+  border-radius: 16px;
+  background:
+    linear-gradient(rgba(var(--paper-0-rgb), 0.82), rgba(var(--paper-0-rgb), 0.82)),
+    linear-gradient(180deg, transparent 0, transparent 35px, rgba(var(--ink-900-rgb), 0.045) 36px);
+  background-size: auto, 100% 36px;
+  box-shadow:
+    0 18px 48px rgba(var(--violet-600-rgb), 0.055),
+    inset 0 1px 0 rgba(var(--white-rgb), 0.72);
+  font-size: 16px;
+  line-height: 1.75;
+  padding: 22px 24px;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-input:focus {
+  border-color: rgba(var(--violet-600-rgb), 0.34);
+  outline: 3px solid rgba(var(--violet-600-rgb), 0.12);
+  outline-offset: 2px;
+}
+
 .concept-page-b2__active-entry .concept-page-b2__attempt-save {
   margin-top: 14px;
   min-height: 44px;
   padding-block: 10px;
 }
 
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-actions {
+  grid-column: 2;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-save,
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__blank-start-button {
+  min-height: 44px;
+  border-radius: 999px;
+  padding: 9px 18px;
+  box-shadow: none;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-save {
+  margin: 0;
+}
+
+.concept-page-b2__active-entry.concept-page-b2__active-entry--prompt-first .concept-page-b2__blank-start {
+  margin: 0;
+}
+
 .concept-page-b2__active-entry .concept-page-b2__blank-start {
   margin: 10px 0 0;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__truth-note {
+  max-width: none;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__truth-note {
+  margin-top: 14px;
+  text-align: right;
+  color: rgba(var(--ink-900-rgb), 0.58);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .concept-page-b2__active-entry--drilling .concept-page-b2__entry-purpose {
@@ -1850,6 +1946,22 @@
   opacity: 1;
 }
 
+[data-theme="dark"] .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-helper,
+[data-theme="dark"] .concept-page-b2__active-entry--prompt-first .concept-page-b2__truth-note {
+  color: rgba(247, 236, 225, 0.56);
+}
+
+[data-theme="dark"] .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-input {
+  background:
+    linear-gradient(rgba(18, 14, 26, 0.90), rgba(18, 14, 26, 0.90)),
+    linear-gradient(180deg, transparent 0, transparent 35px, rgba(247, 236, 225, 0.045) 36px);
+  background-size: auto, 100% 36px;
+  border-color: rgba(176, 156, 224, 0.22);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.18),
+    inset 0 1px 0 rgba(247, 236, 225, 0.06);
+}
+
 @media (max-width: 900px) {
   body[data-map-open="true"] .bottom-nav {
     opacity: 0;
@@ -1890,6 +2002,24 @@
     padding: 16px 0 0;
   }
 
+  .concept-page-b2__active-entry--prompt-first {
+    max-width: none;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt {
+    display: block;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt h3 {
+    max-width: 18ch;
+    margin-bottom: 10px;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-helper {
+    max-width: 58ch;
+    margin-bottom: 14px;
+  }
+
   .node-strip-item.concept-page-b2__route-item,
   .node-strip-item.concept-page-b2__route-marker-item {
     flex-basis: min(270px, 78vw);
@@ -1924,6 +2054,31 @@
   .concept-page-b2__active-entry .concept-page-b2__attempt-input {
     min-height: 148px;
     height: 148px;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-input {
+    min-height: 220px;
+    height: 220px;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-save,
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__blank-start {
+    min-width: 0;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-save,
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__blank-start-button {
+    width: 100%;
+  }
+
+  .concept-page-b2__active-entry--prompt-first .concept-page-b2__truth-note {
+    text-align: left;
   }
 
 }

--- a/public/css/drill-chamber.css
+++ b/public/css/drill-chamber.css
@@ -44,7 +44,7 @@
   opacity: 0.78;
   transition: opacity 240ms cubic-bezier(0.16, 1, 0.3, 1);
 }
-.drill-chamber-view:has(.drill-chamber__composer textarea:focus) .drill-chamber__crumb {
+.drill-chamber-view:has(.drill-chamber__composer textarea:focus-visible) .drill-chamber__crumb {
   opacity: 0.30;
 }
 .drill-chamber__crumb a {
@@ -232,6 +232,40 @@
   border: 0;
 }
 
+.drill-chamber__active[data-loading="true"] {
+  opacity: 0.82;
+}
+
+.drill-chamber__verdict {
+  margin-top: 16px;
+  padding: 12px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(var(--paper-0-rgb), 0.64);
+  color: var(--text-strong);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  box-shadow: 0 1px 0 rgba(var(--paper-0-rgb), 0.80) inset;
+}
+
+.drill-chamber__verdict[hidden] {
+  display: none;
+}
+
+.drill-chamber__verdict-seg {
+  display: inline;
+}
+
+.drill-chamber__verdict-seg:first-child {
+  font-weight: 650;
+}
+
+.drill-chamber__verdict-sep {
+  display: inline-block;
+  margin: 0 8px;
+  color: var(--text-muted);
+}
+
 .drill-chamber__active[data-complete="true"] .drill-chamber__composer textarea,
 .drill-chamber__active[data-complete="true"] .drill-chamber__hint,
 .drill-chamber__active[data-complete="true"] .drill-chamber__voice-button {
@@ -346,6 +380,9 @@
 .drill-chamber__composer textarea::placeholder { color: rgba(36, 32, 56, 0.36); }
 .drill-chamber__composer-foot { color: var(--text-muted, rgba(36, 32, 56, 0.55)); }
 .drill-chamber__hint { color: var(--text-muted, rgba(36, 32, 56, 0.55)); }
+.drill-chamber__hint.is-error {
+  color: #7f3f2f;
+}
 .drill-chamber__send {
   color: var(--primary-readable, #70529b);
   border-color: var(--accent-border-strong, rgba(144, 103, 198, 0.32));
@@ -435,6 +472,9 @@
 }
 [data-theme="dark"] .drill-chamber__composer-foot { color: rgba(247, 236, 225, 0.36); }
 [data-theme="dark"] .drill-chamber__hint { color: rgba(247, 236, 225, 0.36); }
+[data-theme="dark"] .drill-chamber__hint.is-error {
+  color: rgba(255, 182, 160, 0.86);
+}
 [data-theme="dark"] .drill-chamber__send {
   color: rgba(176, 156, 224, 0.85);
   border-color: rgba(176, 156, 224, 0.32);
@@ -454,6 +494,13 @@
   background: rgba(176, 156, 224, 0.10);
   border-color: rgba(176, 156, 224, 0.60);
   color: rgba(247, 236, 225, 0.96);
+}
+
+[data-theme="dark"] .drill-chamber__verdict {
+  background: rgba(247, 236, 225, 0.05);
+  border-color: rgba(247, 236, 225, 0.10);
+  color: rgba(247, 236, 225, 0.86);
+  box-shadow: none;
 }
 
 /* ------- First-cold-attempt creed ------- */
@@ -579,6 +626,10 @@
 }
 
 @media (max-width: 720px) {
+  .drill-chamber__inner {
+    padding: 24px 20px 78px;
+  }
+
   .concept-page-b2__active-entry .drill-chamber__crumb {
     align-items: flex-start;
     flex-wrap: wrap;
@@ -592,6 +643,15 @@
   .drill-chamber__composer-foot {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .drill-chamber__composer-actions,
+  .drill-chamber__send {
+    width: 100%;
+  }
+
+  .drill-chamber__send {
+    min-height: 42px;
   }
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=158'     layer(components);
+@import '../styles.css?v=167'     layer(components);
 @import '../antigravity.css?v=37' layer(legacy);
-@import 'paper.css?v=15'          layer(paper);
+@import 'paper.css?v=17'          layer(paper);

--- a/public/css/paper.css
+++ b/public/css/paper.css
@@ -72,6 +72,10 @@
   padding: clamp(var(--space-5), 4vw, var(--space-6));
 }
 
+.ignition-view .composer-card__field + .composer-card__field {
+  margin-top: var(--space-3);
+}
+
 .composer-card__field {
   display: block;
   width: 100%;
@@ -302,6 +306,19 @@
   overflow: hidden;
 }
 
+.ignition-view--linear .composer-card--tall {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  background: rgba(var(--paper-0-rgb), 0.84);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  box-shadow:
+    0 18px 52px rgba(var(--ink-900-rgb), 0.06),
+    0 1px 0 rgba(var(--paper-0-rgb), 0.86) inset;
+  overflow: hidden;
+}
+
 .ignition-view--linear .composer-card__field--linear {
   background: transparent;
   min-height: 96px;
@@ -321,7 +338,22 @@
 }
 
 .ignition-view--linear .composer-card__field--linear:focus-visible {
-  box-shadow: inset 0 0 0 1px var(--accent-primary);
+  box-shadow: inset 0 -1px 0 rgba(var(--violet-600-rgb), 0.34);
+  background: rgba(var(--paper-0-rgb), 0.42);
+}
+
+.ignition-view--linear #hero-cold-guess-field {
+  padding: 10px 16px 0;
+  min-height: calc(var(--rule-step) * 4.35);
+  color: var(--text-strong);
+}
+
+.ignition-view--linear #hero-cold-guess-field::placeholder {
+  color: rgba(var(--ink-900-rgb), 0.54);
+}
+
+.ignition-view--linear #hero-cold-guess-field:focus-visible {
+  box-shadow: inset 0 -1px 0 rgba(var(--violet-600-rgb), 0.26);
 }
 
 .ignition-view--linear .composer-card__properties {
@@ -356,7 +388,7 @@
 .ignition-view--linear .ig-property__action {
   flex: 0 0 auto;
   margin-left: auto;
-  padding: 4px 8px;
+  padding: 5px 9px;
   border: 0;
   border-radius: 6px;
   background: transparent;
@@ -370,7 +402,7 @@
 }
 
 .ignition-view--linear .ig-property__action:hover {
-  background: var(--surface-nested);
+  background: rgba(var(--mauve-200-rgb), 0.24);
   color: var(--text-strong);
 }
 
@@ -392,7 +424,7 @@
   justify-content: space-between;
   gap: var(--space-3);
   padding: 10px 12px 10px 16px;
-  background: var(--surface-nested);
+  background: rgba(var(--mauve-200-rgb), 0.22);
 }
 
 .ignition-view--linear .composer-card__footer .ig-footnote {
@@ -405,7 +437,7 @@
 
 .ignition-view--linear .composer-card__footer .ig-button--linear {
   min-height: 32px;
-  padding: 0 12px;
+  padding: 0 14px;
   font-size: var(--text-xs);
   font-weight: 600;
   border-radius: 6px;
@@ -444,10 +476,17 @@
   .ignition-view--linear .composer-card__footer {
     flex-direction: column;
     align-items: stretch;
+    gap: var(--space-2);
+    padding: 12px 16px 14px;
+  }
+
+  .ignition-view--linear .composer-card__footer .ig-footnote {
+    text-align: center;
   }
 
   .ignition-view--linear .composer-card__footer .ig-button--linear {
     width: 100%;
+    min-height: 34px;
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,8 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=171">
-  <link rel="stylesheet" href="/css/drill-chamber.css?v=13">
+  <link rel="stylesheet" href="/css/index.css?v=182">
+  <link rel="stylesheet" href="/css/drill-chamber.css?v=16">
 </head>
 
 <body>
@@ -304,7 +304,7 @@
             What are you trying to explain?
           </h1>
           <p class="ig-first-use" id="ignition-first-use">
-            Name a concept or question.
+            Write what you remember first. We'll show what to study — not a summary.
           </p>
         </header>
 
@@ -316,13 +316,20 @@
                   onclick="App.showLibrary()">Open library</button>
         </div>
 
-        <form class="composer-card composer-card--linear" id="hero-single-input"
+        <form class="composer-card composer-card--tall" id="hero-single-input"
               onsubmit="return App.runHeroAction(event)" autocomplete="off">
           <textarea class="composer-card__field composer-card__field--linear"
                     id="hero-single-input-field"
                     rows="2" maxlength="200"
                     placeholder="why vaccines create immune memory"
                     aria-label="Learning goal"
+                    aria-describedby="ignition-boundary hero-door-error"></textarea>
+          <textarea class="composer-card__field" id="hero-cold-guess-field"
+                    rows="5" maxlength="1200"
+                    placeholder="I think…
+I'm fuzzy on…
+(e.g. parts, guesses, confusions)"
+                    aria-label="What do you already think?"
                     aria-describedby="ignition-boundary hero-door-error"></textarea>
 
           <div class="composer-card__properties">
@@ -342,10 +349,10 @@
 
           <footer class="composer-card__footer">
             <p class="ig-footnote" id="ignition-boundary">
-              Study stays hidden until you write first.
+              You'll write first. Answers come after.
             </p>
             <button type="submit" class="ig-button ig-button--linear" id="hero-door-submit"
-                    disabled aria-label="Build draft route">Build draft route</button>
+                    disabled aria-label="Start session">Start session</button>
           </footer>
         </form>
       </div>
@@ -444,8 +451,8 @@
   <!-- PDF.js for robust client-side extraction -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
-  <script src="/js/drill-chamber.js?v=14"></script>
-  <script type="module" src="/js/app.js?v=189"></script>
+  <script src="/js/drill-chamber.js?v=16"></script>
+  <script type="module" src="/js/app.js?v=196"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=29';
+} from './concept-page-view.js?v=31';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
@@ -74,7 +74,10 @@ import {
   runDrillTurn,
 } from './api-client.js?v=2';
 import { visibleSedaPromptFromResponse } from './seda-visible-prompt.js?v=2';
-import { projectCompletedSedaRecord } from './seda-evidence-projection.js';
+import {
+  projectCompletedSedaRecord,
+  projectLatestSedaAttemptEvent,
+} from './seda-evidence-projection.js';
 import {
   bootstrapAuthUi,
   buildLoginHref,
@@ -97,7 +100,13 @@ import {
   buildPendingShellFromDoorInput,
   showLaunchPad as _showLaunchPad,
   runLaunchPadAction as _runLaunchPadAction,
-} from './launch-pad.js?v=3';
+} from './launch-pad.js?v=5';
+import {
+  coldAttemptCompletionLabel,
+  nextSedaPromptAfterVerdict,
+  sedaCompleteCompletionLabel,
+  verdictCopy,
+} from './drill-verdict.js?v=2';
 import { emitTelemetry } from './telemetry.js';
 
 import {
@@ -652,6 +661,11 @@ const App = (() => {
       conceptField.value = '';
       conceptField.style.height = '';
     }
+    const guessField = document.getElementById('hero-cold-guess-field');
+    if (guessField) {
+      guessField.value = '';
+      guessField.style.height = '';
+    }
     // Reset any pending source selection from the door affordance.
     App._pendingDoorSource = null;
     const sourceAttachBtn = document.getElementById('hero-source-attach');
@@ -675,14 +689,16 @@ const App = (() => {
   function runHeroAction(evtOrNothing) {
     // C-prime door submit handler. Reads the concept input and the pending
     // source (if the learner expanded the source-attach panel). Branches:
-    //   source attached → existing concept-create modal flow (source path)
-    //   no source       → write sessionStorage pending shell → showLaunchPad()
+    //   source attached → direct source extraction
+    //   no source       → write sessionStorage pending shell → run launch submit
     if (evtOrNothing && typeof evtOrNothing.preventDefault === 'function') {
       evtOrNothing.preventDefault();
       const conceptField = document.getElementById('hero-single-input-field');
+      const guessField = document.getElementById('hero-cold-guess-field');
       const rawName = (conceptField ? conceptField.value : '').trim();
+      const coldGuess = (guessField ? guessField.value : '').trim();
       const shell = buildPendingShellFromDoorInput(rawName);
-      if (!shell.name) return false;
+      if (!shell.name || !coldGuess) return false;
 
       const sourcePayload = App._pendingDoorSource || null;
 
@@ -701,13 +717,12 @@ const App = (() => {
           name_normalized: shell.name !== rawName,
         });
         /* c8 ignore next -- source-attached submit enters the live extraction path; source UI contracts are covered separately. */
-        runSourceAttachedSubmit({ name: shell.name, source: sourcePayload });
+        runSourceAttachedSubmit({ name: shell.name, source: sourcePayload, startingSketch: coldGuess });
         return false;
       }
 
-      // Source-less path: write pending shell to sessionStorage, then navigate
-      // to the launch pad. DO NOT call /api/extract here — the launch pad
-      // captures the learner's threshold first (C-prime principle #2).
+      // Source-less path: write pending shell to sessionStorage, then reuse
+      // launch-pad.js's submit/persist path from the same screen.
       try {
         sessionStorage.setItem(
           'socratink:pendingShell',
@@ -730,8 +745,12 @@ const App = (() => {
         sourceless: true,
         name_normalized: shell.name !== rawName,
       });
-      App.showLaunchPad();
-      return false;
+      return _runLaunchPadAction(evtOrNothing, App, {
+        input: guessField,
+        submit: document.getElementById('hero-door-submit'),
+        validation: document.getElementById('hero-door-error'),
+        form: document.getElementById('hero-single-input'),
+      });
     }
 
     // Non-form path: the Begin button drives Begin/Extract/Drill/Open-map.
@@ -770,7 +789,10 @@ const App = (() => {
   // ≥2 trimmed chars matches the brainstorm spec for the door.
   function _doorReady() {
     const f = document.getElementById('hero-single-input-field');
-    return !!f && (f.value || '').trim().length >= 2;
+    const guess = document.getElementById('hero-cold-guess-field');
+    return !!f && !!guess
+      && (f.value || '').trim().length >= 2
+      && (guess.value || '').trim().length > 0;
   }
   function _doorUpdateSubmitState() {
     const submitBtn = document.getElementById('hero-door-submit');
@@ -848,14 +870,16 @@ const App = (() => {
   }
 
   function initHeroSingleInput() {
-    // C-prime door: one concept textarea + source-attach toggle.
+    // C-prime door: concept textarea + cold-guess textarea + source toggle.
     const conceptField = document.getElementById('hero-single-input-field');
+    const guessField = document.getElementById('hero-cold-guess-field');
     if (!(conceptField instanceof HTMLTextAreaElement)) return;
 
     const form = document.getElementById('hero-single-input');
 
-    // Enable/disable submit based on non-empty concept input.
+    // Enable/disable submit based on non-empty concept + cold guess.
     conceptField.addEventListener('input', _doorUpdateSubmitState);
+    guessField?.addEventListener('input', _doorUpdateSubmitState);
     _doorUpdateSubmitState();
 
     // Audio feedback (preserve existing behavior).
@@ -864,6 +888,7 @@ const App = (() => {
       (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Enter');
 
     conceptField.addEventListener('focus', () => AudioFX.playFocusTap());
+    guessField?.addEventListener('focus', () => AudioFX.playFocusTap());
     conceptField.addEventListener('keydown', (e) => {
       if (isPrintable(e)) {
         AudioFX.playKeyClick();
@@ -881,6 +906,9 @@ const App = (() => {
           form?.requestSubmit?.();
         }
       }
+    });
+    guessField?.addEventListener('keydown', (e) => {
+      if (isPrintable(e)) AudioFX.playKeyClick();
     });
 
     // Wire the source-attach toggle.
@@ -1378,7 +1406,7 @@ const App = (() => {
 
   // ── persistCreatedConceptFromLaunchPad ────────────────────────────────────
   // Mirrors the persistence phase of finishConceptCreateAfterOverlay for the
-  // C-prime launch-pad flow. No overlay to tear down; no source material.
+  // C-prime launch-pad flow. Overlay teardown stays in launch-pad.js.
   // Caller (launch-pad.js) clears the pending shell ONLY AFTER this returns
   // without throwing, maintaining the persistence-then-clear ordering contract.
   //
@@ -1518,7 +1546,7 @@ const App = (() => {
   //   source — { type: 'text'|'url'|'file', text?, url?, filename? } payload
   //            captured by the door's source-panel.
   /* c8 ignore next -- source-attached creation uses the same persistence boundary as launch-pad and is covered by live smoke. */
-  async function runSourceAttachedSubmit({ name, source }) {
+  async function runSourceAttachedSubmit({ name, source, startingSketch = '' }) {
     const setDoorError = (msg) => {
       const errEl = document.getElementById('hero-door-error');
       if (errEl) {
@@ -1568,7 +1596,7 @@ const App = (() => {
     try {
       const data = await submitConceptCreate({
         name,
-        startingSketch: '',
+        startingSketch,
         source: resolvedSource,
       });
       const provisionalMap = data.provisional_map || data.knowledge_map || null;
@@ -1587,7 +1615,7 @@ const App = (() => {
         knowledgeMap: provisionalMap,
         startedAtIso: new Date().toISOString(),
         startedPerf: performance.now(),
-        startingSketch: '',
+        startingSketch,
         source: resolvedSource,
         overlayHandle,
       });
@@ -3246,6 +3274,7 @@ const App = (() => {
     const gate = document.getElementById('ignition-cap-gate');
     const form = document.getElementById('hero-single-input');
     const field = document.getElementById('hero-single-input-field');
+    const guessField = document.getElementById('hero-cold-guess-field');
     const submit = document.getElementById('hero-door-submit');
     const sourceAttach = document.getElementById('hero-source-attach');
     const capCta = gate?.querySelector('.ig-button');
@@ -3264,6 +3293,7 @@ const App = (() => {
     }
 
     if (field) field.disabled = atCap;
+    if (guessField) guessField.disabled = atCap;
     // pointer-events:none on the form's data-state="locked" stops mouse
     // input but does not prevent keyboard focus; setting disabled also
     // removes the button from the tab order so kb users can't Enter it
@@ -3490,7 +3520,14 @@ const App = (() => {
       : sedaPromptFromResponse(data);
   }
 
-  function saveSedaResponse(concept, nodeContext, data) {
+  function openStudyAfterVerdict(conceptId, nodeId) {
+    cancelDrill();
+    const concept = loadConcepts().find((item) => item?.id === conceptId) || getActiveConcept();
+    if (!concept) return;
+    void revealStudyForEntry(nodeId, concept, parseConceptGraphData(concept) || {});
+  }
+
+  async function saveSedaResponse(concept, nodeContext, data) {
     if (!concept?.id || !data?.sessionId) return;
     persistSedaSessionState(concept.id, {
       sessionId: data.sessionId,
@@ -3499,7 +3536,7 @@ const App = (() => {
       record: data.record || null,
     });
     if (data.caseComplete && data.record) {
-      void projectSedaEvidence(concept, nodeContext, data);
+      await projectSedaEvidence(concept, nodeContext, data);
     }
   }
 
@@ -3520,6 +3557,28 @@ const App = (() => {
     } catch (err) {
       /* c8 ignore next 2 -- defensive storage failure branch. */
       console.warn('SEDA evidence projection unavailable.', err);
+    }
+  }
+
+  async function projectSedaAttemptEvent(concept, nodeContext, data) {
+    try {
+      const training = await trainingStore.loadTraining(concept.id);
+      const next = projectLatestSedaAttemptEvent({
+        training,
+        conceptId: concept.id,
+        nodeId: nodeContext?.id || null,
+        data,
+        sessionId: data.sessionId,
+      });
+      if (!next) return false;
+      await trainingStore.saveTraining(next);
+      const projected = next.node_records?.[nodeContext?.id || ''];
+      const attempts = Array.isArray(projected?.attempts) ? projected.attempts : [];
+      return attempts[attempts.length - 1]?.classification || true;
+    } catch (err) {
+      /* c8 ignore next 2 -- defensive storage failure branch. */
+      console.warn('SEDA attempt projection unavailable.', err);
+      return false;
     }
   }
 
@@ -3544,7 +3603,7 @@ const App = (() => {
     if (data?.awaiting?.key === 'learner_goal') {
       data = await sendSedaTurn(data.sessionId, concept.learnerGoal || '');
     }
-    saveSedaResponse(concept, nodeContext, data);
+    await saveSedaResponse(concept, nodeContext, data);
     return data;
   }
 
@@ -4387,23 +4446,45 @@ const App = (() => {
       if (sessionToken !== drillState.sessionToken || !drillState.node) return;
 
       drillState.sedaSessionId = data.sessionId;
-      saveSedaResponse(concept, drillState.node, data);
+      await saveSedaResponse(concept, drillState.node, data);
+      if (sessionToken !== drillState.sessionToken || !drillState.node) return;
+      const projectedAttemptClassification = data.caseComplete
+        ? null
+        : await projectSedaAttemptEvent(concept, drillState.node, data);
+      const studyReady = data.caseComplete || Boolean(projectedAttemptClassification);
+      if (sessionToken !== drillState.sessionToken || !drillState.node) return;
+      const previousPrompt = chamberLastShownQuestion;
       const promptText = sedaPromptFromResponse(data);
+      const nextPrompt = nextSedaPromptAfterVerdict(promptText, previousPrompt, userText);
       drillState.messages.push({ role: 'user', content: userText });
-      drillState.messages.push({ role: 'assistant', content: promptText });
-      chamberLastShownQuestion = promptText;
+      drillState.messages.push({ role: 'assistant', content: studyReady ? promptText : nextPrompt });
+      chamberLastShownQuestion = studyReady ? promptText : nextPrompt;
       drillState.pending = false;
-      drillState.sessionCompletePending = Boolean(data.caseComplete);
+      drillState.sessionCompletePending = Boolean(studyReady);
       persistSessionState();
 
       if (window.DrillChamber) {
         window.DrillChamber.setLoading?.(false);
-        window.DrillChamber.swapQuestion(promptText);
-        if (data.caseComplete) {
-          /* c8 ignore next -- completed-loop button behavior is covered by API evidence proof; browser smoke covers active turn routing. */
-          window.DrillChamber.setCompletionAction?.('Return to concept', () => cancelDrill());
+        if (studyReady) {
+          window.DrillChamber.appendVerdict?.(verdictCopy({
+            userText,
+            sedaComplete: data.caseComplete,
+            classification: projectedAttemptClassification || undefined,
+          }));
         } else {
-          window.DrillChamber.setComposerEnabled(true);
+          window.DrillChamber.swapQuestion(nextPrompt);
+          setTimeout(() => {
+            window.DrillChamber?.appendVerdict?.(verdictCopy({ userText }));
+            window.DrillChamber?.setCompletionAction?.('Keep going', () => {
+              window.DrillChamber?.setComposerEnabled(true);
+            });
+          }, 260);
+        }
+        if (studyReady) {
+          /* c8 ignore next -- completed-loop button behavior is covered by API evidence proof; browser smoke covers active turn routing. */
+          window.DrillChamber.setCompletionAction?.(sedaCompleteCompletionLabel(), () => openStudyAfterVerdict(concept.id, drillState.node?.id));
+        } else {
+          window.DrillChamber.setComposerEnabled(false);
         }
       }
     } catch (err) {
@@ -4546,6 +4627,12 @@ const App = (() => {
         if (data.agent_response?.trim()) {
           drillState.messages.push({ role: 'assistant', content: data.agent_response.trim() });
         }
+        if (window.DrillChamber && completedNodeTurn && userText) {
+          window.DrillChamber.appendVerdict?.(verdictCopy({
+            classification: mapDrillClassificationForTraining(data.classification),
+            userText,
+          }));
+        }
         drillState.pending = false;
         drillState.sessionCompletePending = data.routing === 'SESSION_COMPLETE' || Boolean(data.session_terminated);
 
@@ -4566,7 +4653,13 @@ const App = (() => {
         if (window.DrillChamber) {
           window.DrillChamber.setLoading?.(false);
           if (completedNodeTurn || data.session_terminated) {
-            window.DrillChamber.setCompletionAction?.('Return to concept', () => cancelDrill());
+            const coldClassification = mapDrillClassificationForTraining(data.classification);
+            window.DrillChamber.setCompletionAction?.(
+              completedColdAttempt ? coldAttemptCompletionLabel(coldClassification) : 'Return to concept',
+              completedColdAttempt
+                ? () => openStudyAfterVerdict(concept.id, drillState.node?.id)
+                : () => cancelDrill(),
+            );
           } else {
             window.DrillChamber.setComposerEnabled(true);
           }
@@ -4786,7 +4879,7 @@ const App = (() => {
             /* c8 ignore start -- opening an already-complete stored session is covered by API proof, not browser smoke. */
             if (data.caseComplete) {
               drillState.sessionCompletePending = true;
-              window.DrillChamber.setCompletionAction?.('Return to concept', () => cancelDrill());
+              window.DrillChamber.setCompletionAction?.(sedaCompleteCompletionLabel(), () => openStudyAfterVerdict(concept.id, nodeContext?.id));
             } else if (initialSedaTurnText) {
               window.DrillChamber.appendHistoryTurn('ai', promptText);
               window.DrillChamber.appendHistoryTurn('learner', initialSedaTurnText);
@@ -5093,6 +5186,7 @@ const App = (() => {
     // runLaunchPadAction is called by the launch-pad form onsubmit handler.
     // It reads the pending shell, posts to /api/extract, persists, and navigates.
     runLaunchPadAction(event) { return _runLaunchPadAction(event, App); },
+    mountExtractOverlayForLaunchPad(name) { return mountExtractOverlay({ name }); },
     // persistCreatedConceptFromLaunchPad — called by launch-pad.js after a
     // successful /api/extract response. Performs localStorage write, grid
     // refresh, and concept selection. Throws on invalid map so launch-pad.js

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -730,6 +730,7 @@ function renderDrillChamberHtml() {
 
         <div class="drill-chamber__active" id="chamber-active">
           <p class="drill-chamber__question" id="chamber-question">—</p>
+          <div class="drill-chamber__verdict" id="chamber-verdict" role="status" aria-live="polite" hidden></div>
           <div class="drill-chamber__composer">
             <textarea id="chamber-composer" placeholder="Write your reconstruction here. Fragments are fine." aria-label="Your reply" rows="3"></textarea>
             <div class="drill-chamber__composer-foot">

--- a/public/js/drill-chamber.js
+++ b/public/js/drill-chamber.js
@@ -48,6 +48,7 @@ function bind() {
   const view = document.getElementById('drill-chamber-view');
   if (els.bound && els.view === view) {
     els.hint = document.getElementById('chamber-hint');
+    els.verdict = document.getElementById('chamber-verdict');
     return hasRequiredElements();
   }
   els.bound = false;
@@ -64,6 +65,7 @@ function bind() {
   els.hint = document.getElementById('chamber-hint');
   els.exit = document.getElementById('chamber-exit');
   els.chatLog = document.getElementById('chamber-chat-log');
+  els.verdict = document.getElementById('chamber-verdict');
 
   if (!hasRequiredElements()) return false;
 
@@ -113,6 +115,7 @@ function show({ conceptName, entryName, question }) {
   if (!bind()) return;
   els.active.querySelectorAll('.drill-chamber__creed').forEach((el) => el.remove());
   clearCompletionAction();
+  clearVerdict();
   resetComposerHint();
   els.conceptName.textContent = conceptName || '—';
   els.entryName.textContent = entryName || '—';
@@ -172,6 +175,7 @@ function appendHistoryTurn(role, text) {
 function swapQuestion(nextText) {
   if (!bind()) return;
   clearCompletionAction();
+  clearVerdict();
   els.active.classList.add('is-fading-out');
   setTimeout(() => {
     if (!hasRequiredElements()) return;
@@ -225,7 +229,10 @@ function clearComposer() {
 }
 
 function setComposerHint(text) {
-  if (els.hint) els.hint.textContent = text;
+  if (els.hint) {
+    els.hint.textContent = text;
+    els.hint.classList?.toggle?.('is-error', Boolean(text && text !== DEFAULT_HINT));
+  }
   setVoiceStatus(text === DEFAULT_HINT ? '' : text);
 }
 
@@ -240,6 +247,32 @@ function clearCompletionAction() {
   els.send.textContent = DEFAULT_SEND_LABEL;
   els.composer.placeholder = _originalPlaceholder;
   resetComposerHint();
+}
+
+function clearVerdict() {
+  if (!bind() || !els.verdict) return;
+  els.verdict.textContent = '';
+  els.verdict.hidden = true;
+}
+
+function appendVerdict(text) {
+  if (!bind() || !els.verdict) return;
+  const copy = String(text || '').trim();
+  if (!copy) return;
+  els.verdict.textContent = '';
+  copy.split(' • ').forEach((segment, index) => {
+    if (index > 0) {
+      const sep = document.createElement('span');
+      sep.className = 'drill-chamber__verdict-sep';
+      sep.textContent = '•';
+      els.verdict.appendChild(sep);
+    }
+    const part = document.createElement('span');
+    part.className = 'drill-chamber__verdict-seg';
+    part.textContent = segment;
+    els.verdict.appendChild(part);
+  });
+  els.verdict.hidden = false;
 }
 
 function setCompletionAction(label = 'Return to concept', handler = null) {
@@ -412,6 +445,6 @@ window.DrillChamber = {
   show, hide, appendHistoryTurn, swapQuestion,
   setComposerEnabled, setLoading, setCompletionAction,
   getComposerValue, clearComposer,
-  appendCreed,
+  appendCreed, appendVerdict, clearVerdict,
   onSend, onExit,
 };

--- a/public/js/drill-verdict.js
+++ b/public/js/drill-verdict.js
@@ -1,0 +1,37 @@
+function learnerSnippet(userText) {
+  const text = String(userText || '').replace(/\s+/g, ' ').trim();
+  return text.length > 72 ? `${text.slice(0, 69)}...` : text;
+}
+
+export function verdictCopy({ classification, userText, sedaComplete = false } = {}) {
+  const snippet = learnerSnippet(userText);
+  const x = snippet ? `your line "${snippet}"` : 'the attempt';
+  if (sedaComplete) return `Checked • Recorded • ${x} is on record. • Study is ready.`;
+  if (classification === 'strong' || classification === 'solid') {
+    return `Checked • Solid enough to compare • You named ${x}. • Study will show what to add.`;
+  }
+  if (classification === 'partial' || classification === 'deep') {
+    return `Checked • Partly there • You have ${x}. • Study will target the missing link.`;
+  }
+  if (classification === 'wrong_direction' || classification === 'misconception') {
+    return `Checked • Wrong angle • You focused on ${x}. • Study will reset the mechanism.`;
+  }
+  return `Checked • Gap found • ${x} exposed what to study next. • Study will target it.`;
+}
+
+export function nextSedaPromptAfterVerdict(promptText, previousPrompt, userText) {
+  const next = String(promptText || '').trim();
+  const prev = String(previousPrompt || '').trim();
+  if (!next || next === prev) {
+    return `You wrote: «${learnerSnippet(userText)}». Now: name the missing link in one sentence.`;
+  }
+  return `You wrote: «${learnerSnippet(userText)}». Now: ${next}`;
+}
+
+export function coldAttemptCompletionLabel(classification) {
+  return classification === 'strong' ? 'Reveal notes and compare' : 'See what to study';
+}
+
+export function sedaCompleteCompletionLabel() {
+  return 'See what to study';
+}

--- a/public/js/launch-pad.js
+++ b/public/js/launch-pad.js
@@ -77,6 +77,15 @@ function hasLaunchAttempt(text) {
   return normalizeWhitespace(text).length > 0;
 }
 
+function launchPadControls(controls = {}) {
+  return {
+    input: controls.input || document.getElementById('launch-pad-input'),
+    submit: controls.submit || document.getElementById('launch-pad-submit'),
+    validation: controls.validation || document.getElementById('launch-pad-validation'),
+    form: controls.form || document.getElementById('launch-pad-form'),
+  };
+}
+
 function readPendingShell() {
   try {
     const raw = sessionStorage.getItem(PENDING_SHELL_KEY);
@@ -169,9 +178,7 @@ export function showLaunchPad(App) {
   });
 
   // Reset validation and input from any prior visit.
-  const input = document.getElementById('launch-pad-input');
-  const submit = document.getElementById('launch-pad-submit');
-  const validation = document.getElementById('launch-pad-validation');
+  const { input, submit, validation } = launchPadControls();
   if (input) input.value = '';
   if (submit) submit.disabled = true;
   if (validation) validation.textContent = '';
@@ -229,7 +236,7 @@ export function showLaunchPad(App) {
  * @param {object} App   The App namespace object (passed by app.js wrapper).
  * @returns {false}  Always returns false to suppress default form submission.
  */
-export async function runLaunchPadAction(event, App) {
+export async function runLaunchPadAction(event, App, controls = {}) {
   if (event && typeof event.preventDefault === 'function') {
     event.preventDefault();
   }
@@ -241,9 +248,7 @@ export async function runLaunchPadAction(event, App) {
     return false;
   }
 
-  const input = document.getElementById('launch-pad-input');
-  const submit = document.getElementById('launch-pad-submit');
-  const validation = document.getElementById('launch-pad-validation');
+  const { input, submit, validation, form } = launchPadControls(controls);
   const threshold = (input ? input.value : '').trim();
 
   if (!hasLaunchAttempt(threshold)) {
@@ -270,7 +275,6 @@ export async function runLaunchPadAction(event, App) {
   // aria-busy="true" tells assistive tech the surface is updating;
   // form.dataset.state='busy' drives the paper composer's dim
   // (paper.css .composer-card[data-state="busy"]).
-  const form = document.getElementById('launch-pad-form');
   if (form) {
     form.setAttribute('aria-busy', 'true');
     form.dataset.state = 'busy';
@@ -281,6 +285,7 @@ export async function runLaunchPadAction(event, App) {
     form.dataset.state = '';
     if (submit) submit.textContent = originalSubmitLabel;
   };
+  const overlayHandle = App.mountExtractOverlayForLaunchPad?.(shell.name) || null;
 
   // ── Step 1: POST /api/extract ─────────────────────────────────────────────
   // Telemetry is emitted AFTER the network result is known — one event per
@@ -303,6 +308,7 @@ export async function runLaunchPadAction(event, App) {
         : MISSING_THRESHOLD_COPY;
       if (validation) validation.textContent = validationCopy;
       if (submit) submit.disabled = false;
+      overlayHandle?.removeOverlay(false);
       clearBuildingState();
       emitTelemetry('concept_create.launch_pad.submit', {
         threshold_len: threshold.length,
@@ -333,6 +339,7 @@ export async function runLaunchPadAction(event, App) {
       : 'Something went wrong. Try again.';
     if (validation) validation.textContent = fallbackMsg;
     if (submit) submit.disabled = false;
+    overlayHandle?.removeOverlay(false);
     clearBuildingState();
     return false;
   }
@@ -367,6 +374,7 @@ export async function runLaunchPadAction(event, App) {
       : 'Could not save the concept locally. Try again.';
     if (validation) validation.textContent = msg;
     if (submit) submit.disabled = false;
+    overlayHandle?.removeOverlay(false);
     clearBuildingState();
     return false;
   }
@@ -377,6 +385,7 @@ export async function runLaunchPadAction(event, App) {
   // ── Step 4: Navigate to graph view ───────────────────────────────────────
   // App.navigateToGraphViewFromLaunchPad handles selectConcept + showMapView
   // and passes {fromLaunchPad: true} for Round E's skeleton-line hook.
+  overlayHandle?.removeOverlay(true);
   App.navigateToGraphViewFromLaunchPad({ fromLaunchPad: true });
 
   return false;

--- a/public/js/seda-evidence-projection.js
+++ b/public/js/seda-evidence-projection.js
@@ -13,6 +13,31 @@ function sedaAttemptId(sessionId, index) {
   return `seda-${sessionId}-${index}`;
 }
 
+function sedaEventAttemptId(sessionId, index) {
+  return `seda-${sessionId}-event-${index}`;
+}
+
+function mapClassification(classification) {
+  if (classification === 'solid' || classification === 'strong') return 'strong';
+  if (classification === 'deep' || classification === 'partial') return 'partial';
+  if (classification === 'shallow' || classification === 'thin') return 'thin';
+  if (classification === 'misconception' || classification === 'wrong_direction') return 'wrong_direction';
+  return null;
+}
+
+function latestColdAttemptEvent(data) {
+  const events = Array.isArray(data?.events) ? data.events : [];
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.type !== 'cold_attempt') continue;
+    const text = typeof event.text === 'string' ? event.text.trim() : '';
+    const classification = mapClassification(event?.evaluation?.classification);
+    if (!text || !classification) continue;
+    return { event, index, text, classification };
+  }
+  return null;
+}
+
 // Select the single attempted backend node record. A SEDA session completes
 // exactly one node, so zero or several attempted records is unexpected; fail
 // closed rather than arbitrarily projecting whichever happens to be first.
@@ -60,6 +85,64 @@ function baseTraining(training, conceptId) {
     source_ref: null,
     sketch: null,
     node_records: {},
+  };
+}
+
+/**
+ * Projects the latest recordable SEDA cold_attempt event before the case is
+ * complete. This lets first-session study reveal honor the cold-attempt gate
+ * without waiting for the whole spaced SEDA case to finish.
+ */
+export function projectLatestSedaAttemptEvent({
+  training = null,
+  conceptId,
+  nodeId,
+  data,
+  sessionId,
+  now = new Date().toISOString(),
+} = {}) {
+  if (!conceptId || !nodeId || !sessionId) return null;
+  const coldAttempt = latestColdAttemptEvent(data);
+  if (!coldAttempt) return null;
+
+  const next = baseTraining(training, conceptId);
+  const nodeRecords = next.node_records && typeof next.node_records === 'object'
+    ? next.node_records
+    : {};
+  const existing = nodeRecords[nodeId] || { attempts: [], repairs: [] };
+  const existingAttempts = Array.isArray(existing.attempts) ? existing.attempts : [];
+  const attemptId = sedaEventAttemptId(sessionId, coldAttempt.index);
+  if (existingAttempts.some((attempt) => attempt?.id === attemptId)) {
+    return null;
+  }
+
+  return {
+    ...next,
+    concept_id: conceptId,
+    schema_version: TRAINING_SCHEMA_VERSION,
+    node_records: {
+      ...nodeRecords,
+      [nodeId]: {
+        ...existing,
+        attempts: [
+          ...existingAttempts,
+          {
+            id: attemptId,
+            at: now,
+            user_text: coldAttempt.text,
+            classification: coldAttempt.classification,
+            gaps: Array.isArray(coldAttempt.event?.evaluation?.gaps)
+              ? coldAttempt.event.evaluation.gaps
+              : [],
+            grader_version: coldAttempt.event?.evaluation?.prompt_version
+              || coldAttempt.event?.evaluation?.grader_version
+              || 'seda-loop',
+            kind: existingAttempts.length === 0 ? 'cold' : 'spaced',
+          },
+        ],
+        repairs: Array.isArray(existing.repairs) ? existing.repairs : [],
+      },
+    },
   };
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,4 +6,4 @@
 @import './css/board-first.css?v=6';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';
-@import './css/concept-page.css?v=45';
+@import './css/concept-page.css?v=54';

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import json
 from urllib.parse import urljoin
 
 from playwright.sync_api import Page, expect
@@ -20,30 +21,108 @@ def _enter_app_shell_as_guest(page: Page, base_url: str) -> None:
     expect(page.locator("#concept-list")).to_be_attached()
 
 
-def test_launch_pad_displays_normalized_concept_and_goal(
+def test_door_forwards_normalized_concept_and_cold_guess(
     clean_page: Page, base_url: str
 ) -> None:
+    captured_payloads: list[dict] = []
+
+    def fulfill_extract(route) -> None:
+        payload = route.request.post_data_json
+        captured_payloads.append(payload)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {
+                        "core_thesis": "Sodium rushing into a neuron starts an electrical signal.",
+                    },
+                    "backbone": [{"id": "b1", "principle": "Sodium influx changes voltage."}],
+                    "clusters": [{
+                        "id": "c1",
+                        "label": "Sodium influx",
+                        "subnodes": [{
+                            "id": "c1_s1",
+                            "label": "Sodium influx",
+                            "mechanism": "Sodium entering the neuron changes membrane voltage.",
+                        }],
+                    }],
+                },
+            }),
+        )
+
+    clean_page.route("**/api/extract", fulfill_extract)
     _enter_app_shell_as_guest(clean_page, base_url)
     clean_page.locator("#nav-ignition").click()
     clean_page.locator("#hero-single-input-field").fill(
         "I want to understand why sodium rushing into a neuron starts an electrical signal"
     )
+    clean_page.locator("#hero-cold-guess-field").fill(
+        "I think sodium crosses the membrane and that changes the electrical state."
+    )
     clean_page.locator("#hero-door-submit").click()
 
-    expect(clean_page.locator("#launch-pad-concept-name")).to_have_text(
-        "sodium rushing into a neuron starts an electrical signal"
+    expect(clean_page.locator("#extract-overlay")).to_be_visible()
+    assert captured_payloads
+    assert captured_payloads[0]["name"] == "sodium rushing into a neuron starts an electrical signal"
+    assert captured_payloads[0]["starting_sketch"] == (
+        "I think sodium crosses the membrane and that changes the electrical state."
     )
-    expect(clean_page.locator("#launch-pad-concept-goal")).to_have_text(
-        "Goal: I want to understand why sodium rushing into a neuron starts an electrical signal"
+    assert captured_payloads[0]["source"] is None
+
+
+def test_source_attached_door_forwards_source_and_cold_guess(
+    clean_page: Page, base_url: str
+) -> None:
+    captured_payloads: list[dict] = []
+
+    def fulfill_extract(route) -> None:
+        captured_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {"core_thesis": "Practice improves recall."},
+                    "backbone": [{"id": "b1", "principle": "Retrieval strengthens memory."}],
+                    "clusters": [{
+                        "id": "c1",
+                        "label": "Retrieval",
+                        "subnodes": [{
+                            "id": "c1_s1",
+                            "label": "Retrieval",
+                            "mechanism": "Retrieval practice strengthens recall.",
+                        }],
+                    }],
+                },
+            }),
+        )
+
+    clean_page.route("**/api/extract", fulfill_extract)
+    _enter_app_shell_as_guest(clean_page, base_url)
+    clean_page.locator("#nav-ignition").click()
+    clean_page.locator("#hero-single-input-field").fill("why practice improves recall")
+    clean_page.locator("#hero-cold-guess-field").fill("Trying to remember makes the memory easier to find.")
+    clean_page.locator("#hero-source-attach").click()
+    clean_page.locator("#hero-source-panel .overlay-textarea").fill("retrieval practice source note")
+    clean_page.locator("#hero-source-panel .creation-source-panel-attach").click()
+    clean_page.locator("#hero-door-submit").click()
+
+    expect(clean_page.locator("#extract-overlay")).to_be_visible()
+    assert captured_payloads
+    assert captured_payloads[0]["starting_sketch"] == (
+        "Trying to remember makes the memory easier to find."
     )
-    expect(clean_page.locator(".ig-concept-mark")).not_to_contain_text(
-        "on I want"
-    )
+    assert captured_payloads[0]["source"] == {
+        "type": "text",
+        "text": "retrieval practice source note",
+    }
 
 
 def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_url: str) -> None:
     _enter_app_shell_as_guest(clean_page, base_url)
 
+    clean_page.locator("#hero-cold-guess-field").press("x")
     clean_page.locator("#hero-source-attach").click()
     expect(clean_page.locator("#hero-source-panel .overlay-textarea")).to_be_visible()
     clean_page.locator("#hero-source-panel .overlay-textarea").fill("source text")
@@ -852,6 +931,84 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               if (previousActiveConcept === null) localStorage.removeItem('learnops_active');
               else localStorage.setItem('learnops_active', previousActiveConcept);
             }
+
+            const drillVerdict = await import('/js/drill-verdict.js');
+            assert(
+              drillVerdict.verdictCopy({ classification: 'partial', userText: 'The query compares with keys.' })
+                .includes('Checked • Partly there •'),
+              'drill verdict partial branch',
+            );
+            assert(
+              drillVerdict.verdictCopy({ classification: 'wrong_direction', userText: 'Keys make the sentence longer.' })
+                .includes('Checked • Wrong angle •'),
+              'drill verdict wrong-direction branch',
+            );
+            same(
+              drillVerdict.nextSedaPromptAfterVerdict('', 'Same question?', 'My rough answer.'),
+              'You wrote: «My rough answer.». Now: name the missing link in one sentence.',
+              'drill verdict fallback prompt',
+            );
+
+            const sedaProjection = await import('/js/seda-evidence-projection.js');
+            same(
+              sedaProjection.projectLatestSedaAttemptEvent({
+                conceptId: 'c',
+                nodeId: 'n',
+                sessionId: 'sess-browser',
+                data: {
+                  events: [
+                    { type: 'cold_attempt', text: 'Earlier weak attempt', evaluation: { classification: 'thin' } },
+                    { type: 'cold_attempt', text: 'Later solid attempt', evaluation: { classification: 'deep' } },
+                  ],
+                },
+                now: '2026-07-09T05:00:00.000Z',
+              }).node_records.n.attempts[0],
+              {
+                id: 'seda-sess-browser-event-1',
+                at: '2026-07-09T05:00:00.000Z',
+                user_text: 'Later solid attempt',
+                classification: 'partial',
+                gaps: [],
+                grader_version: 'seda-loop',
+                kind: 'cold',
+              },
+              'seda projection uses latest recordable cold event',
+            );
+            assert(
+              sedaProjection.projectLatestSedaAttemptEvent({
+                conceptId: 'c',
+                nodeId: 'n',
+                sessionId: 'sess-browser',
+                data: { events: [{ type: 'cold_attempt', text: ' ', evaluation: { classification: 'solid' } }] },
+              }) === null,
+              'seda projection skips blank cold attempts',
+            );
+            assert(
+              sedaProjection.projectLatestSedaAttemptEvent({
+                conceptId: 'c',
+                nodeId: 'n',
+                sessionId: 'sess-browser',
+                data: { events: [{ type: 'cold_attempt', text: 'No usable classification', evaluation: { classification: 'unknown' } }] },
+              }) === null,
+              'seda projection skips unmapped classifications',
+            );
+            const duplicateProjection = sedaProjection.projectLatestSedaAttemptEvent({
+              training: {
+                concept_id: 'c',
+                schema_version: 1,
+                node_records: {
+                  n: {
+                    attempts: [{ id: 'seda-sess-browser-event-0' }],
+                    repairs: [],
+                  },
+                },
+              },
+              conceptId: 'c',
+              nodeId: 'n',
+              sessionId: 'sess-browser',
+              data: { events: [{ type: 'cold_attempt', text: 'Already captured', evaluation: { classification: 'solid' } }] },
+            });
+            assert(duplicateProjection === null, 'seda projection skips duplicate event attempt ids');
 
             const conceptPage = await import('/js/concept-page-view.js');
             const conceptConstellation = await import('/js/concept-constellation-view.js');

--- a/tests/e2e/test_gestalt_hybrid_launch_qa.py
+++ b/tests/e2e/test_gestalt_hybrid_launch_qa.py
@@ -222,16 +222,11 @@ def test_source_less_launch_pad_end_to_end_qa(
     clean_page.locator("#nav-ignition").click()
     expect(clean_page.locator("#ignition-title")).to_have_text("What are you trying to explain?")
     clean_page.locator("#hero-single-input-field").fill("Thermostat feedback loop")
+    clean_page.locator("#hero-cold-guess-field").fill(sketch_text)
     expect(clean_page.locator("#hero-door-submit")).to_be_enabled()
     clean_page.locator("#hero-door-submit").click()
 
-    expect(clean_page.locator("#launch-pad-view")).to_be_visible()
-    expect(clean_page.locator("#launch-pad-concept-name")).to_have_text(
-        "Thermostat feedback loop"
-    )
-    clean_page.locator("#launch-pad-input").fill(sketch_text)
-    expect(clean_page.locator("#launch-pad-submit")).to_be_enabled()
-    clean_page.locator("#launch-pad-submit").click()
+    expect(clean_page.locator("#launch-pad-view")).to_be_hidden()
 
     canvas = clean_page.locator(".concept-page-b2__gestalt")
     expect(canvas).to_be_visible(timeout=10_000)

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -217,10 +217,10 @@ def test_first_run_guidance_is_inline_not_modal(clean_page: Page, base_url: str)
     expect(clean_page.locator(".first-run-welcome")).to_have_count(0)
     clean_page.locator("#nav-ignition").click()
     expect(clean_page.locator("#ignition-first-use")).to_have_text(
-        "Name a concept or question."
+        "Write what you remember first. We'll show what to study — not a summary."
     )
     expect(clean_page.locator("#ignition-boundary")).to_have_text(
-        "Study stays hidden until you write first."
+        "You'll write first. Answers come after."
     )
 
 
@@ -1196,11 +1196,11 @@ def test_start_learning_enters_seda_loop_from_product_flow(
     page.locator("#hero-single-input-field").fill(
         "I want to explain why vaccines create immune memory."
     )
-    page.locator("#hero-door-submit").click()
-    page.locator("#launch-pad-input").fill(
+    page.locator("#hero-cold-guess-field").fill(
         "The first exposure leaves cells that remember the pathogen."
     )
-    page.locator("#launch-pad-submit").click()
+    expect(page.locator("#launch-pad-view")).to_be_hidden()
+    page.locator("#hero-door-submit").click()
 
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
     expect(page.locator("#chamber-question")).to_contain_text(
@@ -1309,6 +1309,149 @@ def test_start_learning_enters_seda_loop_from_product_flow(
     expect(page.locator("#nav-loop")).to_have_count(0)
 
 
+def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
+    clean_page: Page, base_url: str
+) -> None:
+    """A non-final SEDA turn should show feedback, then require an explicit continue."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+
+    def fulfill_extract(route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {"core_thesis": "Immune memory speeds the next response."},
+                    "backbone": [{"id": "b1", "principle": "Immune memory persists."}],
+                    "clusters": [{
+                        "id": "c1",
+                        "label": "Memory cells",
+                        "subnodes": [{
+                            "id": "c1_s1",
+                            "label": "Memory cells",
+                            "mechanism": "Memory cells persist after exposure.",
+                            "learner_scaffold": {
+                                "entry_prompt": "Why is the second exposure faster?",
+                                "task_cue": "Explain the role of memory cells.",
+                            },
+                        }],
+                    }],
+                },
+            }),
+        )
+
+    def fulfill_session(route) -> None:
+        route.fulfill(
+            status=201,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "mid-loop-session",
+                "status": "awaiting_input",
+                "awaiting": {"key": "launch_attempt", "ctaText": "Try your first explanation."},
+                "learnerTranscript": [],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    turn_requests = {"count": 0}
+
+    def fulfill_turn(route) -> None:
+        turn_requests["count"] += 1
+        if turn_requests["count"] == 2:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "sessionId": "mid-loop-session",
+                    "status": "awaiting_input",
+                    "awaiting": {"key": "compare", "ctaText": "Compare your answer with the note."},
+                    "learnerTranscript": [],
+                    "events": [{
+                        "type": "cold_attempt",
+                        "text": "Memory cells remain and respond faster next time.",
+                        "evaluation": {
+                            "classification": "solid",
+                            "gaps": [],
+                            "grader_version": "qa",
+                        },
+                    }],
+                    "caseComplete": False,
+                    "record": None,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "mid-loop-session",
+                "status": "awaiting_input",
+                "awaiting": {"key": "missing_link", "ctaText": "Name the missing link."},
+                "learnerTranscript": [],
+                "events": [],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    page.route("**/api/extract", fulfill_extract)
+    page.route(re.compile(r".*/api/session$"), fulfill_session)
+    page.route(re.compile(r".*/api/session/[^/]+/turn$"), fulfill_turn)
+    page.locator("#nav-ignition").click()
+    page.locator("#hero-single-input-field").fill("why vaccines create immune memory")
+    page.locator("#hero-cold-guess-field").fill("The first exposure leaves memory cells.")
+    page.locator("#hero-door-submit").click()
+
+    expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
+    page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
+          if (!key) return false;
+          const value = JSON.parse(localStorage.getItem(key) || 'null');
+          return value?.sessionId === 'mid-loop-session'
+            && value?.latest?.awaiting?.key === 'launch_attempt';
+        }""",
+        timeout=20_000,
+    )
+    page.locator("#chamber-composer").fill(
+        "Memory cells remain after the first exposure and make the second response faster."
+    )
+    expect(page.locator("#chamber-send")).to_be_enabled()
+    page.locator("#chamber-composer").press("Control+Enter")
+    expect(page.locator("#chamber-question")).to_contain_text(
+        "Name the missing link.", timeout=20_000
+    )
+    assert turn_requests["count"] == 1
+    expect(page.locator("#chamber-verdict")).to_contain_text("Checked", timeout=20_000)
+    expect(page.locator("#chamber-send")).to_have_text("Keep going")
+    expect(page.locator("#chamber-composer")).to_be_disabled()
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-composer")).to_be_enabled()
+    page.locator("#chamber-composer").fill(
+        "Memory cells remain and respond faster next time."
+    )
+    page.locator("#chamber-composer").press("Control+Enter")
+    expect(page.locator("#chamber-verdict")).to_contain_text("Checked", timeout=20_000)
+    expect(page.locator("#chamber-send")).to_have_text("See what to study")
+    projected = page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:training:v1:${conceptId}` : null;
+          if (!key) return null;
+          const value = JSON.parse(localStorage.getItem(key) || 'null');
+          const record = value?.node_records?.c1_s1;
+          return record?.attempts?.length ? record.attempts[0] : null;
+        }""",
+        timeout=20_000,
+    ).json_value()
+    assert projected["classification"] == "strong"
+    assert projected["kind"] == "cold"
+    assert turn_requests["count"] == 2
+
+
 def test_seda_start_failure_offers_retry_from_product_flow(
     page: Page, base_url: str
 ) -> None:
@@ -1359,12 +1502,12 @@ def test_seda_start_failure_offers_retry_from_product_flow(
         )
 
     page.route("**/api/extract", fulfill_extract)
-    page.route("**/api/session", fulfill_session)
+    page.route(re.compile(r".*/api/session$"), fulfill_session)
     page.locator("#nav-ignition").click()
     page.locator("#hero-single-input-field").fill("why vaccines create immune memory")
+    page.locator("#hero-cold-guess-field").fill("The first exposure leaves memory cells.")
     page.locator("#hero-door-submit").click()
-    page.locator("#launch-pad-input").fill("The first exposure leaves memory cells.")
-    page.locator("#launch-pad-submit").click()
+    expect(page.locator("#launch-pad-view")).to_be_hidden()
 
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
     expect(page.locator("#chamber-question")).to_contain_text(
@@ -1478,18 +1621,18 @@ def test_completed_seda_case_projects_visible_evidence(
         )
 
     page.route("**/api/extract", fulfill_extract)
-    page.route("**/api/session", fulfill_session)
+    page.route(re.compile(r".*/api/session$"), fulfill_session)
     page.route(re.compile(r".*/api/session/[^/]+/turn$"), fulfill_turn)
 
     page.locator("#nav-ignition").click()
     page.locator("#hero-single-input-field").fill(
         "I want to explain why vaccines create immune memory."
     )
-    page.locator("#hero-door-submit").click()
-    page.locator("#launch-pad-input").fill(
+    page.locator("#hero-cold-guess-field").fill(
         "The first exposure leaves cells that remember the pathogen."
     )
-    page.locator("#launch-pad-submit").click()
+    page.locator("#hero-door-submit").click()
+    expect(page.locator("#launch-pad-view")).to_be_hidden()
 
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
     # Mirror the proven-stable SEDA choreography: wait until the launch_attempt
@@ -1513,6 +1656,10 @@ def test_completed_seda_case_projects_visible_evidence(
     )
     expect(page.locator("#chamber-hint")).to_have_text("A sentence is enough.")
     page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-verdict")).to_contain_text("Checked", timeout=20_000)
+    expect(page.locator("#chamber-send")).to_have_text("See what to study")
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_be_hidden()
 
     projected = page.wait_for_function(
         """() => {
@@ -1521,7 +1668,9 @@ def test_completed_seda_case_projects_visible_evidence(
           if (!key) return null;
           const value = JSON.parse(localStorage.getItem(key) || 'null');
           const record = value?.node_records?.['c1_s1'];
-          return record?.attempts?.length ? { attempts: record.attempts } : null;
+          return record?.attempts?.length && record?.study_revealed_at
+            ? { attempts: record.attempts, study_revealed_at: record.study_revealed_at }
+            : null;
         }""",
         timeout=20_000,
     ).json_value()
@@ -1549,7 +1698,6 @@ def test_completed_seda_case_projects_visible_evidence(
     )
     assert derived_state == "primed"
 
-    page.locator("#chamber-exit").click()
     page.reload()
     # The evidence artifact renders the strongest/latest reconstruction turn.
     expect(page.locator(".concept-page-b2__evidence")).to_contain_text(
@@ -3206,12 +3354,10 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
 
     clean_page.locator("#nav-ignition").click()
     clean_page.locator("#hero-single-input-field").fill("Thermostat feedback loop")
+    clean_page.locator("#hero-cold-guess-field").fill(sketch_text)
     expect(clean_page.locator("#hero-door-submit")).to_be_enabled()
     clean_page.locator("#hero-door-submit").click()
-    expect(clean_page.locator("#launch-pad-view")).to_be_visible()
-    clean_page.locator("#launch-pad-input").fill(sketch_text)
-    expect(clean_page.locator("#launch-pad-submit")).to_be_enabled()
-    clean_page.locator("#launch-pad-submit").click()
+    expect(clean_page.locator("#launch-pad-view")).to_be_hidden()
 
     canvas = clean_page.locator(".concept-page-b2__gestalt")
     expect(canvas).to_be_visible(timeout=8_000)

--- a/tests/test_extract_route_smallest.py
+++ b/tests/test_extract_route_smallest.py
@@ -58,6 +58,19 @@ def test_extract_empty_sketch_no_source_still_rejected(client):
     assert r.json()["detail"]["error"] == "missing_sketch"
 
 
+def test_fallback_route_truncated_sketch_reads_as_excerpt():
+    sketch = "word " * 60
+
+    route = main._fallback_smallest_route_from_sketch(
+        concept="Transformer attention",
+        launch_attempt=sketch,
+    )
+
+    prompt = route.clusters[0].subnodes[0].learner_scaffold.entry_prompt
+    assert prompt.startswith('You wrote: "word word')
+    assert '..." What do you think connects those parts?' in prompt
+
+
 def test_extract_short_sketch_no_source_returns_smallest_route(client):
     """Any non-empty source-less launch attempt can seed the draft route."""
     from tests._helpers.provisional_map_factory import provisional_map_with_node_count

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -159,6 +159,37 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_drill_verdict_helpers_keep_seda_transitions_specific() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import {
+          nextSedaPromptAfterVerdict,
+          verdictCopy,
+        } from './public/js/drill-verdict.js';
+
+        assert.equal(
+          nextSedaPromptAfterVerdict('Same question?', 'Same question?', 'I guessed with my own words.'),
+          'You wrote: «I guessed with my own words.». Now: name the missing link in one sentence.'
+        );
+        assert.equal(
+          nextSedaPromptAfterVerdict('Explain the mechanism.', 'Same question?', 'My rough answer.'),
+          'You wrote: «My rough answer.». Now: Explain the mechanism.'
+        );
+        assert.match(
+          verdictCopy({ classification: 'partial', userText: 'The query compares with keys.' }),
+          /Checked • Partly there •/
+        );
+        assert.match(
+          verdictCopy({ userText: 'The query compares with keys.', sedaComplete: true }),
+          /Checked • Recorded •/
+        );
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_html_escape_helper_matches_app_contract() -> None:
     result = run_node_module(
         """
@@ -1150,13 +1181,16 @@ def test_new_concept_field_has_unique_accessible_label() -> None:
 
     assert '<h1 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
     assert "What are you trying to explain?" in index_html
-    assert "Name a concept or question." in index_html
-    assert "Study stays hidden until you write first." in index_html
+    assert "Write what you remember first. We'll show what to study" in index_html
+    assert "You'll write first. Answers come after." in index_html
     assert 'id="ignition-boundary"' in index_html
     assert 'class="ig-eyebrow">New session</p>' in index_html
     assert "socratink will ask for your first model" not in index_html
     assert 'id="hero-single-input-field"' in index_html
+    assert 'id="hero-cold-guess-field"' in index_html
     assert 'aria-label="Learning goal"' in index_html
+    assert 'aria-label="What do you already think?"' in index_html
+    assert '>Start session</button>' in index_html
     assert 'aria-label="What do you want to explain?"' not in index_html
 
 

--- a/tests/test_seda_evidence_projection.py
+++ b/tests/test_seda_evidence_projection.py
@@ -132,6 +132,59 @@ def test_projection_is_idempotent_per_session() -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_latest_seda_attempt_event_projects_before_case_complete() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { projectLatestSedaAttemptEvent } from './public/js/seda-evidence-projection.js';
+
+        const first = projectLatestSedaAttemptEvent({
+          training: null,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-1',
+          now: '2026-07-09T05:00:00.000Z',
+          data: {
+            caseComplete: false,
+            events: [{
+              type: 'cold_attempt',
+              text: 'I think queries compare against keys.',
+              evaluation: {
+                classification: 'solid',
+                gaps: [],
+                grader_version: 'seda-test',
+              },
+            }],
+          },
+        });
+        const record = first.node_records.n;
+        assert.equal(record.attempts.length, 1);
+        assert.equal(record.attempts[0].id, 'seda-sess-1-event-0');
+        assert.equal(record.attempts[0].classification, 'strong');
+        assert.equal(record.attempts[0].kind, 'cold');
+        assert.equal(record.attempts[0].at, '2026-07-09T05:00:00.000Z');
+        assert.equal(record.study_revealed_at, undefined);
+
+        const repeat = projectLatestSedaAttemptEvent({
+          training: first,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-1',
+          data: {
+            events: [{
+              type: 'cold_attempt',
+              text: 'I think queries compare against keys.',
+              evaluation: { classification: 'solid', gaps: [] },
+            }],
+          },
+        });
+        assert.equal(repeat, null, 'same event must not duplicate attempts');
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_projection_returns_null_without_completed_record() -> None:
     result = run_node_module(
         """


### PR DESCRIPTION
## Summary
- Overhauls the first-session door and prompt-first chamber polish for a calmer learner-first flow.
- Preserves cold-guess evidence through source-less and source-attached starts, SEDA turns, visible verdicts, and study reveal.
- Adds focused browser/unit coverage for SEDA projection, verdict copy, source-attached door payloads, and mid-loop continue behavior.

## Verification
- python -m py_compile main.py
- node --check public/js/app.js public/js/drill-chamber.js public/js/concept-page-view.js public/js/launch-pad.js public/js/seda-evidence-projection.js public/js/drill-verdict.js
- .venv/bin/pytest -q --ignore=tests/e2e
- bash scripts/doctor.sh
- SOCRATINK_BASE_URL=http://127.0.0.1:8003 bash scripts/qa-smoke.sh
- SOCRATINK_BASE_URL=http://127.0.0.1:8004 bash scripts/check-coverage.sh

## Browser Proof
- Start learning -> cold guess -> chamber -> first answer -> verdict -> Keep going -> second answer -> study reveal completed locally.
- Proof artifacts saved under .qa-runs/final-flow/.