### PR TITLE
Ship first-session verdict and study handoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,21 @@ LEARNING_COMMONS_API_KEY=
 # or set SOCRATINK_LOCAL_AUTH_BYPASS=0, for prod parity locally.
 SOCRATINK_LOCAL_AUTH_BYPASS=
 SOCRATINK_DEV_AUTOGUEST=
-# Optional external loop backend for /loop and /health. Product /api/session/*
-# routes use the app-local/internal loop runtime instead.
+# External loop runtime. Required on Vercel for /api/session/* because the
+# Vercel Node function does not own a supported Python bridge runtime. Deploy
+# the vendored Node + Python loop as a trusted HTTPS service.
 # Example: https://loop-production-07a3.up.railway.app
 LOOP_BACKEND_URL=
+SOCRATINK_LOOP_API_KEY=
+# Set on the hosted loop service so it cannot fall back to a local file store.
+SOCRATINK_LOOP_SESSION_STORE=
+# Optional hosted loop-session expiry override. Default: 30 days. Local dev
+# continues to use SOCRATINK_LOOP_SESSION_STORE_DIR when set.
+SOCRATINK_LOOP_SESSION_TTL_SECONDS=2592000
+# Hosted bridge backpressure. Calls use non-blocking child processes so health
+# and other sessions stay responsive; excess work fails closed instead of
+# growing an unbounded queue.
+SOCRATINK_BRIDGE_TIMEOUT_MS=45000
+SOCRATINK_BRIDGE_MAX_CONCURRENCY=4
+SOCRATINK_BRIDGE_MAX_QUEUE=16
+SOCRATINK_BRIDGE_MAX_OUTPUT_BYTES=1048576

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -69,6 +69,7 @@ jobs:
       SUPABASE_JWT_SECRET: 'dummy-jwt-secret'
       APP_BASE_URL: 'http://localhost:8000'
       GEMINI_API_KEY: dummy-for-tests
+      SOCRATINK_TUI_FAKE_LLM: '1'
       SOCRATINK_BASE_URL: 'http://localhost:8000'
       SOCRATINK_E2E_LOCAL_GUEST: '1'
     steps:

--- a/Dockerfile.loop
+++ b/Dockerfile.loop
@@ -1,0 +1,38 @@
+FROM node:22-bookworm-slim AS node-runtime
+
+FROM python:3.14-slim-bookworm
+
+ENV NODE_ENV=production \
+    SOCRATINK_LOOP_SESSION_STORE=supabase \
+    HOST=0.0.0.0 \
+    PORT=8787 \
+    PYTHON=/app/.venv/bin/python \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates libatomic1 libstdc++6 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 socratink \
+    && useradd --system --uid 10001 --gid socratink --home-dir /app socratink
+
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+
+WORKDIR /app
+
+COPY requirements-loop.txt /tmp/requirements-loop.txt
+RUN python -m venv /app/.venv \
+    && /app/.venv/bin/pip install --no-cache-dir --requirement /tmp/requirements-loop.txt \
+    && rm /tmp/requirements-loop.txt
+
+COPY --chown=socratink:socratink loop-server.mjs bridge.py prompt_templates.py ./
+COPY --chown=socratink:socratink bridge_lib/ ./bridge_lib/
+COPY --chown=socratink:socratink lib/ ./lib/
+COPY --chown=socratink:socratink pedagogical_agents/contracts.json ./pedagogical_agents/contracts.json
+COPY --chown=socratink:socratink vendor/python/ ./vendor/python/
+
+USER socratink
+
+EXPOSE 8787
+
+CMD ["node", "loop-server.mjs"]

--- a/Dockerfile.loop.dockerignore
+++ b/Dockerfile.loop.dockerignore
@@ -1,0 +1,17 @@
+**
+!requirements-loop.txt
+!loop-server.mjs
+!bridge.py
+!prompt_templates.py
+!bridge_lib/
+!bridge_lib/**
+!lib/
+!lib/**
+!pedagogical_agents/
+!pedagogical_agents/contracts.json
+!vendor/
+!vendor/python/
+!vendor/python/**
+**/__pycache__/
+**/*.pyc
+**/*.pyo

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ The product doctrine is stable even while implementation is still moving:
   record projection.
 - `lib/loop-server/`
   HTTP wrapper around the SEDA runtime. `loop_backend_proxy.py` starts this
-  vendored runtime locally when `LOOP_BACKEND_URL` is not configured.
+  vendored runtime locally with a file session store. On Vercel, FastAPI
+  proxies learner sessions to a configured HTTPS loop service that can run
+  both Node and the Python bridge. The service uses the authenticated user's
+  Supabase token and `db/loop_sessions.sql`; it never falls back to serverless
+  temporary storage.
 - `bridge.py`, `bridge_lib/`, `vendor/python/`
   Python bridge seam used by the loop runtime for model calls and fake-loop
   fixtures. These are app-local vendored files; they must not depend on a
@@ -142,6 +146,77 @@ This repo keeps dependency management intentionally simple:
   Context Hub wrapper (`@aisuite/chub`); none of it ships to Vercel.
 - Keep the Python files flat: one pinned package per line, no `-r` includes,
   no hash blocks.
+
+### Hosted loop persistence
+
+Before deploying hosted `/api/session`, deploy the vendored loop runtime to a
+trusted HTTPS service that includes Node, Python and the bridge dependencies.
+Set `LOOP_BACKEND_URL` and the same `SOCRATINK_LOOP_API_KEY` on the Vercel app
+and loop service. Set `SOCRATINK_LOOP_SESSION_STORE=supabase` on the service.
+Apply `db/loop_sessions.sql` to Supabase. The service also needs `SUPABASE_URL`
+and `SUPABASE_PUBLISHABLE_KEY`.
+
+FastAPI forwards the sealed user's access token only to that configured loop
+origin. The loop service uses it for row-level security. It rejects insecure
+origins, and Vercel fails closed when the URL or loop API key is missing. Do
+not configure a Supabase service-role or secret key for this path.
+The proxy rejects bodies over 64 KiB, performs blocking HTTP work off the
+FastAPI event loop, disables automatic retries for learner POSTs, and bounds
+upstream connect/read waits at 5/55 seconds.
+
+Local development keeps the file store under
+`SOCRATINK_LOOP_SESSION_STORE_DIR` (or the operating-system temporary default).
+`SOCRATINK_LOOP_SESSION_TTL_SECONDS` may override the hosted 30-day session
+expiry. Production and Vercel fail closed when durable storage is unavailable.
+Schedule `public.purge_expired_loop_sessions()` once a day from a trusted
+Supabase database schedule so expired rows do not accumulate.
+
+This makes the loop event journal durable and account-scoped. Concepts and the
+app-shell training record are still browser `localStorage`; full cross-device
+learner continuity is not yet complete.
+
+For source-less Door starts, `/api/extract` now returns only a deterministic
+graph-neutral shell. It does not query Learning Commons or generate a route;
+the typed SEDA `sourceLessRoute` is the single authoritative route owner. This
+removes a duplicate model call from the first-session latency and cost path.
+
+### Loop service container
+
+`Dockerfile.loop` packages the existing Node loop server with the repo-pinned
+Python 3.14 bridge environment. `requirements-loop.txt` contains only the
+bridge's direct Python dependencies and keeps their versions aligned with the
+app runtime. The build context is allowlisted by
+`Dockerfile.loop.dockerignore`, so local `.env` files and other workspace files
+cannot enter the image.
+
+```bash
+docker build --file Dockerfile.loop --tag socratink-loop .
+docker run --rm --publish 8787:8787 \
+  --env SOCRATINK_LOOP_API_KEY \
+  --env SUPABASE_URL \
+  --env SUPABASE_PUBLISHABLE_KEY \
+  --env GEMINI_API_KEY \
+  socratink-loop
+```
+
+Inject those four variables at runtime through the hosting platform's secret
+store; do not pass secret values as Docker build arguments. The image sets
+`NODE_ENV=production`, `SOCRATINK_LOOP_SESSION_STORE=supabase`,
+`HOST=0.0.0.0`, and a default `PORT=8787`. A platform-provided `PORT` overrides
+that default. Configure the platform's process health probe to `GET /health`.
+That endpoint proves the process is up; an authenticated create-session smoke
+test is still required to prove Supabase access, row ownership, and the live
+model path.
+
+After deployment, set the app's `LOOP_BACKEND_URL` to the service's HTTPS
+origin and give the app the same `SOCRATINK_LOOP_API_KEY`. The service itself
+does not need `LOOP_BACKEND_URL`. Optional runtime tuning such as
+`SOCRATINK_LOOP_SESSION_TTL_SECONDS`, `LLM_MODEL`, and the bridge controls
+remain environment-only. The bridge runs non-blocking child processes with
+bounded defaults: `SOCRATINK_BRIDGE_TIMEOUT_MS=45000`,
+`SOCRATINK_BRIDGE_MAX_CONCURRENCY=4`, `SOCRATINK_BRIDGE_MAX_QUEUE=16`, and
+`SOCRATINK_BRIDGE_MAX_OUTPUT_BYTES=1048576`. Tune concurrency only after a
+hosted load test confirms CPU, memory, model quota, and database behavior.
 
 ### Deployment Validation
 

--- a/db/README.md
+++ b/db/README.md
@@ -2,3 +2,19 @@
 
 - `feedback.sql` — public feedback capture
 - `learner_state.sql` — auth-bound concepts + training continuity blob
+- `loop_sessions.sql` — RLS-scoped SEDA journals with expiry, bounded payloads,
+  a bounded recent turn-receipt history, and optimistic concurrency
+
+Hosted `/api/session` requires `loop_sessions.sql` to be applied. The trusted
+HTTPS loop service uses `SUPABASE_URL` plus `SUPABASE_PUBLISHABLE_KEY`; FastAPI
+forwards the authenticated user access token only to that configured origin.
+Do not configure a Supabase service-role or secret key for this path.
+
+Each session keeps at most 16 recent turn receipts under a 2 MiB database
+ceiling. This lets a delayed network retry replay its original response after a
+newer turn without letting receipt history grow without bound. Metadata-only
+updates preserve the receipts.
+
+Schedule `public.purge_expired_loop_sessions()` from a trusted Supabase database
+schedule. Application roles cannot execute it. The expiry index keeps the
+cleanup bounded, but rows are not removed until the schedule exists.

--- a/db/loop_sessions.sql
+++ b/db/loop_sessions.sql
@@ -1,0 +1,106 @@
+-- Durable, user-scoped app-local SEDA session journals.
+-- Apply in the Supabase SQL editor before enabling the hosted loop runtime.
+
+CREATE TABLE IF NOT EXISTS public.loop_sessions (
+    session_id UUID PRIMARY KEY,
+    user_id UUID NOT NULL DEFAULT auth.uid() REFERENCES auth.users (id) ON DELETE CASCADE,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    events JSONB NOT NULL DEFAULT '[]'::jsonb,
+    version BIGINT NOT NULL DEFAULT 0,
+    turn_receipts JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '30 days'),
+    CONSTRAINT loop_sessions_metadata_object
+        CHECK (
+            jsonb_typeof(metadata) = 'object'
+            AND octet_length(metadata::text) <= 262144
+        ),
+    CONSTRAINT loop_sessions_events_array
+        CHECK (
+            jsonb_typeof(events) = 'array'
+            AND jsonb_array_length(events) <= 128
+            AND octet_length(events::text) <= 524288
+        ),
+    CONSTRAINT loop_sessions_transcript_tail_bounded
+        CHECK (
+            NOT (metadata ? 'transcript_tail')
+            OR (
+                jsonb_typeof(metadata -> 'transcript_tail') = 'array'
+                AND jsonb_array_length(metadata -> 'transcript_tail') <= 80
+                AND octet_length((metadata -> 'transcript_tail')::text) <= 131072
+            )
+        ),
+    CONSTRAINT loop_sessions_version_nonnegative CHECK (version >= 0),
+    CONSTRAINT loop_sessions_turn_receipts_bounded
+        CHECK (
+            jsonb_typeof(turn_receipts) = 'array'
+            AND jsonb_array_length(turn_receipts) <= 16
+            AND octet_length(turn_receipts::text) <= 2097152
+        ),
+    CONSTRAINT loop_sessions_expiry_after_creation CHECK (expires_at > created_at)
+);
+
+ALTER TABLE public.loop_sessions ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.loop_sessions FROM PUBLIC, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.loop_sessions TO authenticated;
+
+DROP POLICY IF EXISTS "loop_sessions_select_own" ON public.loop_sessions;
+DROP POLICY IF EXISTS "loop_sessions_insert_own" ON public.loop_sessions;
+DROP POLICY IF EXISTS "loop_sessions_update_own" ON public.loop_sessions;
+DROP POLICY IF EXISTS "loop_sessions_delete_own" ON public.loop_sessions;
+
+CREATE POLICY "loop_sessions_select_own"
+ON public.loop_sessions
+FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+CREATE POLICY "loop_sessions_insert_own"
+ON public.loop_sessions
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "loop_sessions_update_own"
+ON public.loop_sessions
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "loop_sessions_delete_own"
+ON public.loop_sessions
+FOR DELETE
+TO authenticated
+USING (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS loop_sessions_user_id_idx
+ON public.loop_sessions (user_id);
+
+CREATE INDEX IF NOT EXISTS loop_sessions_expires_at_idx
+ON public.loop_sessions (expires_at);
+
+CREATE INDEX IF NOT EXISTS loop_sessions_user_updated_at_idx
+ON public.loop_sessions (user_id, updated_at DESC);
+
+-- Call this from a trusted Supabase database schedule. It is deliberately not
+-- executable by application roles.
+CREATE OR REPLACE FUNCTION public.purge_expired_loop_sessions()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    deleted_count INTEGER;
+BEGIN
+    DELETE FROM public.loop_sessions WHERE expires_at <= now();
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_expired_loop_sessions()
+FROM PUBLIC, anon, authenticated;

--- a/docs/design/seda-ui-state-alignment.md
+++ b/docs/design/seda-ui-state-alignment.md
@@ -68,9 +68,58 @@ The accepted north-star image applies to `write`. It is not the whole app shell.
   the next action can be routed.
 - Do not make the map the main surface during `write`; it is peripheral context.
 
+## Source-less route handoff
+
+The app opens the first composer only from the versioned session response
+contract, not by interpreting the raw SEDA event journal:
+
+```text
+sourceLessRoute.contractVersion = 1
+sourceLessRoute.status = ready
+awaiting.key = cold_attempt
+```
+
+`ready` carries the validated first node and provisional map. Backend route
+validation and frontend binding require the same fields, topology, and exactly
+one occurrence of the first node. A non-empty Door sketch may satisfy routing
+substrate only when the session was explicitly created with the source-less
+Door bootstrap option. That sketch remains graph-neutral and non-recordable.
+The preceding app-shell save persists a deterministic graph-neutral shell only;
+it performs no second model route generation. Until `ready`, learner copy says
+only `Preparing your first question…` and the composer remains closed.
+`route_status: pending_seda` plus `graph_neutral: true` is the durable recovery
+marker: reload may rebuild the route only while no attempt or repair evidence
+exists, and any shell-written draft stays unrecorded until the learner reviews
+the authoritative question.
+
+Route generation or contract failure returns typed `route_unavailable`. The
+composer stays closed and no evidence is projected. Recovery preserves the
+Door sketch:
+
+- no recorded evidence: discard only the stale route/session binding and build
+  a fresh first question;
+- any recorded evidence: return to the map without replacing the bound route or
+  its evidence.
+
+An unbound source-less map is eligible for automatic binding only when the
+current Door flow created it. Legacy unbound maps require an explicit recovery
+action, and any existing attempts or repairs force a return to the map. Once a
+route is bound, only that bound node may use its session.
+
+Each prompt response carries `sessionVersion`. Every submitted turn echoes that
+nonnegative version as `expectedVersion` and carries a UUID request ID. A
+transport retry reuses both values; a new learner submission gets a new ID. The
+server checks an idempotent replay before rejecting a stale version, then
+rejects a version mismatch before rehydrating or advancing the session. On a
+typed 409, the app fetches the current prompt, keeps the draft unrecorded, and
+requires the learner to submit it explicitly with a new ID and current version.
+
 ## Current implementation caveat
 
-The app-local SEDA path projects evidence only when `data.caseComplete` is true.
+The app-local SEDA path projects a recordable cold-attempt event before case
+completion so study can open after the first answer. Completed record
+projection later reconciles that event and re-stamps all attempts to the real
+sitting time; it must not append the cold answer twice or manufacture spacing.
 `public/js/seda-evidence-projection.js` re-stamps backend attempts to wall-clock
 time so one sitting cannot falsely derive `solidified`.
 

--- a/docs/product/first-session-momentum-spec.md
+++ b/docs/product/first-session-momentum-spec.md
@@ -93,21 +93,50 @@ IKEA/endowment, loss aversion, contrast). **Socratink-compatible** forms only.
 
 **Intent:** Reciprocity + post-drill contract. User must never submit an answer and get silence or a duplicate empty prompt.
 
+#### B0. Route-ready gate
+
+For a source-less Door session, the saved Door sketch is the graph-neutral
+launch attempt. The chamber composer opens only after the loop returns the
+versioned `sourceLessRoute` as `ready` and awaits `cold_attempt`. Raw loop events
+are audit data, not a frontend routing API.
+
+SEDA is the single authoritative route owner. The Door's `/api/extract` call
+validates the non-empty sketch and persists only a deterministic,
+learner-sketch-grounded shell (`route_owner: seda`, `graph_neutral: true`); it
+does not call Learning Commons or generate a second model route. While SEDA is
+working, the chamber shows `Preparing your first question…`, never the shell's
+provisional prompt.
+
+The shell marker is durable across reloads. A draft written after reload starts
+SEDA route recovery, remains unsubmitted against the newly generated question,
+and cannot fall through to `/api/drill`. If the pending shell already has
+attempt or repair evidence, recovery fails closed and preserves the old node
+keys instead of replacing them.
+
+If the route is unavailable or malformed, keep the composer closed and append
+no evidence. Tell the learner their starting sketch is saved. A fresh-route
+action is allowed only while no evidence exists; otherwise return to the map
+with existing evidence unchanged.
+
 #### B1. Verdict strip (≤2s after submit)
 
 Show inline below the active question / above composer (reuse `.drill-chamber__verdict`).
+If the final evaluation is still in flight after 1.2s, show the neutral pending
+strip `Answer received • Checking the link you wrote.`. Replace it with the
+final verdict on success and clear it on error. Pending copy must not diagnose,
+score, or reveal study content.
 
 **Copy pattern** (wise feedback; strategy not ability):
 
 ```
-Checked • {verdict_label} • {specific_gap_or_strength} • {next_step}
+Checked • {verdict_label} • {learner_line} • {controlled_next_step}
 ```
 
 | Classification / SEDA signal | `verdict_label` | Body pattern |
 | --- | --- | --- |
-| strong / solid | `Solid enough to compare` | "You named {X}. Study will show what to add." |
-| partial / thin | `Partly there` | "You have {X}. Missing link: {gap}." |
-| wrong_direction | `Wrong angle` | "You focused on {X}. The mechanism starts at {Y}." |
+| strong / solid | `Solid enough to compare` | "Your line: {learner snippet}. Study will show what to add." |
+| partial / thin | `Partly there` | "Your line: {learner snippet}. Study will target the missing link." |
+| wrong_direction | `Wrong angle` | "Your line: {learner snippet}. Study will show a different starting point." |
 | SEDA `continue` / repair keys | `Gap found` | "Study will target what you just exposed." |
 | case complete | `Recorded` | "Your attempt is on record. Study is ready." |
 
@@ -116,6 +145,11 @@ Checked • {verdict_label} • {specific_gap_or_strength} • {next_step}
 - Align with [`post-drill-ux-spec.md`](post-drill-ux-spec.md): no raw classifier badges; no score on cold path.
 - Do **not** show tier/band on first cold-adjacent check unless product spec already allows for spaced path only.
 - Verdict must reference **learner words** when `user_text` is available.
+- Do not render raw event evaluation, agent response, gap, correction, score,
+  or diagnostic prose before study reveal. Verdict language is controlled copy.
+- `Recorded` and a study CTA appear only after the app has persisted the local
+  attempt evidence. A projection failure keeps the same idempotent submission
+  available behind a neutral `Try saving again` action.
 
 #### B2. No same-question re-prompt
 
@@ -154,6 +188,8 @@ Never repeat the identical question string in the active prompt area after verdi
 - [ ] `See what to study` or `Reveal notes and compare` visible when routing permits study.
 - [ ] `tests/e2e/test_smoke.py` or new e2e: launch → drill → submit → expects verdict element.
 - [ ] Node contract test for `sedaTurnVerdict` / verdict copy mapping.
+- [ ] POST-launch and GET-rehydrate responses expose the same versioned ready route.
+- [ ] Missing/stale route recovery keeps the Door sketch and never replaces recorded evidence.
 
 ---
 

--- a/docs/project/state.md
+++ b/docs/project/state.md
@@ -9,10 +9,13 @@
 - Hosted runtime: Vercel serverless
 - Current persistence: concepts and app-shell training evidence are browser
   `localStorage` (`learnops_concepts`, `socratink:training:v1:<conceptId>`).
-  App-local SEDA sessions are also keyed from browser `localStorage`
-  (`socratink:seda-session:v1:<conceptId>`), while the loop runtime writes
-  session journals to its file session store (`SOCRATINK_LOOP_SESSION_STORE_DIR`
-  or the OS temp default). This is not Supabase-backed durable learner state.
+  The browser keeps the app-local SEDA resume pointer in `localStorage`
+  (`socratink:seda-session:v1:<conceptId>`). Locally, the loop runtime writes
+  journals to `SOCRATINK_LOOP_SESSION_STORE_DIR` or the OS temporary default.
+  On Vercel, FastAPI sends session calls to the configured HTTPS loop service;
+  its journals use the RLS-scoped Supabase `loop_sessions` table after
+  `db/loop_sessions.sql` is applied. Production does not fall back to `/tmp`.
+  This is durable session history, not complete cross-device learner state.
 - Evidence source of truth: live logs plus the operational docs in this repo
 
 ## Current Phase
@@ -20,8 +23,10 @@ The original thermostat starter-map MVP loop shipped. Per [ADR-0004](../adr/0004
 
 ## Active Risks
 - Hosted behavior may still diverge from local behavior.
-- `localStorage` and loop file-session persistence are fragile and easy to wipe;
-  they do not provide cross-browser or Supabase-backed resume continuity.
+- Browser concepts, training evidence, and SEDA resume pointers remain easy to
+  wipe and do not yet provide full cross-browser continuity. Hosted session
+  journals also remain unavailable until `db/loop_sessions.sql` is applied and
+  the trusted loop service is deployed and configured.
 - Chat/test instrumentation is incomplete, so some regressions will still be harder to reconstruct than they should be.
 - External ingestion paths still need defensive hosted behavior and graceful fallback.
 - Library shows only the user's own reconstructed work (ADR-0004); there are no checked-in Library fixtures. A first-run user may start source-less through Door -> Launch pad -> non-empty Launch attempt -> Smallest actionable route.
@@ -54,7 +59,8 @@ The original thermostat starter-map MVP loop shipped. Per [ADR-0004](../adr/0004
 
 ## Environment Lessons
 - Local success is not deployment validation.
-- Vercel serverless file writes are not durable release evidence; export Socratink Brain-marked runtime logs or use a durable store for hosted drill telemetry.
+- Vercel session durability depends on the RLS-scoped Supabase store and its
+  deployment-time schema/config proof; local file-store success is not enough.
 - Hosted YouTube transcript retrieval can fail because cloud/serverless IPs are blocked.
 - Manual transcript paste remains the hosted fallback.
 - External calls must be reviewed for SSRF risk and error leakage.

--- a/lib/bridge/client.mjs
+++ b/lib/bridge/client.mjs
@@ -1,11 +1,15 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { eventBuilders } from "../seda/event-facts.mjs";
 
 const MAX_DIAGNOSTIC_TEXT_CHARS = 20_000;
 const DEFAULT_BRIDGE_TIMEOUT_MS = 45_000;
+const DEFAULT_BRIDGE_MAX_CONCURRENCY = 4;
+const DEFAULT_BRIDGE_MAX_QUEUE = 16;
+const DEFAULT_BRIDGE_MAX_OUTPUT_BYTES = 1024 * 1024;
 const SECRET_ENV_KEYS = /(?:API|TOKEN|KEY|SECRET|PASSWORD|AUTH)/i;
+const bridgeLimiter = { active: 0, queue: [] };
 
 function truncate(value, limit = MAX_DIAGNOSTIC_TEXT_CHARS) {
   const text = String(value ?? "");
@@ -108,6 +112,67 @@ function normalizeTimeoutMs(raw) {
   return value;
 }
 
+function callTimeoutMs(raw, configuredTimeoutMs) {
+  if (raw == null || raw === "") return configuredTimeoutMs;
+  const requestedTimeoutMs = normalizeTimeoutMs(raw);
+  if (requestedTimeoutMs === 0) return configuredTimeoutMs;
+  if (configuredTimeoutMs === 0) return requestedTimeoutMs;
+  return Math.min(requestedTimeoutMs, configuredTimeoutMs);
+}
+
+function normalizeInteger(raw, fallback, { allowZero = false } = {}) {
+  if (raw == null || raw === "") return fallback;
+  const value = Number(raw);
+  const minimum = allowZero ? 0 : 1;
+  if (!Number.isInteger(value) || value < minimum) return fallback;
+  return value;
+}
+
+function releaseBridgeSlot() {
+  bridgeLimiter.active = Math.max(0, bridgeLimiter.active - 1);
+  const nextIndex = bridgeLimiter.queue.findIndex(
+    (waiter) => bridgeLimiter.active < waiter.maxConcurrency,
+  );
+  if (nextIndex < 0) return;
+  const [next] = bridgeLimiter.queue.splice(nextIndex, 1);
+  clearTimeout(next.timeoutHandle);
+  bridgeLimiter.active += 1;
+  next.resolve({ ok: true, release: releaseBridgeSlot });
+}
+
+function acquireBridgeSlot({ maxConcurrency, maxQueue, timeoutMs }) {
+  if (bridgeLimiter.active < maxConcurrency) {
+    bridgeLimiter.active += 1;
+    return Promise.resolve({ ok: true, release: releaseBridgeSlot });
+  }
+  if (bridgeLimiter.queue.length >= maxQueue) {
+    return Promise.resolve({
+      ok: false,
+      error: "BridgeBusy",
+      message: "bridge concurrency limit reached",
+    });
+  }
+  return new Promise((resolve) => {
+    const waiter = {
+      maxConcurrency,
+      resolve,
+      timeoutHandle: null,
+    };
+    if (timeoutMs > 0) {
+      waiter.timeoutHandle = setTimeout(() => {
+        const index = bridgeLimiter.queue.indexOf(waiter);
+        if (index >= 0) bridgeLimiter.queue.splice(index, 1);
+        resolve({
+          ok: false,
+          error: "BridgeTimeout",
+          message: `bridge subprocess timed out after ${timeoutMs}ms`,
+        });
+      }, timeoutMs);
+    }
+    bridgeLimiter.queue.push(waiter);
+  });
+}
+
 export function createBridgeClient({
   workspaceRoot,
   bridgePath,
@@ -115,33 +180,169 @@ export function createBridgeClient({
   envOverrides = null,
   diagnosticsDir = null,
   timeoutMs = process.env.SOCRATINK_BRIDGE_TIMEOUT_MS,
+  maxConcurrency = process.env.SOCRATINK_BRIDGE_MAX_CONCURRENCY,
+  maxQueue = process.env.SOCRATINK_BRIDGE_MAX_QUEUE,
+  maxOutputBytes = process.env.SOCRATINK_BRIDGE_MAX_OUTPUT_BYTES,
 }) {
   const bridgeTimeoutMs = normalizeTimeoutMs(timeoutMs);
+  const bridgeMaxConcurrency = normalizeInteger(
+    maxConcurrency,
+    DEFAULT_BRIDGE_MAX_CONCURRENCY,
+  );
+  const bridgeMaxQueue = normalizeInteger(
+    maxQueue,
+    DEFAULT_BRIDGE_MAX_QUEUE,
+    { allowZero: true },
+  );
+  const bridgeMaxOutputBytes = normalizeInteger(
+    maxOutputBytes,
+    DEFAULT_BRIDGE_MAX_OUTPUT_BYTES,
+  );
   const spawnEnv =
     envOverrides && Object.keys(envOverrides).length
       ? { ...process.env, ...envOverrides }
       : null;
-  function runBridge(action, payload) {
+  async function runBridge(action, payload, callOptions = {}) {
     const startedAt = Date.now();
-    const result = spawnSync(python, [bridgePath, action], {
-      cwd: workspaceRoot,
-      input: JSON.stringify(payload),
-      encoding: "utf8",
-      ...(bridgeTimeoutMs > 0
-        ? { timeout: bridgeTimeoutMs, killSignal: "SIGTERM" }
-        : {}),
-      ...(spawnEnv ? { env: spawnEnv } : {}),
+    const activeTimeoutMs = callTimeoutMs(
+      callOptions.timeoutMs,
+      bridgeTimeoutMs,
+    );
+    const slot = await acquireBridgeSlot({
+      maxConcurrency: bridgeMaxConcurrency,
+      maxQueue: bridgeMaxQueue,
+      timeoutMs: activeTimeoutMs,
     });
+    let slotError = null;
+    let result;
+    if (!slot.ok) {
+      slotError = slot;
+      result = {
+        status: null,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        timedOut: slot.error === "BridgeTimeout",
+        outputLimitExceeded: false,
+      };
+    } else {
+      const queuedMs = Date.now() - startedAt;
+      const processTimeoutMs = activeTimeoutMs > 0
+        ? Math.max(1, activeTimeoutMs - queuedMs)
+        : 0;
+      try {
+        result = await new Promise((resolve) => {
+          let stdout = "";
+          let stderr = "";
+          let stdoutBytes = 0;
+          let stderrBytes = 0;
+          let spawnError = null;
+          let timedOut = false;
+          let outputLimitExceeded = false;
+          let timeoutHandle = null;
+          let forceKillHandle = null;
+
+          const child = spawn(python, [bridgePath, action], {
+            cwd: workspaceRoot,
+            stdio: ["pipe", "pipe", "pipe"],
+            ...(spawnEnv ? { env: spawnEnv } : {}),
+          });
+          const terminateChild = () => {
+            child.kill("SIGTERM");
+            forceKillHandle ||= setTimeout(
+              () => child.kill("SIGKILL"),
+              1_000,
+            );
+          };
+          const appendOutput = (current, usedBytes, chunk) => {
+            const buffer = Buffer.from(chunk);
+            const remaining = Math.max(0, bridgeMaxOutputBytes - usedBytes);
+            const kept = buffer.subarray(0, remaining);
+            return {
+              text: current + kept.toString("utf8"),
+              bytes: usedBytes + kept.length,
+              exceeded: buffer.length > remaining,
+            };
+          };
+
+          child.stdout.setEncoding("utf8");
+          child.stderr.setEncoding("utf8");
+          child.stdout.on("data", (chunk) => {
+            const next = appendOutput(stdout, stdoutBytes, chunk);
+            stdout = next.text;
+            stdoutBytes = next.bytes;
+            if (next.exceeded && !outputLimitExceeded) {
+              outputLimitExceeded = true;
+              terminateChild();
+            }
+          });
+          child.stderr.on("data", (chunk) => {
+            const next = appendOutput(stderr, stderrBytes, chunk);
+            stderr = next.text;
+            stderrBytes = next.bytes;
+            if (next.exceeded && !outputLimitExceeded) {
+              outputLimitExceeded = true;
+              terminateChild();
+            }
+          });
+          child.on("error", (error) => {
+            spawnError = error;
+          });
+          child.stdin.on("error", (error) => {
+            if (error?.code !== "EPIPE") spawnError ||= error;
+          });
+          child.on("close", (status, signal) => {
+            if (timeoutHandle) clearTimeout(timeoutHandle);
+            if (forceKillHandle) clearTimeout(forceKillHandle);
+            resolve({
+              status,
+              signal,
+              stdout,
+              stderr: stderr || spawnError?.message || "",
+              timedOut,
+              outputLimitExceeded,
+            });
+          });
+
+          if (processTimeoutMs > 0) {
+            timeoutHandle = setTimeout(() => {
+              timedOut = true;
+              terminateChild();
+            }, processTimeoutMs);
+          }
+
+          child.stdin.end(JSON.stringify(payload));
+        });
+      } finally {
+        slot.release();
+      }
+    }
     const durationMs = Date.now() - startedAt;
-    const timedOut = result.error?.code === "ETIMEDOUT";
-    const transportError = timedOut
-      ? {
-          error: "BridgeTimeout",
-          message: `bridge subprocess timed out after ${bridgeTimeoutMs}ms`,
-          timeout_ms: bridgeTimeoutMs,
-          duration_ms: durationMs,
-        }
-      : null;
+    const timedOut = result.timedOut === true;
+    let transportError = null;
+    if (slotError) {
+      transportError = {
+        error: slotError.error,
+        message: slotError.message,
+        ...(slotError.error === "BridgeTimeout"
+          ? { timeout_ms: activeTimeoutMs }
+          : {}),
+        duration_ms: durationMs,
+      };
+    } else if (timedOut) {
+      transportError = {
+        error: "BridgeTimeout",
+        message: `bridge subprocess timed out after ${activeTimeoutMs}ms`,
+        timeout_ms: activeTimeoutMs,
+        duration_ms: durationMs,
+      };
+    } else if (result.outputLimitExceeded) {
+      transportError = {
+        error: "BridgeOutputTooLarge",
+        message: `bridge output exceeded ${bridgeMaxOutputBytes} bytes`,
+        duration_ms: durationMs,
+      };
+    }
     let parsed;
     try {
       parsed = JSON.parse(result.stdout || "{}");
@@ -159,7 +360,7 @@ export function createBridgeClient({
             spawnEnv,
             transportError,
             durationMs,
-            timeoutMs: bridgeTimeoutMs,
+            timeoutMs: activeTimeoutMs,
           })
         : null;
     return {
@@ -172,8 +373,8 @@ export function createBridgeClient({
     };
   }
 
-  function callBridge(action, payload) {
-    const result = runBridge(action, payload);
+  async function callBridge(action, payload, callOptions = {}) {
+    const result = await runBridge(action, payload, callOptions);
     if (result.transportError) {
       const bridgeError = new Error(result.transportError.message);
       bridgeError.error = result.transportError.error;
@@ -202,8 +403,8 @@ export function createBridgeClient({
     return result.parsed;
   }
 
-  function callBridgeResult(action, payload) {
-    const result = runBridge(action, payload);
+  async function callBridgeResult(action, payload, callOptions = {}) {
+    const result = await runBridge(action, payload, callOptions);
     if (result.transportError) {
       return {
         ok: false,
@@ -220,6 +421,7 @@ export function createBridgeClient({
         error: "BridgeNonJson",
         message: "bridge returned non-json output",
         diagnostic: result.diagnostic,
+        duration_ms: result.duration_ms,
       };
     }
     if (result.status !== 0) {
@@ -229,6 +431,7 @@ export function createBridgeClient({
         message:
           result.parsed.message || result.stderr || "bridge exited nonzero",
         diagnostic: result.diagnostic,
+        duration_ms: result.duration_ms,
       };
     }
     return { ok: true, payload: result.parsed };

--- a/lib/loop-public/loop.js
+++ b/lib/loop-public/loop.js
@@ -21,6 +21,8 @@ const sendButton = form.querySelector('button[type="submit"]');
 const sendButtonLabel = sendButton?.querySelector(".send-label");
 
 let sessionId = null;
+let sessionVersion = null;
+let pendingTurn = null;
 let busy = false;
 let lastPromptMarker = null;
 let currentAwaiting = null;
@@ -455,8 +457,32 @@ async function post(path, body) {
     body: JSON.stringify(body ?? {}),
   });
   const data = await res.json().catch(() => ({}));
-  if (!res.ok) throw new Error(data.error || res.statusText);
+  if (!res.ok) {
+    const error = new Error(data.message || data.error || res.statusText);
+    error.status = res.status;
+    error.body = data;
+    throw error;
+  }
   return data;
+}
+
+async function get(path) {
+  const res = await fetch(path, { headers: apiHeaders() });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const error = new Error(data.message || data.error || res.statusText);
+    error.status = res.status;
+    error.body = data;
+    throw error;
+  }
+  return data;
+}
+
+function requireSessionVersion(data) {
+  if (!Number.isInteger(data?.sessionVersion) || data.sessionVersion < 0) {
+    throw new Error('Loop response did not include a valid session version.');
+  }
+  return data.sessionVersion;
 }
 
 function llmPillLabel(llm) {
@@ -537,6 +563,7 @@ async function selectLlmOption(option) {
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error || res.statusText);
+      sessionVersion = requireSessionVersion(data);
     }
     setLlmSelection(llm);
     saveLlmPreference(llm);
@@ -627,6 +654,7 @@ async function refreshHealth() {
 }
 
 function applyTurnResponse(data) {
+  sessionVersion = requireSessionVersion(data);
   if (llmOverrideAllowed && data.llm_active?.provider && data.llm_active?.model) {
     setLlmSelection(data.llm_active);
   }
@@ -635,6 +663,8 @@ function applyTurnResponse(data) {
   if (data.complete) {
     appendChatLine("meta", "— session ended — type a concept to start a new session.");
     sessionId = null;
+    sessionVersion = null;
+    pendingTurn = null;
     showAwaitingPrompt({ label: "Concept: ", key: "concept" });
     setComposerEnabled(true);
     input.placeholder = "Pick a concept…";
@@ -675,20 +705,47 @@ async function sendTurn(text, options = {}) {
   await ensureSession();
   const phaseBeforeTurn = activePhaseSlug();
   busy = true;
-  if (options.appendUser !== false) {
-    appendChatLine("user", text, { force: true });
-  }
   lastPromptMarker = null;
   setBusy(true, phaseBeforeTurn);
   try {
-    const payload = options.emptyPayload ? {} : { text };
+    const turnText = options.emptyPayload ? null : text;
+    if (!pendingTurn || pendingTurn.text !== turnText) {
+      if (!Number.isInteger(sessionVersion) || sessionVersion < 0) {
+        throw new Error('This prompt is missing its session version.');
+      }
+      pendingTurn = {
+        text: turnText,
+        requestId: crypto.randomUUID(),
+        expectedVersion: sessionVersion,
+      };
+    }
+    const payload = {
+      requestId: pendingTurn.requestId,
+      expectedVersion: pendingTurn.expectedVersion,
+      ...(options.emptyPayload ? {} : { text: pendingTurn.text }),
+    };
     const data = await post(`/api/session/${sessionId}/turn`, payload);
+    if (options.appendUser !== false) {
+      appendChatLine("user", text, { force: true });
+    }
+    pendingTurn = null;
     busy = false;
     setBusy(false, data.phase ?? phasePill.dataset.phase);
     applyTurnResponse(data);
   } catch (error) {
     busy = false;
     setBusy(false);
+    if (error?.status === 409 && error?.body?.error === 'session_conflict') {
+      const latest = await get(`/api/session/${sessionId}`);
+      pendingTurn = null;
+      applyTurnResponse(latest);
+      const conflict = new Error(
+        'Session changed elsewhere. Review the current prompt, then send your draft again.',
+      );
+      conflict.status = 409;
+      conflict.awaiting = latest.awaiting;
+      throw conflict;
+    }
     throw error;
   }
 }
@@ -715,7 +772,9 @@ form.addEventListener("submit", async (event) => {
   } catch (error) {
     busy = false;
     appendChatLine("error", error.message || "Request failed.", { force: true });
-    showAwaitingPrompt(awaitingBeforeSubmit);
+    showAwaitingPrompt(error.awaiting || awaitingBeforeSubmit);
+    input.value = text;
+    resizeComposerInput();
     setBusy(false);
     setComposerEnabled(true);
     input.focus();

--- a/lib/loop-server/console-capture.mjs
+++ b/lib/loop-server/console-capture.mjs
@@ -1,46 +1,41 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 // eslint-disable-next-line no-control-regex -- strip terminal color codes
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const captureContext = new AsyncLocalStorage();
+const originals = {
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+};
+let installed = false;
 
 export function stripAnsi(text) {
   return String(text).replace(ANSI_RE, "");
 }
 
-export function captureConsole(sink) {
-  const original = {
-    log: console.log,
-    info: console.info,
-    warn: console.warn,
-    error: console.error,
-  };
+export function withConsoleCapture(sink, operation) {
+  installConsoleCapture();
+  return captureContext.run(sink, operation);
+}
 
-  function push(level, args) {
-    const line = args
-      .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
-      .join(" ");
-    sink.push({ level, text: stripAnsi(line) });
+function installConsoleCapture() {
+  if (installed) return;
+  installed = true;
+  for (const level of Object.keys(originals)) {
+    console[level] = (...args) => {
+      const sink = captureContext.getStore();
+      if (sink) sink.push({ level, text: formatLine(args) });
+      originals[level](...args);
+    };
   }
+}
 
-  console.log = (...args) => {
-    push("log", args);
-    original.log(...args);
-  };
-  console.info = (...args) => {
-    push("info", args);
-    original.info(...args);
-  };
-  console.warn = (...args) => {
-    push("warn", args);
-    original.warn(...args);
-  };
-  console.error = (...args) => {
-    push("error", args);
-    original.error(...args);
-  };
-
-  return () => {
-    console.log = original.log;
-    console.info = original.info;
-    console.warn = original.warn;
-    console.error = original.error;
-  };
+function formatLine(args) {
+  return stripAnsi(
+    args
+      .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+      .join(" "),
+  );
 }

--- a/lib/loop-server/http-server.mjs
+++ b/lib/loop-server/http-server.mjs
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,9 +9,14 @@ import {
   sessionResponse,
 } from "./session.mjs";
 import {
+  assertRequestId,
   createFileSessionStore,
+  defaultSessionStoreRoot,
+  durableSessionStoreRequired,
+  replayForRequest,
   SessionStoreError,
 } from "./session-store.mjs";
+import { createSupabaseSessionStore } from "./supabase-session-store.mjs";
 import { isFeedbackConfigured } from "../feedback/send.mjs";
 import { LOOP_APP_VERSION } from "./version.mjs";
 import {
@@ -31,10 +37,10 @@ const WORKSPACE_ROOT = paths.workspaceRoot;
 const LOOP_PUBLIC = process.env.SOCRATINK_LOOP_PUBLIC_DIR
   ? path.resolve(process.env.SOCRATINK_LOOP_PUBLIC_DIR)
   : path.join(WORKSPACE_ROOT, "lib/loop-public");
-const API_KEY = process.env.SOCRATINK_LOOP_API_KEY || "";
+const USER_ACCESS_TOKEN_HEADER = "x-socratink-user-access-token";
+const MAX_REQUEST_BODY_BYTES = 64 * 1024;
 
 const { lookup: agentLookup, contracts: agentContracts } = await loadAgentLookup();
-const defaultSessionStore = createFileSessionStore();
 
 function json(res, status, body) {
   res.writeHead(status, {
@@ -49,10 +55,17 @@ function unauthorized(res) {
 }
 
 function checkAuth(req, res) {
-  if (!API_KEY) return true;
+  const apiKey = String(process.env.SOCRATINK_LOOP_API_KEY || "").trim();
+  if (!apiKey) {
+    if (durableSessionStoreRequired(process.env)) {
+      json(res, 503, { error: "loop_api_key_required" });
+      return false;
+    }
+    return true;
+  }
   const header = req.headers.authorization || "";
   const token = header.startsWith("Bearer ") ? header.slice(7) : "";
-  if (token !== API_KEY) {
+  if (token !== apiKey) {
     unauthorized(res);
     return false;
   }
@@ -61,9 +74,20 @@ function checkAuth(req, res) {
 
 async function readJson(req) {
   const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > MAX_REQUEST_BODY_BYTES) {
+      throw new SessionStoreError("RequestTooLarge", "request body is too large");
+    }
+    chunks.push(chunk);
+  }
   if (!chunks.length) return {};
-  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    throw new SessionStoreError("InvalidJson", "request body must be valid JSON");
+  }
 }
 
 function contentType(filePath) {
@@ -101,10 +125,37 @@ async function serveStatic(req, res, options) {
 }
 
 export function createLoopServer() {
-  return createLoopServerWithStore({ sessionStore: defaultSessionStore });
+  return createLoopServerWithStore({
+    sessionStoreResolver: createSessionStoreResolver(),
+  });
 }
 
-export function createLoopServerWithStore({ sessionStore }) {
+export function createSessionStoreResolver({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const durableRequired = durableSessionStoreRequired(env);
+  const localStore = durableRequired
+    ? null
+    : createFileSessionStore({ rootDir: defaultSessionStoreRoot(env) });
+  return function resolveSessionStore(req) {
+    if (localStore) return localStore;
+    return createSupabaseSessionStore({
+      supabaseUrl: env.SUPABASE_URL || "",
+      publishableKey: env.SUPABASE_PUBLISHABLE_KEY || "",
+      accessToken: singleHeader(req.headers[USER_ACCESS_TOKEN_HEADER]),
+      fetchImpl,
+      sessionTtlSeconds: env.SOCRATINK_LOOP_SESSION_TTL_SECONDS,
+    });
+  };
+}
+
+export function createLoopServerWithStore({
+  sessionStore = null,
+  sessionStoreResolver = null,
+  createSession = createSessionState,
+  advance = advanceSession,
+} = {}) {
   return http.createServer(async (req, res) => {
     try {
       const url = req.url?.split("?")[0] || "/";
@@ -141,8 +192,20 @@ export function createLoopServerWithStore({ sessionStore }) {
 
       if (!checkAuth(req, res)) return;
 
+      const resolveStore = () => {
+        const resolved = sessionStore || sessionStoreResolver?.(req);
+        if (!resolved) {
+          throw new SessionStoreError(
+            "StoreConfigurationError",
+            "loop session storage is not configured",
+          );
+        }
+        return resolved;
+      };
+
       if (req.method === "POST" && url === "/api/session") {
         const payload = await readJson(req);
+        const sourceLessDoorBootstrap = payload.sourceLessDoorBootstrap === true;
         let llm = null;
         if (payload.llm && isModelOverrideAllowed(req)) {
           const validated = validateLlmSelection(payload.llm);
@@ -152,18 +215,20 @@ export function createLoopServerWithStore({ sessionStore }) {
           }
           llm = validated.llm;
         }
+        const sessionStore = resolveStore();
         const sessionId = crypto.randomUUID();
         const bridgeDiagnosticsDir = sessionStore.rootDir
           ? path.join(sessionStore.rootDir, sessionId, "bridge-diagnostics")
           : null;
-        const session = await createSessionState({
+        const session = await createSession({
           agentLookup,
           agentContracts,
           id: sessionId,
           llm,
           bridgeDiagnosticsDir,
+          sourceLessDoorBootstrap,
         });
-        await sessionStore.create(session.id, {
+        const created = await sessionStore.create(session.id, {
           status: session.status,
           phase: session.phase,
           awaiting: session.awaiting,
@@ -171,13 +236,18 @@ export function createLoopServerWithStore({ sessionStore }) {
           caseComplete: false,
           llm,
           bridgeDiagnosticsDir,
+          sourceLessDoorBootstrap,
         });
         const eventStart = session.events.length;
-        const body = await advanceSession(session);
+        const body = {
+          ...await advance(session),
+          sessionVersion: created.version + 1,
+        };
         await sessionStore.appendEvents(
           session.id,
           session.events.slice(eventStart),
           { ...body, bridgeDiagnosticsDir },
+          { expectedVersion: created.version },
         );
         json(res, 201, body);
         return;
@@ -189,6 +259,7 @@ export function createLoopServerWithStore({ sessionStore }) {
           json(res, 403, { error: "model override not allowed" });
           return;
         }
+        const sessionStore = resolveStore();
         const stored = await loadStoredSession(sessionStore, llmMatch[1], res);
         if (!stored) return;
         const payload = await readJson(req);
@@ -197,37 +268,75 @@ export function createLoopServerWithStore({ sessionStore }) {
           json(res, 400, { error: validated.error });
           return;
         }
-        await sessionStore.updateMetadata(llmMatch[1], { llm: validated.llm });
-        json(res, 200, { llm: validated.llm });
+        const updated = await sessionStore.updateMetadata(
+          llmMatch[1],
+          { llm: validated.llm },
+          { expectedVersion: stored.version },
+        );
+        json(res, 200, { llm: validated.llm, sessionVersion: updated.version });
         return;
       }
 
       const turnMatch = url.match(/^\/api\/session\/([^/]+)\/turn$/);
       if (req.method === "POST" && turnMatch) {
+        const sessionStore = resolveStore();
         const stored = await loadStoredSession(sessionStore, turnMatch[1], res);
         if (!stored) return;
+        const payload = await readJson(req);
+        const requestId = assertRequestId(payload.requestId);
+        if (!requestId) {
+          throw new SessionStoreError(
+            "InvalidRequestId",
+            "requestId is required for every session turn",
+          );
+        }
+        const requestHash = turnRequestHash(payload);
+        const replayedResponse = replayForRequest(stored, requestId, requestHash);
+        if (replayedResponse) {
+          json(res, 200, replayedResponse);
+          return;
+        }
+        const expectedVersion = assertExpectedVersion(payload.expectedVersion);
+        if (expectedVersion !== stored.version) {
+          const conflict = new SessionStoreError(
+            "SessionConflict",
+            "session changed after this prompt was shown",
+          );
+          conflict.currentVersion = stored.version;
+          throw conflict;
+        }
         const session = await loadSessionStateFromStore({
           stored,
           res,
           agentLookup,
           agentContracts,
+          createSession,
         });
         if (!session) return;
         applyEmptyJournalMetadata(session, stored);
-        const payload = await readJson(req);
         const eventStart = session.events.length;
-        const body = await advanceSession(session, payload.text);
-        await sessionStore.appendEvents(
+        const body = {
+          ...await advance(session, payload.text),
+          sessionVersion: expectedVersion + 1,
+        };
+        const committed = await sessionStore.appendEvents(
           session.id,
           session.events.slice(eventStart),
           body,
+          {
+            expectedVersion,
+            requestId,
+            requestHash,
+            response: body,
+          },
         );
-        json(res, 200, body);
+        json(res, 200, committed.replayedResponse || body);
         return;
       }
 
       const getMatch = url.match(/^\/api\/session\/([^/]+)$/);
       if (req.method === "GET" && getMatch) {
+        const sessionStore = resolveStore();
         const stored = await loadStoredSession(sessionStore, getMatch[1], res);
         if (!stored) return;
         const session = await loadSessionStateFromStore({
@@ -235,22 +344,24 @@ export function createLoopServerWithStore({ sessionStore }) {
           res,
           agentLookup,
           agentContracts,
+          createSession,
         });
         if (!session) return;
         applyEmptyJournalMetadata(session, stored);
         session.status = stored.metadata.status || session.status;
         session.awaiting = stored.metadata.awaiting || session.awaiting;
         await materializeSessionRecord(session);
-        json(res, 200, sessionResponse(session, stored.metadata.transcript_tail || []));
+        json(res, 200, {
+          ...sessionResponse(session, stored.metadata.transcript_tail || []),
+          sessionVersion: stored.version,
+        });
         return;
       }
 
       json(res, 404, { error: "not found" });
     } catch (error) {
       console.error(error);
-      json(res, 500, {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      writeRequestError(res, error);
     }
   });
 }
@@ -260,15 +371,19 @@ async function loadSessionStateFromStore({
   res,
   agentLookup,
   agentContracts,
+  createSession = createSessionState,
 }) {
   try {
-    return await createSessionState({
+    return await createSession({
       agentLookup,
       agentContracts,
       id: stored.sessionId,
       events: stored.events,
       llm: stored.metadata.llm || null,
       bridgeDiagnosticsDir: stored.metadata.bridge_diagnostics_dir || null,
+      sourceLessDoorBootstrap: Boolean(
+        stored.metadata.source_less_door_bootstrap,
+      ),
     });
   } catch (error) {
     if (error instanceof CannotRehydrateSession) {
@@ -298,12 +413,80 @@ async function loadStoredSession(sessionStore, sessionId, res) {
     return await sessionStore.load(sessionId);
   } catch (error) {
     if (error instanceof SessionStoreError) {
-      const status = error.code === "SessionNotFound" ? 404 : 400;
-      json(res, status, { error: error.message });
-      return null;
+      if (error.code === "SessionNotFound") {
+        json(res, 404, { error: "session_not_found" });
+        return null;
+      }
+      if (error.code === "InvalidSessionId") {
+        json(res, 400, { error: error.message, code: error.code });
+        return null;
+      }
     }
     throw error;
   }
+}
+
+function turnRequestHash(payload) {
+  return createHash("sha256")
+    .update(JSON.stringify({
+      text: payload.text ?? null,
+      expectedVersion: payload.expectedVersion ?? null,
+    }))
+    .digest("hex");
+}
+
+function assertExpectedVersion(value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new SessionStoreError(
+      "InvalidExpectedVersion",
+      "expectedVersion must be a nonnegative integer",
+    );
+  }
+  return value;
+}
+
+function singleHeader(value) {
+  return Array.isArray(value) ? value[0] : String(value || "");
+}
+
+function writeRequestError(res, error) {
+  if (!(error instanceof SessionStoreError)) {
+    json(res, 500, { error: "internal_error" });
+    return;
+  }
+  if (["SessionConflict", "IdempotencyConflict"].includes(error.code)) {
+    json(res, 409, {
+      error: "session_conflict",
+      code: error.code,
+      message: error.message,
+      ...(Number.isInteger(error.currentVersion)
+        ? { currentVersion: error.currentVersion }
+        : {}),
+    });
+    return;
+  }
+  if (error.code === "SessionNotFound") {
+    json(res, 404, { error: "session_not_found" });
+    return;
+  }
+  if (error.code === "StoreAuthenticationRequired") {
+    json(res, 401, { error: "session_auth_required" });
+    return;
+  }
+  if (["StoreConfigurationError", "StoreUnavailable"].includes(error.code)) {
+    json(res, 503, { error: "session_store_unavailable", code: error.code });
+    return;
+  }
+  if ([
+    "RequestTooLarge",
+    "SessionEventsLimitExceeded",
+    "SessionMetadataLimitExceeded",
+    "SessionResponseLimitExceeded",
+  ].includes(error.code)) {
+    json(res, 413, { error: "session_limit_exceeded", code: error.code });
+    return;
+  }
+  json(res, 400, { error: error.message, code: error.code });
 }
 
 export function startLoopServer(port = Number(process.env.PORT || 8787), host = process.env.HOST || "") {

--- a/lib/loop-server/runtime.mjs
+++ b/lib/loop-server/runtime.mjs
@@ -47,6 +47,7 @@ export async function createSessionState({
   id = null,
   events = null,
   llm = null,
+  sourceLessDoorBootstrap = false,
   bridgeDiagnosticsDir = null,
 }) {
   const bridge = sessionBridgeWithDiagnostics({ llm, diagnosticsDir: bridgeDiagnosticsDir });
@@ -87,6 +88,7 @@ export async function createSessionState({
       logRawLlm: false,
       loopUi: true,
       loopUiPacing: "one_beat",
+      sourceLessDoorBootstrap: sourceLessDoorBootstrap === true,
     },
   };
 }

--- a/lib/loop-server/session-store.mjs
+++ b/lib/loop-server/session-store.mjs
@@ -5,6 +5,17 @@ import path from "node:path";
 const SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+export const SESSION_STORE_LIMITS = Object.freeze({
+  events: 128,
+  eventBytes: 512 * 1024,
+  transcriptEntries: 80,
+  transcriptBytes: 128 * 1024,
+  metadataBytes: 256 * 1024,
+  replayResponseBytes: 768 * 1024,
+  receiptEntries: 16,
+  receiptBytes: 2_000_000,
+});
+
 export class SessionStoreError extends Error {
   constructor(code, message) {
     super(message);
@@ -20,17 +31,209 @@ export function defaultSessionStoreRoot(env = process.env) {
   );
 }
 
+export function durableSessionStoreRequired(env = process.env) {
+  return Boolean(
+    env.VERCEL
+    || env.VERCEL_ENV
+    || String(env.NODE_ENV || "").toLowerCase() === "production"
+    || String(env.SOCRATINK_LOOP_SESSION_STORE || "").toLowerCase() === "supabase"
+  );
+}
+
+export function assertSessionId(sessionId) {
+  if (!SESSION_ID_PATTERN.test(String(sessionId || ""))) {
+    throw new SessionStoreError("InvalidSessionId", "invalid session id");
+  }
+}
+
+export function assertRequestId(requestId) {
+  if (requestId == null || requestId === "") return null;
+  if (!SESSION_ID_PATTERN.test(String(requestId))) {
+    throw new SessionStoreError("InvalidRequestId", "requestId must be a UUID");
+  }
+  return String(requestId).toLowerCase();
+}
+
+export function replayForRequest(stored, requestId, requestHash) {
+  const normalizedRequestId = assertRequestId(requestId);
+  if (!normalizedRequestId) return null;
+  const receipts = normalizeReceipts(stored.receipts || []);
+  const receipt = [...receipts]
+    .reverse()
+    .find((candidate) => candidate.request_id === normalizedRequestId);
+  if (!receipt) return null;
+  if (!requestHash || receipt.request_hash !== requestHash) {
+    throw new SessionStoreError(
+      "IdempotencyConflict",
+      "requestId was already used with a different turn payload",
+    );
+  }
+  return receipt.response;
+}
+
+export function buildSessionCommit({
+  stored,
+  addedEvents,
+  metadata = {},
+  expectedVersion,
+  requestId = null,
+  requestHash = null,
+  response = null,
+  updatedAt,
+}) {
+  if (!Array.isArray(addedEvents)) {
+    throw new SessionStoreError("InvalidEvents", "events must be an array");
+  }
+  const normalizedRequestId = assertRequestId(requestId);
+  const replayedResponse = replayForRequest(stored, normalizedRequestId, requestHash);
+  if (replayedResponse) return { replayedResponse };
+  if (
+    expectedVersion != null
+    && Number(expectedVersion) !== Number(stored.version)
+  ) {
+    throw new SessionStoreError("SessionConflict", "session version changed");
+  }
+
+  if (
+    normalizedRequestId
+    && (typeof requestHash !== "string" || !requestHash || response == null)
+  ) {
+    throw new SessionStoreError(
+      "InvalidRequestId",
+      "requestId requires a payload hash and replay response",
+    );
+  }
+
+  const events = [...stored.events, ...addedEvents];
+  assertJsonArrayBounds(events, {
+    maxEntries: SESSION_STORE_LIMITS.events,
+    maxBytes: SESSION_STORE_LIMITS.eventBytes,
+    code: "SessionEventsLimitExceeded",
+  });
+  if (response != null) {
+    assertJsonBytes(
+      response,
+      SESSION_STORE_LIMITS.replayResponseBytes,
+      "SessionResponseLimitExceeded",
+    );
+  }
+  const receipts = normalizedRequestId
+    ? appendBoundedReceipt(stored.receipts || [], {
+        request_id: normalizedRequestId,
+        request_hash: requestHash,
+        response,
+      })
+    : normalizeReceipts(stored.receipts || []);
+
+  const transcriptTail = boundTranscript([
+    ...(stored.metadata.transcript_tail || []),
+    ...(Array.isArray(metadata.transcript) ? metadata.transcript : []),
+  ]);
+  const nextVersion = Number(stored.version) + 1;
+  const nextMetadata = {
+    ...stored.metadata,
+    session_id: stored.sessionId,
+    created_at: stored.metadata.created_at || updatedAt,
+    updated_at: updatedAt,
+    event_count: events.length,
+    version: nextVersion,
+    status: metadata.status || stored.metadata.status || "active",
+    phase: metadata.phase ?? stored.metadata.phase ?? null,
+    awaiting: metadata.awaiting ?? stored.metadata.awaiting ?? null,
+    transcript_tail: transcriptTail,
+    complete: Boolean(metadata.complete ?? stored.metadata.complete),
+    case_complete: Boolean(metadata.caseComplete ?? stored.metadata.case_complete),
+    llm: metadata.llm_active ?? stored.metadata.llm ?? null,
+    bridge_diagnostics_dir:
+      metadata.bridgeDiagnosticsDir
+      ?? stored.metadata.bridge_diagnostics_dir
+      ?? null,
+  };
+  assertJsonBytes(
+    nextMetadata,
+    SESSION_STORE_LIMITS.metadataBytes,
+    "SessionMetadataLimitExceeded",
+  );
+
+  return {
+    events,
+    metadata: nextMetadata,
+    version: nextVersion,
+    receipts,
+  };
+}
+
+export function normalizeReceipts(value) {
+  if (!Array.isArray(value)) {
+    throw new SessionStoreError(
+      "StoreUnavailable",
+      "session receipt history is invalid",
+    );
+  }
+  const receipts = value.map((receipt) => {
+    if (
+      !receipt
+      || typeof receipt !== "object"
+      || typeof receipt.request_hash !== "string"
+      || !receipt.request_hash
+      || receipt.response == null
+    ) {
+      throw new SessionStoreError(
+        "StoreUnavailable",
+        "session receipt history is invalid",
+      );
+    }
+    let requestId;
+    try {
+      requestId = assertRequestId(receipt.request_id);
+    } catch {
+      throw new SessionStoreError(
+        "StoreUnavailable",
+        "session receipt history is invalid",
+      );
+    }
+    assertJsonBytes(
+      receipt.response,
+      SESSION_STORE_LIMITS.replayResponseBytes,
+      "StoreUnavailable",
+    );
+    return {
+      request_id: requestId,
+      request_hash: receipt.request_hash,
+      response: receipt.response,
+    };
+  });
+  assertJsonArrayBounds(receipts, {
+    maxEntries: SESSION_STORE_LIMITS.receiptEntries,
+    maxBytes: SESSION_STORE_LIMITS.receiptBytes,
+    code: "StoreUnavailable",
+  });
+  return receipts;
+}
+
+function appendBoundedReceipt(existing, receipt) {
+  const receipts = [...normalizeReceipts(existing), receipt]
+    .slice(-SESSION_STORE_LIMITS.receiptEntries);
+  while (
+    receipts.length > 1
+    && jsonBytes(receipts) > SESSION_STORE_LIMITS.receiptBytes
+  ) {
+    receipts.shift();
+  }
+  assertJsonArrayBounds(receipts, {
+    maxEntries: SESSION_STORE_LIMITS.receiptEntries,
+    maxBytes: SESSION_STORE_LIMITS.receiptBytes,
+    code: "SessionReceiptsLimitExceeded",
+  });
+  return receipts;
+}
+
 export function createFileSessionStore({
   rootDir = defaultSessionStoreRoot(),
   now = () => new Date().toISOString(),
 } = {}) {
   const root = path.resolve(rootDir);
-
-  function assertSessionId(sessionId) {
-    if (!SESSION_ID_PATTERN.test(String(sessionId || ""))) {
-      throw new SessionStoreError("InvalidSessionId", "invalid session id");
-    }
-  }
+  const locks = new Map();
 
   function sessionDir(sessionId) {
     assertSessionId(sessionId);
@@ -42,26 +245,38 @@ export function createFileSessionStore({
   }
 
   async function create(sessionId, metadata = {}) {
-    const dir = sessionDir(sessionId);
-    await fs.mkdir(root, { recursive: true });
-    await fs.mkdir(dir, { recursive: false });
-    const createdAt = now();
-    await writeJson(path.join(dir, "metadata.json"), {
-      session_id: sessionId,
-      created_at: createdAt,
-      updated_at: createdAt,
-      event_count: 0,
-      status: metadata.status || "active",
-      phase: metadata.phase || "idle",
-      awaiting: metadata.awaiting || null,
-      transcript_tail: [],
-      complete: Boolean(metadata.complete),
-      case_complete: Boolean(metadata.caseComplete),
-      llm: metadata.llm || null,
-      bridge_diagnostics_dir: metadata.bridgeDiagnosticsDir || null,
+    return withSessionLock(sessionId, async () => {
+      const dir = sessionDir(sessionId);
+      await fs.mkdir(root, { recursive: true });
+      try {
+        await fs.mkdir(dir, { recursive: false });
+      } catch (error) {
+        if (error?.code === "EEXIST") {
+          throw new SessionStoreError("SessionConflict", "session already exists");
+        }
+        throw error;
+      }
+      const createdAt = now();
+      await writeJson(path.join(dir, "metadata.json"), {
+        session_id: sessionId,
+        created_at: createdAt,
+        updated_at: createdAt,
+        event_count: 0,
+        version: 0,
+        status: metadata.status || "active",
+        phase: metadata.phase || "idle",
+        awaiting: metadata.awaiting || null,
+        transcript_tail: [],
+        complete: Boolean(metadata.complete),
+        case_complete: Boolean(metadata.caseComplete),
+        llm: metadata.llm || null,
+        bridge_diagnostics_dir: metadata.bridgeDiagnosticsDir || null,
+        source_less_door_bootstrap: metadata.sourceLessDoorBootstrap === true,
+        turn_receipts: [],
+      });
+      await fs.writeFile(path.join(dir, "events.jsonl"), "", { flag: "wx" });
+      return load(sessionId);
     });
-    await fs.writeFile(path.join(dir, "events.jsonl"), "", { flag: "wx" });
-    return load(sessionId);
   }
 
   async function load(sessionId) {
@@ -76,7 +291,14 @@ export function createFileSessionStore({
         .map((line) => line.trim())
         .filter(Boolean)
         .map((line) => JSON.parse(line));
-      return { sessionId, metadata, events };
+      const { turn_receipts: turnReceipts = [], ...sessionMetadata } = metadata;
+      return {
+        sessionId,
+        metadata: sessionMetadata,
+        events,
+        version: Number(sessionMetadata.version || 0),
+        receipts: normalizeReceipts(turnReceipts),
+      };
     } catch (error) {
       if (error?.code === "ENOENT") {
         throw new SessionStoreError("SessionNotFound", "session not found");
@@ -131,49 +353,70 @@ export function createFileSessionStore({
     return { deleted_count: deletedCount };
   }
 
-  async function appendEvents(sessionId, events, metadata = {}) {
-    const dir = sessionDir(sessionId);
-    if (!Array.isArray(events)) {
-      throw new SessionStoreError("InvalidEvents", "events must be an array");
-    }
-    await fs.mkdir(dir, { recursive: true });
-    if (events.length) {
-      const lines = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
-      await fs.appendFile(path.join(dir, "events.jsonl"), lines, "utf8");
-    }
-    const existing = await load(sessionId);
-    const transcriptTail = [
-      ...(existing.metadata.transcript_tail || []),
-      ...(Array.isArray(metadata.transcript) ? metadata.transcript : []),
-    ].slice(-200);
-    await writeJson(path.join(dir, "metadata.json"), {
-      session_id: sessionId,
-      created_at: existing.metadata.created_at || now(),
-      updated_at: now(),
-      event_count: existing.events.length,
-      status: metadata.status || existing.metadata.status || "active",
-      phase: metadata.phase ?? existing.metadata.phase ?? null,
-      awaiting: metadata.awaiting ?? existing.metadata.awaiting ?? null,
-      transcript_tail: transcriptTail,
-      complete: Boolean(metadata.complete),
-      case_complete: Boolean(metadata.caseComplete),
-      llm: metadata.llm_active ?? existing.metadata.llm ?? null,
-      bridge_diagnostics_dir:
-        metadata.bridgeDiagnosticsDir ?? existing.metadata.bridge_diagnostics_dir ?? null,
+  async function appendEvents(sessionId, events, metadata = {}, commit = {}) {
+    return withSessionLock(sessionId, async () => {
+      const dir = sessionDir(sessionId);
+      const existing = await load(sessionId);
+      const mutation = buildSessionCommit({
+        stored: existing,
+        addedEvents: events,
+        metadata,
+        ...commit,
+        updatedAt: now(),
+      });
+      if (mutation.replayedResponse) {
+        return { ...existing, replayedResponse: mutation.replayedResponse };
+      }
+      if (events.length) {
+        const lines = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+        await fs.appendFile(path.join(dir, "events.jsonl"), lines, "utf8");
+      }
+      await writeJson(path.join(dir, "metadata.json"), {
+        ...mutation.metadata,
+        turn_receipts: mutation.receipts,
+      });
+      return load(sessionId);
     });
-    return load(sessionId);
   }
 
-  async function updateMetadata(sessionId, partial) {
-    const dir = sessionDir(sessionId);
-    const existing = await load(sessionId);
-    await writeJson(path.join(dir, "metadata.json"), {
-      ...existing.metadata,
-      ...partial,
-      session_id: sessionId,
-      updated_at: now(),
+  async function updateMetadata(sessionId, partial, { expectedVersion } = {}) {
+    return withSessionLock(sessionId, async () => {
+      const dir = sessionDir(sessionId);
+      const existing = await load(sessionId);
+      if (
+        expectedVersion != null
+        && Number(expectedVersion) !== Number(existing.version)
+      ) {
+        throw new SessionStoreError("SessionConflict", "session version changed");
+      }
+      await writeJson(path.join(dir, "metadata.json"), {
+        ...existing.metadata,
+        ...partial,
+        session_id: sessionId,
+        version: existing.version + 1,
+        updated_at: now(),
+        turn_receipts: existing.receipts,
+      });
+      return load(sessionId);
     });
-    return load(sessionId);
+  }
+
+  async function withSessionLock(sessionId, operation) {
+    assertSessionId(sessionId);
+    const previous = locks.get(sessionId) || Promise.resolve();
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+    const current = previous.then(() => gate);
+    locks.set(sessionId, current);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (locks.get(sessionId) === current) locks.delete(sessionId);
+    }
   }
 
   return {
@@ -186,6 +429,41 @@ export function createFileSessionStore({
     updateMetadata,
     assertSessionId,
   };
+}
+
+function assertJsonArrayBounds(value, { maxEntries, maxBytes, code }) {
+  if (value.length > maxEntries) {
+    throw new SessionStoreError(code, "session event limit exceeded");
+  }
+  assertJsonBytes(value, maxBytes, code);
+}
+
+function assertJsonBytes(value, maxBytes, code) {
+  if (jsonBytes(value) > maxBytes) {
+    throw new SessionStoreError(code, "session payload limit exceeded");
+  }
+}
+
+function jsonBytes(value) {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function boundTranscript(entries) {
+  const bounded = entries
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return entry;
+      if (typeof entry.text !== "string" || entry.text.length <= 8_000) return entry;
+      return { ...entry, text: entry.text.slice(0, 8_000) };
+    })
+    .slice(-SESSION_STORE_LIMITS.transcriptEntries);
+  while (
+    bounded.length
+    && Buffer.byteLength(JSON.stringify(bounded), "utf8")
+      > SESSION_STORE_LIMITS.transcriptBytes
+  ) {
+    bounded.shift();
+  }
+  return bounded;
 }
 
 async function readJson(filePath) {

--- a/lib/loop-server/session.mjs
+++ b/lib/loop-server/session.mjs
@@ -1,7 +1,7 @@
 import { handleFeedbackCommand } from "../feedback/handle.mjs";
 import { enrichAwaiting } from "./awaiting-cta.mjs";
 import { isExitCommand, isFeedbackCommand } from "../seda/prompt-commands.mjs";
-import { captureConsole } from "./console-capture.mjs";
+import { withConsoleCapture } from "./console-capture.mjs";
 import { PROMPT_REQUIRED } from "./errors.mjs";
 import { createHttpPrompt } from "./http-prompt.mjs";
 import { filterLearnerTranscript } from "./learner-transcript.mjs";
@@ -13,6 +13,7 @@ import {
 } from "../seda/session-record.mjs";
 import { FINAL_NOW } from "../seda/constants.mjs";
 import { summarizeTraining } from "../seda/training-summary.mjs";
+import { validateRoutePayload } from "../seda/bridge-fail-closed.mjs";
 import {
   getHostedLoopPacingStop,
   isHostedLoopPacingEnabled,
@@ -40,42 +41,41 @@ export async function materializeSessionRecord(session) {
 
 export async function advanceSession(session, userText) {
   const transcript = [];
-  const restore = captureConsole(transcript);
-  const trimmedUserText = userText == null ? "" : String(userText).trim();
-  const isOptionalLearnerGoalSkip =
-    trimmedUserText === ""
-    && (
-      session.awaiting?.key === "learner_goal"
-      || (
-        session.phase === "ignition"
-        && session.ctx?.learnerGoal === null
-        && session.ctx?.launchAttempt === null
-      )
-    );
+  return withConsoleCapture(transcript, async () => {
+    const trimmedUserText = userText == null ? "" : String(userText).trim();
+    const isOptionalLearnerGoalSkip =
+      trimmedUserText === ""
+      && (
+        session.awaiting?.key === "learner_goal"
+        || (
+          session.phase === "ignition"
+          && session.ctx?.learnerGoal === null
+          && session.ctx?.launchAttempt === null
+        )
+      );
 
-  if (
-    userText != null
-    && (trimmedUserText !== "" || isOptionalLearnerGoalSkip)
-  ) {
-    const trimmed = trimmedUserText;
-    if (isFeedbackCommand(trimmed)) {
-      await handleFeedbackCommand(trimmed, session);
-      session.transcript.push(...transcript);
-      return sessionResponse(session, transcript);
+    if (
+      userText != null
+      && (trimmedUserText !== "" || isOptionalLearnerGoalSkip)
+    ) {
+      const trimmed = trimmedUserText;
+      if (isFeedbackCommand(trimmed)) {
+        await handleFeedbackCommand(trimmed, session);
+        session.transcript.push(...transcript);
+        return sessionResponse(session, transcript);
+      }
+      if (isExitCommand(trimmed)) {
+        session.events.push(eventBuilders.idleExit());
+        session.phase = null;
+        session.status = "complete";
+        session.awaiting = null;
+        console.log("[Idle] Session ended.");
+        session.transcript.push(...transcript);
+        return sessionResponse(session, transcript);
+      }
+      session.pendingInput = trimmed;
     }
-    if (isExitCommand(trimmed)) {
-      session.events.push(eventBuilders.idleExit());
-      session.phase = null;
-      session.status = "complete";
-      session.awaiting = null;
-      console.log("[Idle] Session ended.");
-      session.transcript.push(...transcript);
-      return sessionResponse(session, transcript);
-    }
-    session.pendingInput = trimmed;
-  }
 
-  try {
     let stoppedForPacing = false;
     session.phase = session.phase ?? "idle";
     const prompt = createHttpPrompt({
@@ -147,9 +147,7 @@ export async function advanceSession(session, userText) {
       agentContracts: session.ctx.agentContracts,
     });
     return sessionResponse(session, transcript);
-  } finally {
-    restore();
-  }
+  });
 }
 
 export function isCaseComplete(events = []) {
@@ -183,6 +181,7 @@ export function sessionResponse(session, delta) {
     status: session.status,
     phase: session.phase,
     awaiting,
+    sourceLessRoute: sourceLessRouteResult(session.events, awaiting),
     transcript,
     learnerTranscript: filterLearnerTranscript(transcript, awaiting?.ctaText),
     events: session.events,
@@ -192,5 +191,55 @@ export function sessionResponse(session, delta) {
     complete: session.status === "complete",
     caseComplete: isCaseComplete(session.events),
     record: session.record ?? null,
+  };
+}
+
+export const SOURCE_LESS_ROUTE_CONTRACT_VERSION = 1;
+
+/**
+ * Stable app-facing route handoff. Raw events remain available for audit and
+ * replay, but clients do not need to interpret the journal to open a route.
+ */
+export function sourceLessRouteResult(events = [], awaiting = null) {
+  const launchIndex = events.findLastIndex((event) => event?.type === "launch_attempt");
+  if (launchIndex < 0) return null;
+
+  const routeIndex = events.findLastIndex((event) => event?.type === "route_generated");
+  const routeFailureIndex = events.findLastIndex(
+    (event) => event?.type === "bridge_error"
+      && event?.phase === "route"
+      && event?.action === "generate-route",
+  );
+  if (routeFailureIndex > routeIndex) {
+    return unavailableSourceLessRoute("generation_failed");
+  }
+  if (awaiting?.key === "substrate_refinement") return null;
+  if (routeIndex < launchIndex) {
+    return unavailableSourceLessRoute("missing_route");
+  }
+
+  const event = events[routeIndex];
+  const invalid = validateRoutePayload({
+    first_node: event.first_node,
+    provisional_map: event.provisional_map,
+  });
+  if (invalid) return unavailableSourceLessRoute("invalid_route_contract");
+  if (awaiting?.key !== "cold_attempt") return null;
+
+  return {
+    contractVersion: SOURCE_LESS_ROUTE_CONTRACT_VERSION,
+    status: "ready",
+    firstNode: event.first_node,
+    provisionalMap: event.provisional_map,
+  };
+}
+
+function unavailableSourceLessRoute(reason) {
+  return {
+    contractVersion: SOURCE_LESS_ROUTE_CONTRACT_VERSION,
+    status: "route_unavailable",
+    code: "route_unavailable",
+    reason,
+    retryable: true,
   };
 }

--- a/lib/loop-server/supabase-session-store.mjs
+++ b/lib/loop-server/supabase-session-store.mjs
@@ -1,0 +1,328 @@
+import {
+  assertSessionId,
+  buildSessionCommit,
+  normalizeReceipts,
+  replayForRequest,
+  SessionStoreError,
+} from "./session-store.mjs";
+
+const DEFAULT_SESSION_TTL_SECONDS = 60 * 60 * 24 * 30;
+const MAX_RECENT_SESSIONS = 50;
+
+export function createSupabaseSessionStore({
+  supabaseUrl = process.env.SUPABASE_URL,
+  publishableKey = process.env.SUPABASE_PUBLISHABLE_KEY,
+  accessToken,
+  fetchImpl = globalThis.fetch,
+  now = () => new Date().toISOString(),
+  sessionTtlSeconds = Number(
+    process.env.SOCRATINK_LOOP_SESSION_TTL_SECONDS || DEFAULT_SESSION_TTL_SECONDS,
+  ),
+} = {}) {
+  const baseUrl = String(supabaseUrl || "").trim().replace(/\/+$/, "");
+  const apiKey = String(publishableKey || "").trim();
+  const userToken = String(accessToken || "").trim();
+  if (!baseUrl || !apiKey) {
+    throw new SessionStoreError(
+      "StoreConfigurationError",
+      "durable loop storage requires Supabase URL and publishable key",
+    );
+  }
+  if (!userToken) {
+    throw new SessionStoreError(
+      "StoreAuthenticationRequired",
+      "durable loop storage requires an authenticated user token",
+    );
+  }
+  if (isServiceRoleKey(apiKey)) {
+    throw new SessionStoreError(
+      "StoreConfigurationError",
+      "loop storage must use a Supabase publishable key",
+    );
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new SessionStoreError(
+      "StoreConfigurationError",
+      "durable loop storage requires fetch",
+    );
+  }
+  const ttlSeconds = boundedTtl(sessionTtlSeconds);
+  const tableUrl = `${baseUrl}/rest/v1/loop_sessions`;
+
+  async function request(path = "", options = {}) {
+    let response;
+    try {
+      response = await fetchImpl(`${tableUrl}${path}`, {
+        ...options,
+        signal: options.signal || AbortSignal.timeout(10_000),
+        headers: {
+          apikey: apiKey,
+          authorization: `Bearer ${userToken}`,
+          "content-type": "application/json",
+          ...(options.headers || {}),
+        },
+      });
+    } catch (error) {
+      throw new SessionStoreError(
+        "StoreUnavailable",
+        "durable loop storage is unavailable",
+      );
+    }
+
+    let text;
+    try {
+      text = await response.text();
+    } catch {
+      throw new SessionStoreError(
+        "StoreUnavailable",
+        "durable loop storage response failed",
+      );
+    }
+    const body = text ? safeJson(text) : null;
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new SessionStoreError(
+          "StoreAuthenticationRequired",
+          "durable loop storage rejected the user session",
+        );
+      }
+      if (response.status === 409) {
+        throw new SessionStoreError("SessionConflict", "session version changed");
+      }
+      throw new SessionStoreError(
+        "StoreUnavailable",
+        "durable loop storage request failed",
+      );
+    }
+    return body;
+  }
+
+  async function create(sessionId, metadata = {}) {
+    assertSessionId(sessionId);
+    const createdAt = now();
+    const rows = await request("", {
+      method: "POST",
+      headers: { prefer: "return=representation" },
+      body: JSON.stringify({
+        session_id: sessionId,
+        metadata: initialMetadata(sessionId, metadata, createdAt),
+        events: [],
+        version: 0,
+        turn_receipts: [],
+        expires_at: expiresAt(createdAt, ttlSeconds),
+      }),
+    });
+    return normalizeSingleRow(rows, sessionId);
+  }
+
+  async function load(sessionId) {
+    assertSessionId(sessionId);
+    const query = new URLSearchParams({
+      select:
+        "session_id,metadata,events,version,turn_receipts,expires_at",
+      session_id: `eq.${sessionId}`,
+      limit: "1",
+    });
+    const rows = await request(`?${query}`);
+    const stored = normalizeSingleRow(rows, sessionId, { missingOk: true });
+    if (!stored || Date.parse(stored.expiresAt) <= Date.parse(now())) {
+      throw new SessionStoreError("SessionNotFound", "session not found");
+    }
+    return stored;
+  }
+
+  async function listRecent({ limit = 12 } = {}) {
+    const boundedLimit = Math.max(0, Math.min(MAX_RECENT_SESSIONS, Number(limit) || 0));
+    if (!boundedLimit) return [];
+    const query = new URLSearchParams({
+      select:
+        "session_id,metadata,events,version,turn_receipts,expires_at",
+      expires_at: `gt.${now()}`,
+      order: "updated_at.desc",
+      limit: String(boundedLimit),
+    });
+    const rows = await request(`?${query}`);
+    return Array.isArray(rows) ? rows.map(normalizeRow) : [];
+  }
+
+  async function clearReports() {
+    const rows = await request("?session_id=not.is.null", {
+      method: "DELETE",
+      headers: { prefer: "return=representation" },
+    });
+    return { deleted_count: Array.isArray(rows) ? rows.length : 0 };
+  }
+
+  async function appendEvents(sessionId, events, metadata = {}, commit = {}) {
+    if (commit.expectedVersion == null) {
+      throw new SessionStoreError(
+        "InvalidExpectedVersion",
+        "durable session writes require an expected version",
+      );
+    }
+    const stored = await load(sessionId);
+    const mutation = buildSessionCommit({
+      stored,
+      addedEvents: events,
+      metadata,
+      ...commit,
+      updatedAt: now(),
+    });
+    if (mutation.replayedResponse) {
+      return { ...stored, replayedResponse: mutation.replayedResponse };
+    }
+
+    const rows = await casPatch(sessionId, commit.expectedVersion, {
+      metadata: mutation.metadata,
+      events: mutation.events,
+      version: mutation.version,
+      turn_receipts: mutation.receipts,
+      updated_at: mutation.metadata.updated_at,
+      expires_at: expiresAt(mutation.metadata.updated_at, ttlSeconds),
+    });
+    if (Array.isArray(rows) && rows.length) return normalizeRow(rows[0]);
+
+    const winner = await load(sessionId);
+    const replayedResponse = replayForRequest(
+      winner,
+      commit.requestId,
+      commit.requestHash,
+    );
+    if (replayedResponse) return { ...winner, replayedResponse };
+    throw new SessionStoreError("SessionConflict", "session version changed");
+  }
+
+  async function updateMetadata(sessionId, partial, { expectedVersion } = {}) {
+    if (expectedVersion == null) {
+      throw new SessionStoreError(
+        "InvalidExpectedVersion",
+        "durable session writes require an expected version",
+      );
+    }
+    const stored = await load(sessionId);
+    if (Number(stored.version) !== Number(expectedVersion)) {
+      throw new SessionStoreError("SessionConflict", "session version changed");
+    }
+    const updatedAt = now();
+    const version = stored.version + 1;
+    const rows = await casPatch(sessionId, expectedVersion, {
+      metadata: {
+        ...stored.metadata,
+        ...partial,
+        session_id: sessionId,
+        version,
+        updated_at: updatedAt,
+      },
+      version,
+      updated_at: updatedAt,
+      expires_at: expiresAt(updatedAt, ttlSeconds),
+    });
+    if (!Array.isArray(rows) || !rows.length) {
+      throw new SessionStoreError("SessionConflict", "session version changed");
+    }
+    return normalizeRow(rows[0]);
+  }
+
+  async function casPatch(sessionId, expectedVersion, values) {
+    const query = new URLSearchParams({
+      session_id: `eq.${sessionId}`,
+      version: `eq.${expectedVersion}`,
+    });
+    return request(`?${query}`, {
+      method: "PATCH",
+      headers: { prefer: "return=representation" },
+      body: JSON.stringify(values),
+    });
+  }
+
+  return {
+    rootDir: null,
+    create,
+    load,
+    listRecent,
+    clearReports,
+    appendEvents,
+    updateMetadata,
+    assertSessionId,
+  };
+}
+
+function initialMetadata(sessionId, metadata, createdAt) {
+  return {
+    session_id: sessionId,
+    created_at: createdAt,
+    updated_at: createdAt,
+    event_count: 0,
+    version: 0,
+    status: metadata.status || "active",
+    phase: metadata.phase || "idle",
+    awaiting: metadata.awaiting || null,
+    transcript_tail: [],
+    complete: Boolean(metadata.complete),
+    case_complete: Boolean(metadata.caseComplete),
+    llm: metadata.llm || null,
+    bridge_diagnostics_dir: null,
+    source_less_door_bootstrap: metadata.sourceLessDoorBootstrap === true,
+  };
+}
+
+function normalizeSingleRow(rows, sessionId, { missingOk = false } = {}) {
+  if (!Array.isArray(rows) || !rows.length) {
+    if (missingOk) return null;
+    throw new SessionStoreError("SessionNotFound", "session not found");
+  }
+  return normalizeRow(rows[0], sessionId);
+}
+
+function normalizeRow(row, expectedSessionId = null) {
+  const sessionId = String(row?.session_id || "");
+  assertSessionId(sessionId);
+  if (expectedSessionId && sessionId !== expectedSessionId) {
+    throw new SessionStoreError("StoreUnavailable", "durable loop storage returned bad data");
+  }
+  if (!row.metadata || !Array.isArray(row.events)) {
+    throw new SessionStoreError("StoreUnavailable", "durable loop storage returned bad data");
+  }
+  const version = Number(row.version || 0);
+  return {
+    sessionId,
+    metadata: { ...row.metadata, version },
+    events: row.events,
+    version,
+    receipts: normalizeReceipts(row.turn_receipts || []),
+    expiresAt: row.expires_at || "",
+  };
+}
+
+function boundedTtl(value) {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds)) return DEFAULT_SESSION_TTL_SECONDS;
+  return Math.max(60 * 60, Math.min(60 * 60 * 24 * 365, Math.floor(seconds)));
+}
+
+function expiresAt(timestamp, ttlSeconds) {
+  return new Date(Date.parse(timestamp) + ttlSeconds * 1000).toISOString();
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new SessionStoreError(
+      "StoreUnavailable",
+      "durable loop storage returned an invalid response",
+    );
+  }
+}
+
+function isServiceRoleKey(key) {
+  if (key.startsWith("sb_secret_")) return true;
+  const parts = key.split(".");
+  if (parts.length !== 3) return false;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    return payload?.role === "service_role";
+  } catch {
+    return false;
+  }
+}

--- a/lib/seda/bridge-fail-closed.mjs
+++ b/lib/seda/bridge-fail-closed.mjs
@@ -4,11 +4,17 @@ const SAFE_ERROR_MESSAGES = {
   BridgeNonJson: "bridge returned non-json output",
   BridgeExitNonZero: "bridge exited nonzero",
   BridgeTimeout: "bridge subprocess timed out",
+  BridgeBusy: "bridge is busy; try again",
+  BridgeOutputTooLarge: "bridge output exceeded its safe limit",
   BridgeContractInvalid: "bridge response failed contract validation",
 };
 
 function clean(value) {
   return String(value ?? "").trim();
+}
+
+function cleanString(value) {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function isObject(value) {
@@ -49,10 +55,10 @@ export function bridgeErrorEvent({
   });
 }
 
-export function callBridgeSafely({ bridge, action, payload }) {
+export async function callBridgeSafely({ bridge, action, payload }) {
   if (typeof bridge.callBridgeResult === "function") {
     try {
-      const result = bridge.callBridgeResult(action, payload);
+      const result = await bridge.callBridgeResult(action, payload);
       if (result && typeof result.ok === "boolean") return result;
     } catch (error) {
       if (typeof bridge.callBridge !== "function") {
@@ -66,7 +72,7 @@ export function callBridgeSafely({ bridge, action, payload }) {
     }
   }
   try {
-    return { ok: true, payload: bridge.callBridge(action, payload) };
+    return { ok: true, payload: await bridge.callBridge(action, payload) };
   } catch (error) {
     return {
       ok: false,
@@ -128,12 +134,33 @@ export function validateSubstrateGatePayload(payload) {
 
 export function validateRoutePayload(route) {
   if (!isObject(route)) return "missing route object";
-  if (!isObject(route.provisional_map)) return "missing provisional_map object";
-  if (!isObject(route.first_node)) return "missing first_node object";
-  if (!clean(route.first_node.id)) return "missing first_node.id";
-  if (!clean(route.first_node.learner_prompt)) {
-    return "missing first_node.learner_prompt";
+  const routeMap = route.provisional_map;
+  const firstNode = route.first_node;
+  if (!isObject(routeMap)) return "missing provisional_map object";
+  if (!isObject(firstNode)) return "missing first_node object";
+  for (const field of ["id", "label", "learner_prompt", "mechanism"]) {
+    if (!cleanString(firstNode[field])) return `missing first_node.${field}`;
   }
+  if (!Array.isArray(routeMap.backbone) || routeMap.backbone.length === 0) {
+    return "provisional_map.backbone must be non-empty";
+  }
+  if (!Array.isArray(routeMap.clusters)) {
+    return "provisional_map.clusters must be an array";
+  }
+
+  const firstNodeId = cleanString(firstNode.id);
+  const backboneMatches = routeMap.backbone.filter(
+    (node) => cleanString(node?.id) === firstNodeId,
+  ).length;
+  const subnodeMatches = routeMap.clusters.reduce(
+    (total, cluster) => total + (Array.isArray(cluster?.subnodes)
+      ? cluster.subnodes.filter((node) => cleanString(node?.id) === firstNodeId).length
+      : 0),
+    0,
+  );
+  const matches = backboneMatches + subnodeMatches;
+  if (matches === 0) return "first_node.id is absent from provisional_map";
+  if (matches > 1) return "first_node.id is duplicated in provisional_map";
   return null;
 }
 

--- a/lib/seda/handlers/cold-attempt.mjs
+++ b/lib/seda/handlers/cold-attempt.mjs
@@ -28,7 +28,7 @@ export async function handleColdAttempt({
   console.log("");
   console.log(ctx.section("cold", "Cold Attempt"));
   const coldAttempt = await prompt.ask("cold_attempt", "First question: ");
-  const coldResult = callBridgeSafely({
+  const coldResult = await callBridgeSafely({
     bridge,
     action: "evaluate-attempt",
     payload: {

--- a/lib/seda/handlers/delta.mjs
+++ b/lib/seda/handlers/delta.mjs
@@ -30,7 +30,7 @@ export async function handleDelta({ events, derived, store, bridge, options, ctx
     );
     ctx.zeroSchemaCold = false;
   }
-  const scaffoldCallResult = callBridgeSafely({
+  const scaffoldCallResult = await callBridgeSafely({
     bridge,
     action: "repair-scaffold",
     payload: {
@@ -77,7 +77,7 @@ export async function handleDelta({ events, derived, store, bridge, options, ctx
     ctx.coldAttemptText,
   );
   const scaffold = scaffoldReview.scaffold;
-  const drillCallResult = callBridgeSafely({
+  const drillCallResult = await callBridgeSafely({
     bridge,
     action: "socratic-repair-drill",
     payload: {

--- a/lib/seda/handlers/post-bridge-transfer.mjs
+++ b/lib/seda/handlers/post-bridge-transfer.mjs
@@ -52,7 +52,7 @@ export async function handlePostBridgeTransfer({
   const pressurePrompt = "Transfer check: ";
   const gapAttempt = await prompt.ask("gap_attempt", pressurePrompt);
   const repairEv = events.findLast((e) => e.type === "repair");
-  const gapResult = callBridgeSafely({
+  const gapResult = await callBridgeSafely({
     bridge,
     action: "evaluate-attempt",
     payload: {

--- a/lib/seda/handlers/repair-dialogue.mjs
+++ b/lib/seda/handlers/repair-dialogue.mjs
@@ -197,7 +197,7 @@ export async function handleRepairDialogue({ events, bridge, prompt, options, ct
     return { llm_calls: sessionLlmCalls };
   }
 
-  const dialogueResult = callBridgeSafely({
+  const dialogueResult = await callBridgeSafely({
     bridge,
     action: "repair-dialogue",
     payload: buildRepairDialogueBridgeArgs(ctx, repair, turnIndex, options),

--- a/lib/seda/handlers/repair-recovery.mjs
+++ b/lib/seda/handlers/repair-recovery.mjs
@@ -46,7 +46,7 @@ export async function handleRepairRecovery({ events, bridge, prompt, options, ct
     return { llm_calls: [] };
   }
 
-  const dialogueResult = callBridgeSafely({
+  const dialogueResult = await callBridgeSafely({
     bridge,
     action: "repair-dialogue",
     payload: buildRepairDialogueBridgeArgs(ctx, repairText, turnIndex, options),

--- a/lib/seda/handlers/route.mjs
+++ b/lib/seda/handlers/route.mjs
@@ -13,12 +13,12 @@ function latestSubstrateAdequacy(events) {
   return adequacy === "minimal" ? "minimal" : "adequate";
 }
 
-export function handleRoute({ events, bridge, options, ctx }) {
+export async function handleRoute({ events, bridge, options, ctx }) {
   console.log("");
   console.log(ctx.section("route", "Route"));
   console.log("Generating Smallest actionable route...");
   const substrateAdequacy = latestSubstrateAdequacy(events);
-  const routeResult = generateRouteWithRetry({
+  const routeResult = await generateRouteWithRetry({
     callBridgeResult: bridge.callBridgeResult,
     concept: ctx.concept,
     learnerGoal: ctx.learnerGoal,

--- a/lib/seda/handlers/spaced-redrill.mjs
+++ b/lib/seda/handlers/spaced-redrill.mjs
@@ -33,7 +33,7 @@ export async function handleSpacedRedrill({
     usage: { input_tokens: 0, output_tokens: 0 },
   });
   const spacedAttempt = await prompt.ask("spaced_attempt", "Memory check: ");
-  const spacedResult = callBridgeSafely({
+  const spacedResult = await callBridgeSafely({
     bridge,
     action: "evaluate-attempt",
     payload: {

--- a/lib/seda/handlers/substrate-gate.mjs
+++ b/lib/seda/handlers/substrate-gate.mjs
@@ -40,7 +40,7 @@ function latestEvent(events, type) {
   return events.findLast((event) => event.type === type);
 }
 
-function callSubstrateBridge({
+async function callSubstrateBridge({
   bridge,
   ctx,
   options,
@@ -48,7 +48,7 @@ function callSubstrateBridge({
   seedOffered,
   refinementText = "",
 }) {
-  const result = callBridgeSafely({
+  const result = await callBridgeSafely({
     bridge,
     action: "substrate-gate",
     payload: {
@@ -125,6 +125,10 @@ function substrateComposerText(seedText, refinementPrompt) {
   return `${seedText}\n\n${refinementPrompt}`;
 }
 
+function doorSketchCanRouteImmediately(options, launchText) {
+  return options.sourceLessDoorBootstrap === true && clean(launchText).length > 0;
+}
+
 /**
  * Bridge-backed substrate gate. The bridge judges adequacy; this handler owns
  * the hybrid policy cap: one seed, one refinement, then conservative routing.
@@ -145,7 +149,17 @@ export async function handleSubstrateGate({
   let refinementEvent = latestEvent(events, "substrate_refinement");
 
   if (!seedEvent && !refinementEvent) {
-    const gateResult = callSubstrateBridge({
+    if (doorSketchCanRouteImmediately(options, launchText)) {
+      // The product Door already required a generative commitment. Route from
+      // that learner-owned sketch without paying for a second adequacy call.
+      // This remains graph-neutral and never counts as training evidence.
+      events.push(substrateConfirmedEvent("minimal", {
+        classification: "minimal",
+        judge_reason: "Non-empty source-less Door sketch supplied.",
+      }));
+      return { llm_calls: llmCalls };
+    }
+    const gateResult = await callSubstrateBridge({
       bridge,
       ctx,
       options,
@@ -192,7 +206,7 @@ export async function handleSubstrateGate({
     refinementEvent = latestEvent(events, "substrate_refinement");
   }
 
-  const gateResult = callSubstrateBridge({
+  const gateResult = await callSubstrateBridge({
     bridge,
     ctx,
     options,

--- a/lib/seda/route-generation.mjs
+++ b/lib/seda/route-generation.mjs
@@ -8,55 +8,9 @@ import {
   validateRoutePayload,
 } from "./bridge-fail-closed.mjs";
 
-function fallbackRoute({ concept, learnerGoal, launchAttempt }) {
-  const label = String(concept || "Concept").trim() || "Concept";
-  const thesis = learnerGoal || `Explain the basic mechanism behind ${label}.`;
-  return {
-    provisional_map: {
-      metadata: { core_thesis: thesis },
-      backbone: [
-        {
-          id: "b1",
-          principle: "A process changes a starting state into an outcome.",
-          dependent_clusters: ["c1"],
-        },
-      ],
-      clusters: [
-        {
-          id: "c1",
-          label,
-          subnodes: [
-            {
-              id: "c1_s1",
-              label,
-              learner_scaffold: {
-                task_label: "Explain the before-change-after mechanism",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    first_node: {
-      id: "c1_s1",
-      kc_id: "c1_s1",
-      label,
-      mechanism: launchAttempt || thesis,
-      learner_prompt:
-        "Explain the before state, the change, and the result in your own words.",
-      evidence_goal:
-        "Learner reconstructs the before-change-after mechanism without answer leakage.",
-    },
-    llm_call: {
-      provider: "orchestrator",
-      model: "route-fallback",
-      latency_ms: 0,
-      usage: { input_tokens: 0, output_tokens: 0 },
-    },
-  };
-}
+const ROUTE_ATTEMPT_TIMEOUT_MS = 25_000;
 
-export function generateRouteWithRetry({
+export async function generateRouteWithRetry({
   callBridgeResult,
   concept,
   learnerGoal,
@@ -69,15 +23,21 @@ export function generateRouteWithRetry({
   const retryReasons = [];
   const maxAttempts = 2;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const result = callBridgeResult("generate-route", {
-      concept,
-      learner_goal: learnerGoal || null,
-      launch_attempt: launchAttempt,
-      substrate_adequacy: substrateAdequacy,
-      log_raw_llm: logRawLlm,
-      route_attempt: attempt,
-      route_retry_reason: retryReasons.at(-1)?.message || null,
-    });
+    const result = await callBridgeResult(
+      "generate-route",
+      {
+        concept,
+        learner_goal: learnerGoal || null,
+        launch_attempt: launchAttempt,
+        substrate_adequacy: substrateAdequacy,
+        log_raw_llm: logRawLlm,
+        route_attempt: attempt,
+        route_retry_reason: retryReasons.at(-1)?.message || null,
+      },
+      // Two route attempts must complete inside the 55 second HTTP proxy read
+      // window, including process startup and response serialization.
+      { timeoutMs: ROUTE_ATTEMPT_TIMEOUT_MS },
+    );
     if (result.ok) {
       const invalid = validateRoutePayload(result.payload);
       if (invalid) {
@@ -103,13 +63,7 @@ export function generateRouteWithRetry({
           attempt,
           error: result.error || "route_generation_failed",
           message: result.message || "",
-          fallback: "generic_before_change_after_prompt",
         });
-        return {
-          route: fallbackRoute({ concept, learnerGoal, launchAttempt }),
-          retryReasons,
-          bridgeError: null,
-        };
       }
       return {
         route: null,

--- a/loop_backend_proxy.py
+++ b/loop_backend_proxy.py
@@ -6,6 +6,7 @@ runtime from this repo and proxies to it over loopback.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import socket
 import subprocess
@@ -14,6 +15,7 @@ import time
 import atexit
 from pathlib import Path
 from typing import Mapping
+from urllib.parse import urlsplit
 import urllib3
 from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
@@ -37,6 +39,8 @@ _REQUEST_HEADER_ALLOWLIST = {"accept", "content-type"}
 _RESPONSE_HEADER_DENYLIST = _HOP_BY_HOP | {"content-encoding"}
 
 _POOL = urllib3.PoolManager()
+_LOOP_PROXY_TIMEOUT = urllib3.Timeout(connect=5.0, read=55.0)
+_MAX_LOOP_REQUEST_BODY_BYTES = 64 * 1024
 _REPO_ROOT = Path(__file__).resolve().parent
 _LOCAL_LOOP_PROCESS: subprocess.Popen | None = None
 _LOCAL_LOOP_BASE: str | None = None
@@ -129,38 +133,53 @@ def _start_local_loop_backend() -> str:
     ) from last_error
 
 
-def _vercel_internal_loop_base(request: Request) -> str | None:
-    if not force_vercel_internal_loop():
-        return None
-    host = request.headers.get("x-forwarded-host") or request.headers.get("host")
-    if not host:
-        return None
-    proto = request.headers.get("x-forwarded-proto") or "https"
-    return f"{proto}://{host}/api/internal-loop"
-
-
-def force_vercel_internal_loop() -> bool:
+def is_vercel_runtime() -> bool:
     return bool(os.environ.get("VERCEL") or os.environ.get("VERCEL_ENV"))
+
+
+def _validated_hosted_loop_base(raw_base: str) -> str:
+    base = raw_base.strip().rstrip("/")
+    parsed = urlsplit(base)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail="Hosted loop backend must be a trusted HTTPS origin.",
+        )
+    return base
 
 
 def _loop_backend_base(
     *,
     request: Request,
     force_local_runtime: bool = False,
-) -> tuple[str, bool]:
+) -> str:
     if force_local_runtime:
-        internal_base = _vercel_internal_loop_base(request)
-        if internal_base:
-            return internal_base, True
+        if is_vercel_runtime():
+            hosted_base = os.environ.get("LOOP_BACKEND_URL", "").strip()
+            if not hosted_base or not os.environ.get("SOCRATINK_LOOP_API_KEY", "").strip():
+                raise HTTPException(
+                    status_code=503,
+                    detail="Hosted loop backend is not configured.",
+                )
+            return _validated_hosted_loop_base(hosted_base)
+        return _start_local_loop_backend()
     base = os.environ.get("LOOP_BACKEND_URL", "").strip().rstrip("/")
-    if base and not force_local_runtime:
-        return base, False
+    if base:
+        return base
     if os.environ.get("SOCRATINK_LOOP_DISABLE_LOCAL") == "1":
         raise HTTPException(
             status_code=503,
             detail="Loop backend is not configured for this deployment.",
         )
-    return _start_local_loop_backend(), False
+    return _start_local_loop_backend()
 
 
 def _loop_unavailable_response(request: Request, err: HTTPException) -> Response:
@@ -211,27 +230,28 @@ def _loop_unavailable_response(request: Request, err: HTTPException) -> Response
     )
 
 
-def _internal_loop_token() -> str:
-    return (
-        os.environ.get("SOCRATINK_LOOP_API_KEY", "").strip()
-        or os.environ.get("SESSION_COOKIE_KEY", "").strip()
-    )
-
-
-def _forward_headers(request: Request, *, internal_loop: bool = False) -> dict[str, str]:
+def _forward_headers(
+    request: Request,
+    *,
+    include_user_token: bool = False,
+) -> dict[str, str]:
     headers: dict[str, str] = {}
     for key, value in request.headers.items():
         lowered = key.lower()
         if lowered in _REQUEST_HEADER_ALLOWLIST:
             headers[key] = value
-    if internal_loop:
-        token = _internal_loop_token()
-        if token:
-            headers["X-Socratink-Internal-Loop-Token"] = token
-        return headers
     api_key = os.environ.get("SOCRATINK_LOOP_API_KEY", "").strip()
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    if include_user_token:
+        session = getattr(request.state, "auth_session", None)
+        user_access_token = getattr(session, "access_token", None)
+        if not user_access_token:
+            raise HTTPException(
+                status_code=401,
+                detail="Authenticated session required for durable loop storage.",
+            )
+        headers["X-Socratink-User-Access-Token"] = user_access_token
     return headers
 
 
@@ -243,6 +263,25 @@ def _response_headers(upstream: Mapping[str, str]) -> dict[str, str]:
     }
 
 
+async def _bounded_request_body(request: Request) -> bytes:
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > _MAX_LOOP_REQUEST_BODY_BYTES:
+                raise HTTPException(status_code=413, detail="Loop request body is too large.")
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid Content-Length header.")
+
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in request.stream():
+        size += len(chunk)
+        if size > _MAX_LOOP_REQUEST_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="Loop request body is too large.")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 async def proxy_loop_backend(
     request: Request,
     upstream_path: str,
@@ -250,7 +289,7 @@ async def proxy_loop_backend(
     force_local_runtime: bool = False,
 ) -> Response:
     try:
-        base, internal_loop = _loop_backend_base(
+        base = _loop_backend_base(
             request=request,
             force_local_runtime=force_local_runtime,
         )
@@ -258,23 +297,41 @@ async def proxy_loop_backend(
         return _loop_unavailable_response(request, err)
     query = f"?{request.url.query}" if request.url.query else ""
     url = f"{base}{upstream_path}{query}"
-    body = await request.body()
+    body = await _bounded_request_body(request)
     try:
-        upstream = _POOL.request(
+        upstream = await asyncio.to_thread(
+            _POOL.request,
             request.method,
             url,
             body=body or None,
-            headers=_forward_headers(request, internal_loop=internal_loop),
+            headers=_forward_headers(
+                request,
+                include_user_token=(
+                    force_local_runtime and is_vercel_runtime()
+                ),
+            ),
             redirect=False,
             preload_content=False,
+            retries=False,
+            timeout=_LOOP_PROXY_TIMEOUT,
         )
+    except urllib3.exceptions.TimeoutError as err:
+        raise HTTPException(
+            status_code=503,
+            detail="Loop backend request timed out.",
+        ) from err
     except urllib3.exceptions.HTTPError as err:
         raise HTTPException(
             status_code=502,
             detail="Loop backend request failed.",
         ) from err
     try:
-        payload = upstream.read()
+        payload = await asyncio.to_thread(upstream.read)
+    except urllib3.exceptions.TimeoutError as err:
+        raise HTTPException(
+            status_code=503,
+            detail="Loop backend response timed out.",
+        ) from err
     except urllib3.exceptions.HTTPError as err:
         raise HTTPException(
             status_code=502,

--- a/main.py
+++ b/main.py
@@ -254,6 +254,7 @@ async def require_login_or_guest_entry(request: Request, call_next):
         return RedirectResponse(url=f"/login{query}", status_code=302)
 
     state = _resolve_session_state(request)
+    request.state.auth_session = state
     is_protected = _is_protected_html_request(request) or _is_protected_api_request(
         request
     )
@@ -309,6 +310,7 @@ class ExtractRequest(BaseModel):
     learner_goal: str | None = Field(None, max_length=1_000)
     starting_sketch: str | None = Field(None, max_length=10_000)
     source: SourceAttachment | None = None
+    route_owner: Literal["extract", "seda"] | None = None
     api_key: str | None = Field(None, max_length=200)
 
 
@@ -368,6 +370,7 @@ def _resolve_extract_path(req: "ExtractRequest") -> dict:
         "name": name,
         "launch_attempt": sketch,
         "learner_goal": learner_goal,
+        "route_owner": req.route_owner,
     }
 
 
@@ -595,6 +598,17 @@ def extract(req: ExtractRequest):
 
     try:
         if decision["path"] == "from_launch_attempt":
+            if decision.get("route_owner") == "seda":
+                shell = _fallback_smallest_route_from_sketch(
+                    concept=decision["name"],
+                    launch_attempt=decision["launch_attempt"],
+                    learner_goal=decision.get("learner_goal"),
+                ).model_dump()
+                shell["metadata"]["route_status"] = "pending_seda"
+                shell["metadata"]["graph_neutral"] = True
+                logger.info("concept_create.route_deferred", extra={"owner": "seda"})
+                return {"provisional_map": shell, "route_owner": "seda"}
+
             lc_result = None
             lc_query_failed = False
             lc_client = None

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -1977,7 +1977,7 @@
 
 @media (max-width: 720px) {
   body[data-map-open="true"] .map-view {
-    padding-top: 72px;
+    padding-top: calc(72px + env(safe-area-inset-top));
     padding-right: 12px;
     padding-left: 12px;
   }

--- a/public/css/drill-chamber.css
+++ b/public/css/drill-chamber.css
@@ -636,6 +636,11 @@
     gap: 8px;
   }
 
+  .concept-page-b2__active-entry .drill-chamber__crumb a {
+    min-height: 44px;
+    align-items: center;
+  }
+
   .concept-page-b2__active-entry .drill-chamber__active {
     min-height: 220px;
   }
@@ -645,13 +650,21 @@
     flex-direction: column;
   }
 
-  .drill-chamber__composer-actions,
-  .drill-chamber__send {
+  .drill-chamber__composer-actions {
     width: 100%;
   }
 
   .drill-chamber__send {
-    min-height: 42px;
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+    min-height: 48px;
+  }
+
+  .drill-chamber__voice-button {
+    width: 44px;
+    height: 44px;
+    min-height: 44px;
   }
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=167'     layer(components);
+@import '../styles.css?v=168'     layer(components);
 @import '../antigravity.css?v=37' layer(legacy);
-@import 'paper.css?v=17'          layer(paper);
+@import 'paper.css?v=18'          layer(paper);

--- a/public/css/paper.css
+++ b/public/css/paper.css
@@ -486,7 +486,7 @@
 
   .ignition-view--linear .composer-card__footer .ig-button--linear {
     width: 100%;
-    min-height: 34px;
+    min-height: 48px;
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,8 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=182">
-  <link rel="stylesheet" href="/css/drill-chamber.css?v=16">
+  <link rel="stylesheet" href="/css/index.css?v=184">
+  <link rel="stylesheet" href="/css/drill-chamber.css?v=17">
 </head>
 
 <body>
@@ -451,8 +451,8 @@ I'm fuzzy on…
   <!-- PDF.js for robust client-side extraction -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
-  <script src="/js/drill-chamber.js?v=16"></script>
-  <script type="module" src="/js/app.js?v=196"></script>
+  <script src="/js/drill-chamber.js?v=18"></script>
+  <script type="module" src="/js/app.js?v=201"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/ai_service.js
+++ b/public/js/ai_service.js
@@ -12,15 +12,17 @@
  * `Server error <status>: <text>` message with `.status` set.
  *
  * @param {{ name: string, learnerGoal?: string, startingSketch: string,
+ *           routeOwner?: 'extract'|'seda',
  *           source: null | { type: 'text'|'url'|'file', text?: string, url?: string, filename?: string } }} args
  * @returns {Promise<{ provisional_map?: object, knowledge_map?: object }>}
  */
-export async function submitConceptCreate({ name, learnerGoal, startingSketch, source }) {
+export async function submitConceptCreate({ name, learnerGoal, startingSketch, source, routeOwner }) {
   const body = {
     name,
     learner_goal: learnerGoal || undefined,
     starting_sketch: startingSketch,
     source,
+    route_owner: routeOwner || undefined,
   };
   const response = await fetch("/api/extract", {
     method: "POST",
@@ -70,15 +72,26 @@ async function postJson(url, body = {}) {
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    /* c8 ignore next 2 -- HTTP error text is a defensive client branch; backend error behavior is covered separately. */
-    const text = await response.text().catch(() => "");
-    throw new Error(`Server error ${response.status}: ${text}`);
+    const payload = await response.json().catch(async () => ({
+      message: await response.text().catch(() => ''),
+    }));
+    const error = new Error(
+      payload?.message || payload?.error || `Server error ${response.status}`,
+    );
+    error.status = response.status;
+    error.code = payload?.code || payload?.error || null;
+    error.body = payload || {};
+    throw error;
   }
   return response.json();
 }
 
-export function createSedaSession() {
-  return postJson("/api/session", {});
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function createSedaSession({ sourceLessDoorBootstrap = false } = {}) {
+  return postJson("/api/session", sourceLessDoorBootstrap === true
+    ? { sourceLessDoorBootstrap: true }
+    : {});
 }
 
 export async function getSedaSession(sessionId) {
@@ -87,13 +100,48 @@ export async function getSedaSession(sessionId) {
     headers: { Accept: "application/json" },
   });
   if (!response.ok) {
-    /* c8 ignore next 2 -- HTTP error text is a defensive client branch; backend error behavior is covered separately. */
-    const text = await response.text().catch(() => "");
-    throw new Error(`Server error ${response.status}: ${text}`);
+    const payload = await response.json().catch(async () => ({
+      message: await response.text().catch(() => ''),
+    }));
+    const error = new Error(
+      payload?.message || payload?.error || `Server error ${response.status}`,
+    );
+    error.status = response.status;
+    error.code = payload?.code || payload?.error || null;
+    error.body = payload || {};
+    throw error;
   }
   return response.json();
 }
 
-export function sendSedaTurn(sessionId, text) {
-  return postJson(`/api/session/${encodeURIComponent(sessionId)}/turn`, { text });
+function assertSessionVersion(value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error('A nonnegative SEDA expectedVersion is required.');
+  }
+  return value;
+}
+
+export function createSedaTurnSubmission(text, expectedVersion, requestId = null) {
+  const generated = globalThis.crypto?.randomUUID?.();
+  const stableRequestId = String(requestId || generated || '').trim();
+  if (!UUID_RE.test(stableRequestId)) throw new Error('A SEDA turn requestId UUID is required.');
+  return {
+    text: String(text ?? ''),
+    requestId: stableRequestId,
+    expectedVersion: assertSessionVersion(expectedVersion),
+  };
+}
+
+export function sendSedaTurn(sessionId, submission) {
+  const turn = submission;
+  if (!turn || typeof turn !== 'object') {
+    throw new Error('A SEDA turn submission is required.');
+  }
+  const requestId = String(turn.requestId || '').trim();
+  if (!UUID_RE.test(requestId)) throw new Error('A SEDA turn requestId UUID is required.');
+  return postJson(`/api/session/${encodeURIComponent(sessionId)}/turn`, {
+    text: String(turn.text ?? ''),
+    requestId,
+    expectedVersion: assertSessionVersion(turn.expectedVersion),
+  });
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,10 +1,11 @@
 import { Bus } from './bus.js';
 import {
+  createSedaTurnSubmission,
   createSedaSession,
   getSedaSession,
   sendSedaTurn,
   submitConceptCreate,
-} from './ai_service.js?v=2';
+} from './ai_service.js?v=5';
 import {
   playAnim,
   renderGrid as renderDeskGrid,
@@ -30,7 +31,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=31';
+} from './concept-page-view.js?v=33';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
@@ -73,11 +74,19 @@ import {
   runRepairReps,
   runDrillTurn,
 } from './api-client.js?v=2';
-import { visibleSedaPromptFromResponse } from './seda-visible-prompt.js?v=2';
+import { visibleSedaPromptFromResponse } from './seda-visible-prompt.js?v=3';
 import {
   projectCompletedSedaRecord,
   projectLatestSedaAttemptEvent,
-} from './seda-evidence-projection.js';
+} from './seda-evidence-projection.js?v=1';
+import {
+  bindSourceLessSedaRoute,
+  boundSourceLessSedaNodeId,
+  boundSourceLessSedaSessionId,
+  clearBoundSourceLessSedaRoute,
+  hasBoundSourceLessSedaRoute,
+  readySourceLessSedaRoute,
+} from './seda-route-binding.js?v=1';
 import {
   bootstrapAuthUi,
   buildLoginHref,
@@ -100,13 +109,13 @@ import {
   buildPendingShellFromDoorInput,
   showLaunchPad as _showLaunchPad,
   runLaunchPadAction as _runLaunchPadAction,
-} from './launch-pad.js?v=5';
+} from './launch-pad.js?v=6';
 import {
   coldAttemptCompletionLabel,
   nextSedaPromptAfterVerdict,
   sedaCompleteCompletionLabel,
   verdictCopy,
-} from './drill-verdict.js?v=2';
+} from './drill-verdict.js?v=6';
 import { emitTelemetry } from './telemetry.js';
 
 import {
@@ -132,6 +141,7 @@ const App = (() => {
   let learnerStatePushTimer = null;
   let readyFilterActive = false;
   let cachedDueItems = [];
+  const freshSourceLessConceptIds = new Set();
 
   function saveConcepts(arr) {
     persistConcepts(arr);
@@ -1465,6 +1475,10 @@ const App = (() => {
     // No source text — contentStore is not written for source-less concepts.
     concepts.push(concept);
     saveConcepts(concepts);
+    // This in-memory marker is deliberately scoped to the current Door flow.
+    // A legacy unbound map must not gain permission to replace node ids merely
+    // because it lacks a persisted marker.
+    freshSourceLessConceptIds.add(id);
     void initializeConceptTraining({
       conceptId: id,
       provenance: {
@@ -2229,9 +2243,19 @@ const App = (() => {
     });
   }
 
+  function hasPendingSourceLessSedaRoute(concept, graphData = null) {
+    const data = graphData || parseConceptGraphData(concept) || {};
+    return isSourceLessConcept(concept, data)
+      && data?.metadata?.route_status === 'pending_seda'
+      && data?.metadata?.graph_neutral === true
+      && !hasBoundSourceLessSedaRoute(data);
+  }
+
   function shouldResumeSedaForConcept(conceptId) {
     const stored = loadSedaSessionState(conceptId);
-    return Boolean(stored?.sessionId && stored?.latest?.caseComplete !== true);
+    if (stored?.sessionId && stored?.latest?.caseComplete !== true) return true;
+    const concept = loadConcepts().find((item) => item?.id === conceptId) || null;
+    return hasPendingSourceLessSedaRoute(concept);
   }
 
   function buildSedaResumeDrillContext(entryId, concept, data, training = null, options = {}) {
@@ -2448,6 +2472,15 @@ const App = (() => {
     button.disabled = true;
     button.setAttribute('aria-disabled', 'true');
 
+    const graphData = parseConceptGraphData(concept) || data || {};
+    if (hasPendingSourceLessSedaRoute(concept, graphData)) {
+      startDrill(buildSedaResumeDrillContext(entryId, concept, graphData, null, {
+        // This draft was written against the durable shell, not the route SEDA
+        // is about to generate. Keep it visible, but never auto-submit it.
+        restoredDraftText: userText.trim(),
+      }));
+      return;
+    }
     if (shouldResumeSedaForConcept(concept.id)) {
       startDrill(buildSedaResumeDrillContext(entryId, concept, data, null, {
         initialTurnText: userText.trim(),
@@ -2455,7 +2488,6 @@ const App = (() => {
       return;
     }
 
-    const graphData = parseConceptGraphData(concept) || data || {};
     const backbone = deriveConceptEntries(graphData);
     const match = findConceptEntryById(backbone, entryId);
     const entry = match?.entry || {};
@@ -2891,6 +2923,7 @@ const App = (() => {
     // Wire CTA and re-edit affordance
     const docEl = mountEl.querySelector('.concept-page-b2__doc');
     if (docEl) rebindActiveEntryHandlers(docEl, concept, data, training);
+    restoreActiveEntryDraft(activeEntryId);
 
     // Wire route-margin click + vertical keyboard nav.
     bindConceptRouteMarginHandlers(mountEl, data, concept, training);
@@ -3454,6 +3487,8 @@ const App = (() => {
     _normalizationIdx: 0,
     sessionCompletePending: false,
     sedaSessionId: null,
+    sedaSessionVersion: null,
+    sedaPendingSubmission: null,
     sedaActive: false,
   };
 
@@ -3504,10 +3539,63 @@ const App = (() => {
         ...state,
         updatedAt: new Date().toISOString(),
       }));
+      return true;
+    } catch (err) {
+      /* c8 ignore next 2 -- defensive localStorage failure branch. */
+      console.warn('SEDA session state unavailable.', err);
+      return false;
+    }
+  }
+
+  function clearSedaSessionState(conceptId) {
+    try {
+      localStorage.removeItem(sedaSessionKey(conceptId));
     } catch (err) {
       /* c8 ignore next -- defensive localStorage failure branch. */
-      console.warn('SEDA session state unavailable.', err);
+      console.warn('SEDA session state could not be cleared.', err);
     }
+  }
+
+  function routeUnavailableError(reason) {
+    const error = new Error(`Source-less route unavailable: ${reason}`);
+    error.code = 'route_unavailable';
+    error.reason = reason;
+    return error;
+  }
+
+  function assertSedaStartupStillCurrent(conceptId, sessionToken) {
+    if (
+      sessionToken == null
+      || (
+        drillState.sessionToken === sessionToken
+        && drillState.sedaActive
+        && getActiveId() === conceptId
+      )
+    ) return;
+    const error = new Error('Discarded a stale SEDA startup response.');
+    error.code = 'stale_seda_start';
+    throw error;
+  }
+
+  async function hasRecordedConceptEvidence(conceptId) {
+    const training = await trainingStore.loadTraining(conceptId);
+    return Object.values(training?.node_records || {}).some((record) => (
+      (Array.isArray(record?.attempts) && record.attempts.length > 0)
+      || (Array.isArray(record?.repairs) && record.repairs.length > 0)
+    ));
+  }
+
+  function resetSourceLessRouteForFreshStart(concept) {
+    const graphData = parseConceptGraphData(concept) || {};
+    const persisted = persistActiveConceptGraphData(
+      clearBoundSourceLessSedaRoute(graphData),
+      { conceptId: concept.id },
+    );
+    if (!persisted) return null;
+    clearSedaSessionState(concept.id);
+    freshSourceLessConceptIds.add(concept.id);
+    concept.graphData = persisted.graphData;
+    return persisted;
   }
 
   function sedaPromptFromResponse(data) {
@@ -3527,17 +3615,35 @@ const App = (() => {
     void revealStudyForEntry(nodeId, concept, parseConceptGraphData(concept) || {});
   }
 
+  function restoreUnrecordedDraft(text, { chamber = false, entryId = null } = {}) {
+    const draft = String(text || '').trim();
+    if (!draft) return;
+    if (chamber) {
+      const target = document.getElementById('chamber-composer');
+      if (target && 'value' in target) target.value = draft;
+      return;
+    }
+    const resolvedEntryId = entryId || drillState.node?.id || _activeEntryId;
+    if (!resolvedEntryId) return;
+    routeAttemptDrafts.set(routeAttemptDraftKey(resolvedEntryId), draft);
+    restoreActiveEntryDraft(resolvedEntryId);
+  }
+
   async function saveSedaResponse(concept, nodeContext, data) {
-    if (!concept?.id || !data?.sessionId) return;
-    persistSedaSessionState(concept.id, {
+    if (!concept?.id || !data?.sessionId) return false;
+    sessionVersionFromResponse(data);
+    const persisted = persistSedaSessionState(concept.id, {
       sessionId: data.sessionId,
+      sessionVersion: data.sessionVersion,
       nodeId: nodeContext?.id || null,
       latest: data,
       record: data.record || null,
     });
+    if (!persisted) return false;
     if (data.caseComplete && data.record) {
-      await projectSedaEvidence(concept, nodeContext, data);
+      return projectSedaEvidence(concept, nodeContext, data);
     }
+    return !data.caseComplete;
   }
 
   // Reconstruction evidence must survive outside the chamber: project the
@@ -3553,10 +3659,20 @@ const App = (() => {
         record: data.record,
         sessionId: data.sessionId,
       });
-      if (next) await trainingStore.saveTraining(next);
+      /* c8 ignore start -- completed-record idempotency is proven in the projection module contract. */
+      if (!next) {
+        const attempts = training?.node_records?.[nodeContext?.id || '']?.attempts;
+        return Array.isArray(attempts) && attempts.some(
+          (attempt) => attempt?.id === `seda-${data.sessionId}-0`,
+        );
+      }
+      /* c8 ignore stop */
+      await trainingStore.saveTraining(next);
+      return true;
     } catch (err) {
       /* c8 ignore next 2 -- defensive storage failure branch. */
       console.warn('SEDA evidence projection unavailable.', err);
+      return false;
     }
   }
 
@@ -3570,41 +3686,200 @@ const App = (() => {
         data,
         sessionId: data.sessionId,
       });
-      if (!next) return false;
+      if (!next) {
+        const attempts = training?.node_records?.[nodeContext?.id || '']?.attempts;
+        const prefix = `seda-${data.sessionId}-event-`;
+        const projected = Array.isArray(attempts)
+          ? attempts.findLast((attempt) => String(attempt?.id || '').startsWith(prefix))
+          : null;
+        return { ok: true, classification: projected?.classification || null };
+      }
       await trainingStore.saveTraining(next);
       const projected = next.node_records?.[nodeContext?.id || ''];
       const attempts = Array.isArray(projected?.attempts) ? projected.attempts : [];
-      return attempts[attempts.length - 1]?.classification || true;
+      return {
+        ok: true,
+        classification: attempts[attempts.length - 1]?.classification || true,
+      };
     } catch (err) {
       /* c8 ignore next 2 -- defensive storage failure branch. */
       console.warn('SEDA attempt projection unavailable.', err);
-      return false;
+      return { ok: false, classification: null };
     }
   }
 
-  async function loadOrCreateSedaResponse(concept, nodeContext) {
+  function sessionVersionFromResponse(data) {
+    const version = data?.sessionVersion;
+    if (!Number.isInteger(version) || version < 0) {
+      /* c8 ignore next -- transport helpers and server contracts reject invalid versions before this browser boundary. */
+      throw new Error('The learning loop returned an invalid session version.');
+    }
+    return version;
+  }
+
+  function sedaSubmissionForResponse(text, data, requestId = null) {
+    return createSedaTurnSubmission(
+      text,
+      sessionVersionFromResponse(data),
+      requestId,
+    );
+  }
+
+  async function loadOrCreateSedaResponse(
+    concept,
+    nodeContext,
+    { sessionToken = null } = {},
+  ) {
+    const existingGraphData = parseConceptGraphData(concept) || {};
+    const expectedGraphRevision = String(concept.graphData || '');
+    const sourceLess = isSourceLessConcept(concept, existingGraphData);
+    const routeBound = sourceLess && hasBoundSourceLessSedaRoute(existingGraphData);
+    const durablePendingRoute = hasPendingSourceLessSedaRoute(
+      concept,
+      existingGraphData,
+    );
+    if (
+      durablePendingRoute
+      && await hasRecordedConceptEvidence(concept.id)
+    ) {
+      throw routeUnavailableError('pending_route_has_evidence');
+    }
+    if (
+      sourceLess
+      && !routeBound
+      && !durablePendingRoute
+      && !freshSourceLessConceptIds.has(concept.id)
+    ) {
+      throw routeUnavailableError('unbound_route_requires_confirmation');
+    }
+    const resumingBoundNode = routeBound
+      && nodeContext?.id === boundSourceLessSedaNodeId(existingGraphData);
+    if (routeBound && !resumingBoundNode) {
+      throw routeUnavailableError('bound_node_mismatch');
+    }
+    const boundSessionId = resumingBoundNode
+      ? boundSourceLessSedaSessionId(existingGraphData)
+      : '';
+    if (resumingBoundNode && !boundSessionId) {
+      throw routeUnavailableError('missing_bound_session');
+    }
     const stored = loadSedaSessionState(concept.id);
     const sameStoredNode = Boolean(stored?.nodeId && stored.nodeId === nodeContext?.id);
+    const sameBoundSession = !resumingBoundNode || stored?.sessionId === boundSessionId;
     let data = null;
-    if (stored?.sessionId && sameStoredNode && !stored?.latest?.caseComplete) {
+    if (stored?.sessionId && sameStoredNode && sameBoundSession && !stored?.latest?.caseComplete) {
       try {
         data = await getSedaSession(stored.sessionId);
       } catch {
-        /* c8 ignore next -- stale stored session falls back to creating a new app session. */
+        /* c8 ignore next -- the bound-session guard below fails closed after a stale resume. */
         data = null;
       }
     }
     if (!data) {
-      data = await createSedaSession();
+      if (resumingBoundNode) {
+        throw routeUnavailableError('stale_bound_session');
+      }
+      data = await createSedaSession({ sourceLessDoorBootstrap: sourceLess });
+    }
+    if (resumingBoundNode && data?.sessionId !== boundSessionId) {
+      throw routeUnavailableError('bound_session_mismatch');
     }
     if (data?.awaiting?.key === 'cmd') {
-      data = await sendSedaTurn(data.sessionId, concept.name || 'Untitled concept');
+      data = await sendSedaTurn(
+        data.sessionId,
+        sedaSubmissionForResponse(concept.name || 'Untitled concept', data),
+      );
     }
     if (data?.awaiting?.key === 'learner_goal') {
-      data = await sendSedaTurn(data.sessionId, concept.learnerGoal || '');
+      data = await sendSedaTurn(
+        data.sessionId,
+        sedaSubmissionForResponse(concept.learnerGoal || '', data),
+      );
     }
-    await saveSedaResponse(concept, nodeContext, data);
-    return data;
+    if (data?.awaiting?.key === 'launch_attempt') {
+      const launchAttempt = sourceLess
+        ? String(
+          concept.startingMapContext
+          || existingGraphData?.metadata?.starting_map_context
+          || ''
+        ).trim()
+        : '';
+      if (launchAttempt) {
+        // The source-less Door already captured this global starting model.
+        // Feed it into SEDA before the chamber opens so the first answer the
+        // learner writes in the room is the local, recordable cold attempt.
+        // This bootstrap turn bypasses requestSedaTurn on purpose: launch
+        // attempts shape routing but never append learner training evidence.
+        data = await sendSedaTurn(
+          data.sessionId,
+          sedaSubmissionForResponse(launchAttempt, data),
+        );
+      }
+    }
+
+    // Model-backed route generation can finish after the learner has exited or
+    // selected another concept. Do not let that late response write local
+    // session, graph, or drill state into a different active surface.
+    assertSedaStartupStillCurrent(concept.id, sessionToken);
+
+    if (resumingBoundNode && data?.awaiting?.key === 'cold_attempt') {
+      const readyRoute = readySourceLessSedaRoute(data);
+      if (String(readyRoute.first_node?.id || '').trim() !== boundSourceLessSedaNodeId(existingGraphData)) {
+        throw routeUnavailableError('bound_route_mismatch');
+      }
+    }
+
+    let routeBinding = null;
+    let activeConcept = concept;
+    let responseSavedForBinding = false;
+    if (sourceLess && !routeBound) {
+      // SEDA chooses the actual learning target only after reading the Door
+      // sketch. Bind and persist that route before the composer can open, so
+      // prompt, evidence, and study all point at the same authoritative node.
+      // Any malformed/missing route fails into the existing retry UI before
+      // session state or learner training evidence is written.
+      routeBinding = bindSourceLessSedaRoute({
+        data,
+        existingMap: existingGraphData,
+        concept,
+      });
+      Object.assign(nodeContext, routeBinding.nodeContext, { drillMode: 'seda' });
+      // Save the exact bound node/session before stamping the map marker. If
+      // session storage is unavailable, fail without leaving a graph that
+      // claims it has a resumable authoritative route.
+      responseSavedForBinding = await saveSedaResponse(concept, nodeContext, data);
+      /* c8 ignore start -- defensive browser-storage failure; save/persistence retry UX is covered on the active turn path. */
+      if (!responseSavedForBinding) {
+        throw new Error('Could not persist the source-less SEDA session.');
+      }
+      /* c8 ignore stop */
+      const persistedConcept = persistActiveConceptGraphData(
+        routeBinding.graphData,
+        { conceptId: concept.id, expectedGraphRevision },
+      );
+      /* c8 ignore start -- stale graph revision is rejected before route state can be stamped. */
+      if (!persistedConcept) {
+        clearSedaSessionState(concept.id);
+        throw new Error('Could not persist the source-less SEDA route.');
+      }
+      /* c8 ignore stop */
+      activeConcept = persistedConcept;
+      concept.graphData = persistedConcept.graphData;
+      freshSourceLessConceptIds.delete(concept.id);
+      drillState.node = nodeContext;
+      activeDrillNode = nodeContext.id;
+      currentGraphController?.setActiveDrillNode?.(activeDrillNode);
+    }
+
+    if (!responseSavedForBinding) {
+      const responseSaved = await saveSedaResponse(activeConcept, nodeContext, data);
+      /* c8 ignore start -- defensive browser-storage failure on bound-session resume. */
+      if (!responseSaved) {
+        throw new Error('Could not persist the source-less SEDA response.');
+      }
+      /* c8 ignore stop */
+    }
+    return { data, routeBinding, concept: activeConcept };
   }
 
   function parseConceptGraphData(concept) {
@@ -3612,11 +3887,20 @@ const App = (() => {
     return normalizeGraphData(concept.graphData).graphData;
   }
 
-  function persistActiveConceptGraphData(graphData) {
+  function persistActiveConceptGraphData(
+    graphData,
+    { conceptId = getActiveId(), expectedGraphRevision = null } = {},
+  ) {
     const concepts = loadConcepts();
-    const activeId = getActiveId();
-    const conceptIdx = concepts.findIndex((concept) => concept.id === activeId);
+    const conceptIdx = concepts.findIndex((concept) => concept.id === conceptId);
     if (conceptIdx === -1) return null;
+    if (
+      expectedGraphRevision != null
+      && String(concepts[conceptIdx].graphData || '') !== expectedGraphRevision
+    ) {
+      /* c8 ignore next -- late-response CAS failure is covered through the stale-start browser contract. */
+      return null;
+    }
 
     const normalizedGraphData = normalizeGraphData(graphData).graphData;
     concepts[conceptIdx].graphData = JSON.stringify(normalizedGraphData);
@@ -4279,8 +4563,10 @@ const App = (() => {
     drillState.attemptTurnCount = 0;
     drillState.helpTurnCount = 0;
     drillState.sessionCompletePending = false;
-    /* c8 ignore next 2 -- completeStudy reset mirrors cancelDrill; SEDA state mutation is covered in the active path. */
+    /* c8 ignore next 3 -- completeStudy reset mirrors cancelDrill; SEDA state mutation is covered in the active path. */
     drillState.sedaSessionId = null;
+    drillState.sedaSessionVersion = null;
+    drillState.sedaPendingSubmission = null;
     drillState.sedaActive = false;
     drillState.sessionToken += 1;
     if (drillUi) drillUi.style.display = 'none';
@@ -4439,23 +4725,45 @@ const App = (() => {
     drillState.pending = true;
     if (chatInput) chatInput.disabled = true;
     showTypingIndicator();
+    window.DrillChamber?.setLoading?.(true, { checkingAnswer: Boolean(String(userText || '').trim()) });
+
+    const normalizedText = String(userText ?? '');
+    const pendingSubmission = drillState.sedaPendingSubmission;
+    const submission = pendingSubmission?.text === normalizedText
+      ? pendingSubmission
+      : createSedaTurnSubmission(normalizedText, drillState.sedaSessionVersion);
+    drillState.sedaPendingSubmission = submission;
 
     try {
-      const data = await sendSedaTurn(drillState.sedaSessionId, userText);
+      const data = await sendSedaTurn(drillState.sedaSessionId, submission);
       hideTypingIndicator();
       if (sessionToken !== drillState.sessionToken || !drillState.node) return;
-
-      drillState.sedaSessionId = data.sessionId;
-      await saveSedaResponse(concept, drillState.node, data);
+      const responseSaved = await saveSedaResponse(concept, drillState.node, data);
+      /* c8 ignore start -- session-state storage failure shares the proven idempotent persistence-retry UI. */
+      if (!responseSaved) {
+        showSedaPersistenceRetry(normalizedText);
+        return;
+      }
+      /* c8 ignore stop */
       if (sessionToken !== drillState.sessionToken || !drillState.node) return;
-      const projectedAttemptClassification = data.caseComplete
-        ? null
+      const projectedAttempt = data.caseComplete
+        ? { ok: true, classification: null }
         : await projectSedaAttemptEvent(concept, drillState.node, data);
+      if (!projectedAttempt.ok) {
+        showSedaPersistenceRetry(normalizedText);
+        return;
+      }
+      drillState.sedaPendingSubmission = null;
+      drillState.sedaSessionId = data.sessionId;
+      drillState.sedaSessionVersion = sessionVersionFromResponse(data);
+      const projectedAttemptClassification = projectedAttempt.classification;
       const studyReady = data.caseComplete || Boolean(projectedAttemptClassification);
       if (sessionToken !== drillState.sessionToken || !drillState.node) return;
       const previousPrompt = chamberLastShownQuestion;
       const promptText = sedaPromptFromResponse(data);
       const nextPrompt = nextSedaPromptAfterVerdict(promptText, previousPrompt, userText);
+      window.DrillChamber?.appendHistoryTurn('ai', previousPrompt || '');
+      window.DrillChamber?.appendHistoryTurn('learner', normalizedText);
       drillState.messages.push({ role: 'user', content: userText });
       drillState.messages.push({ role: 'assistant', content: studyReady ? promptText : nextPrompt });
       chamberLastShownQuestion = studyReady ? promptText : nextPrompt;
@@ -4474,7 +4782,7 @@ const App = (() => {
         } else {
           window.DrillChamber.swapQuestion(nextPrompt);
           setTimeout(() => {
-            window.DrillChamber?.appendVerdict?.(verdictCopy({ userText }));
+            window.DrillChamber?.appendVerdict?.(verdictCopy({ userText, recordable: false }));
             window.DrillChamber?.setCompletionAction?.('Keep going', () => {
               window.DrillChamber?.setComposerEnabled(true);
             });
@@ -4492,7 +4800,95 @@ const App = (() => {
       hideTypingIndicator();
       if (sessionToken !== drillState.sessionToken) return;
       drillState.pending = false;
-      throw err;
+      window.DrillChamber?.setLoading?.(false);
+      if (err?.status === 409 && err?.body?.error === 'session_conflict') {
+        await reconcileSedaSessionConflict(concept, normalizedText, sessionToken);
+        return;
+      }
+      console.error(err);
+      showSedaTransportRetry(normalizedText);
+      return;
+      /* c8 ignore stop */
+    }
+  }
+
+  function showSedaPersistenceRetry(userText) {
+    drillState.pending = false;
+    window.DrillChamber?.setLoading?.(false);
+    window.DrillChamber?.appendVerdict?.(
+      'Answer received • Not saved in this browser yet.',
+    );
+    window.DrillChamber?.setCompletionAction?.('Try saving again', () => {
+      window.DrillChamber?.setComposerEnabled(false);
+      void requestSedaTurn(userText);
+    });
+    restoreUnrecordedDraft(userText, { chamber: true });
+  }
+
+  function showSedaTransportRetry(userText) {
+    drillState.pending = false;
+    window.DrillChamber?.setLoading?.(false);
+    window.DrillChamber?.appendVerdict?.(
+      'Answer kept • Not recorded • The learning loop did not respond.',
+    );
+    window.DrillChamber?.setCompletionAction?.('Try sending again', () => {
+      window.DrillChamber?.setComposerEnabled(false);
+      void requestSedaTurn(userText);
+    });
+    // Completion actions normally clear the composer. Put the learner's exact
+    // draft back after installing the retry action so a network failure never
+    // turns visible effort into a blank form.
+    restoreUnrecordedDraft(userText, { chamber: true });
+  }
+
+  async function reconcileSedaSessionConflict(concept, draft, sessionToken) {
+    try {
+      const latest = await getSedaSession(drillState.sedaSessionId);
+      if (sessionToken !== drillState.sessionToken || !drillState.node) return;
+      const responseSaved = await saveSedaResponse(concept, drillState.node, latest);
+      /* c8 ignore start -- conflict refresh storage failure reuses the persistence-retry contract. */
+      if (!responseSaved) {
+        showSedaPersistenceRetry(draft);
+        return;
+      }
+      /* c8 ignore stop */
+      drillState.sedaSessionVersion = sessionVersionFromResponse(latest);
+      // A stale submission belongs to the prompt/version that produced it.
+      // Clearing it here ensures an explicit resubmit gets a fresh id bound to
+      // the newly fetched prompt instead of silently replaying stale text.
+      drillState.sedaPendingSubmission = null;
+      drillState.pending = false;
+      /* c8 ignore start -- defensive conflict after remote case completion returns the preserved draft to the map. */
+      if (latest.caseComplete) {
+        window.DrillChamber?.appendVerdict?.(
+          'Session changed in another tab • Your draft was not recorded.',
+        );
+        window.DrillChamber?.setCompletionAction?.('Return to map', () => {
+          const entryId = drillState.node?.id;
+          cancelDrill();
+          restoreUnrecordedDraft(draft, { entryId });
+        });
+        return;
+      }
+      /* c8 ignore stop */
+      const currentPrompt = sedaPromptFromResponse(latest);
+      const question = document.getElementById('chamber-question');
+      if (question) question.textContent = currentPrompt;
+      chamberLastShownQuestion = currentPrompt;
+      restoreUnrecordedDraft(draft, { chamber: true });
+      window.DrillChamber?.appendVerdict?.(
+        'Session changed in another tab • Review the current question, then check your draft again.',
+      );
+      window.DrillChamber?.setComposerEnabled(true);
+    } catch (refreshError) {
+      /* c8 ignore start -- refresh transport failure preserves the draft and is covered by the general transport-retry proof. */
+      console.error(refreshError);
+      if (sessionToken !== drillState.sessionToken) return;
+      restoreUnrecordedDraft(draft, { chamber: true });
+      window.DrillChamber?.appendVerdict?.(
+        'Session changed in another tab • Your draft was not recorded.',
+      );
+      window.DrillChamber?.setComposerEnabled(true);
       /* c8 ignore stop */
     }
   }
@@ -4753,6 +5149,10 @@ const App = (() => {
     const initialSedaTurnText = usesSedaLoop
       ? String(nodeContext?.initialTurnText || '').trim()
       : '';
+    const restoredSedaDraftText = usesSedaLoop
+      ? String(nodeContext?.restoredDraftText || '').trim()
+      : '';
+    const unrecordedSedaDraftText = restoredSedaDraftText || initialSedaTurnText;
 
     // TODO(post-launch): see paired comment ~line 3592. All four guards
     // below (re-drill spacing, 4-entries-per-session, time limit,
@@ -4813,6 +5213,8 @@ const App = (() => {
     drillState.helpTurnCount = 0;
     drillState.sessionCompletePending = false;
     drillState.sedaSessionId = null;
+    drillState.sedaSessionVersion = null;
+    drillState.sedaPendingSubmission = null;
     drillState.sedaActive = usesSedaLoop;
     drillState.sessionToken += 1;
     activeDrillNode = nodeContext?.id || null;
@@ -4857,7 +5259,12 @@ const App = (() => {
     // Show the ironclad chamber view.
     const conceptName = concept?.name || concept?.metadata?.name || 'Concept';
     const entryName = nodeContext.fullLabel || nodeContext.id || 'Entry';
-    const visibleQuestion = drillQuestionForNodeContext(nodeContext, concept);
+    const awaitingAuthoritativeSourceLessRoute = usesSedaLoop
+      && isSourceLessConcept(concept, km)
+      && !hasBoundSourceLessSedaRoute(km);
+    const visibleQuestion = awaitingAuthoritativeSourceLessRoute
+      ? 'Preparing your first question…'
+      : drillQuestionForNodeContext(nodeContext, concept);
     if (window.DrillChamber) {
       window.DrillChamber.show({
         conceptName,
@@ -4868,32 +5275,124 @@ const App = (() => {
         const sedaStartToken = drillState.sessionToken;
         window.DrillChamber.setComposerEnabled(false);
         window.DrillChamber.setLoading?.(true);
-        loadOrCreateSedaResponse(concept, nodeContext)
-          .then(async (data) => {
+        loadOrCreateSedaResponse(
+          concept,
+          nodeContext,
+          { sessionToken: sedaStartToken },
+        )
+          .then(async ({ data, routeBinding, concept: activeConcept }) => {
             if (drillState.sessionToken !== sedaStartToken || !drillState.sedaActive) return;
             drillState.sedaSessionId = data.sessionId;
-            const promptText = drillPromptFromSedaResponse(data, nodeContext, concept);
+            drillState.sedaSessionVersion = sessionVersionFromResponse(data);
+            const promptText = routeBinding && data?.awaiting?.key === 'cold_attempt'
+              ? routeBinding.nodeContext.prompt
+              : drillPromptFromSedaResponse(data, nodeContext, activeConcept);
             chamberLastShownQuestion = promptText;
-            window.DrillChamber.swapQuestion(promptText);
+            if (routeBinding) {
+              const training = await trainingStore.loadTraining(activeConcept.id);
+              if (drillState.sessionToken !== sedaStartToken || !drillState.sedaActive) return;
+              const liveMapContent = document.getElementById('map-content');
+              if (liveMapContent) {
+                renderConceptPageB2(
+                  liveMapContent,
+                  routeBinding.graphData,
+                  activeConcept,
+                  training,
+                  { activeEntryId: nodeContext.id, isDrilling: true },
+                );
+              }
+              window.DrillChamber.show({
+                conceptName: activeConcept?.name || 'Concept',
+                entryName: nodeContext.fullLabel || nodeContext.id || 'Entry',
+                question: promptText,
+              });
+              // show() enables a freshly rendered composer by default; keep it
+              // closed until the authoritative node and session are both ready.
+              window.DrillChamber.setComposerEnabled(false);
+              currentGraphController?.setActiveDrillNode?.(nodeContext.id);
+              currentGraphController?.setInteractionMode?.(initialMode, nodeContext.id);
+            } else {
+              window.DrillChamber.swapQuestion(promptText);
+            }
             window.DrillChamber.setLoading?.(false);
             /* c8 ignore start -- opening an already-complete stored session is covered by API proof, not browser smoke. */
             if (data.caseComplete) {
               drillState.sessionCompletePending = true;
-              window.DrillChamber.setCompletionAction?.(sedaCompleteCompletionLabel(), () => openStudyAfterVerdict(concept.id, nodeContext?.id));
+              window.DrillChamber.setCompletionAction?.(sedaCompleteCompletionLabel(), () => openStudyAfterVerdict(activeConcept.id, nodeContext?.id));
             } else if (initialSedaTurnText) {
-              window.DrillChamber.appendHistoryTurn('ai', promptText);
-              window.DrillChamber.appendHistoryTurn('learner', initialSedaTurnText);
               await requestSedaTurn(initialSedaTurnText);
             } else {
             /* c8 ignore stop */
               window.DrillChamber.setComposerEnabled(true);
+              if (restoredSedaDraftText) {
+                restoreUnrecordedDraft(restoredSedaDraftText, { chamber: true });
+                window.DrillChamber.appendVerdict?.(
+                  'Draft kept • Not recorded against this question.',
+                );
+              }
             }
           })
-          .catch((err) => {
+          .catch(async (err) => {
             /* c8 ignore start -- defensive startup failure branch for unavailable local loop backend. */
             console.error(err);
+            if (drillState.sessionToken !== sedaStartToken || !drillState.sedaActive) return;
+            if (err?.code === 'stale_seda_start') return;
             drillState.pending = false;
             drillState.sedaSessionId = null;
+            drillState.sedaSessionVersion = null;
+            drillState.sedaPendingSubmission = null;
+            if (err?.code === 'route_unavailable') {
+              let hasEvidence = err?.reason === 'bound_node_mismatch';
+              if (!hasEvidence) {
+                try {
+                  hasEvidence = await hasRecordedConceptEvidence(concept.id);
+                } catch (evidenceError) {
+                  hasEvidence = true;
+                  console.warn('Could not inspect recorded evidence during route recovery.', evidenceError);
+                }
+              }
+              if (drillState.sessionToken !== sedaStartToken || !drillState.sedaActive) return;
+              window.DrillChamber.setLoading?.(false);
+              window.DrillChamber.setComposerEnabled(false);
+              if (unrecordedSedaDraftText) {
+                restoreUnrecordedDraft(unrecordedSedaDraftText);
+                window.DrillChamber.appendVerdict?.('Draft kept • Not recorded.');
+              }
+              if (hasEvidence) {
+                window.DrillChamber.swapQuestion(
+                  'This learning route cannot be resumed. Your recorded work is still on the map.',
+                );
+                window.DrillChamber.setCompletionAction?.('Return to map', () => {
+                  const entryId = nodeContext?.id;
+                  cancelDrill();
+                  restoreUnrecordedDraft(unrecordedSedaDraftText, { entryId });
+                });
+              } else {
+                window.DrillChamber.swapQuestion(
+                  'We could not build the first question. Your starting sketch is saved.',
+                );
+                window.DrillChamber.setCompletionAction?.('Build the first question again', () => {
+                  const retryContext = {
+                    ...nodeContext,
+                    graphNeutral: true,
+                    drillMode: 'seda',
+                    // The fresh route may ask a different question. Do not
+                    // silently submit text written against the stale route.
+                    initialTurnText: '',
+                    restoredDraftText: unrecordedSedaDraftText,
+                  };
+                  if (!resetSourceLessRouteForFreshStart(concept)) {
+                    window.DrillChamber.swapQuestion(
+                      'Your starting sketch is saved, but a fresh question could not be prepared.',
+                    );
+                    return;
+                  }
+                  cancelDrill({ restoreMap: false });
+                  startDrill(retryContext);
+                });
+              }
+              return;
+            }
             window.DrillChamber.swapQuestion('The learning loop could not start. Try again when ready.');
             window.DrillChamber.setLoading?.(false);
             window.DrillChamber.setCompletionAction?.('Try again', () => {
@@ -4928,8 +5427,10 @@ const App = (() => {
         // Accumulate the completed turn into history before the next round trip.
         // The AI side is the question we'd just been asking the learner;
         // the learner side is what they just wrote.
-        window.DrillChamber.appendHistoryTurn('ai', chamberLastShownQuestion || '');
-        window.DrillChamber.appendHistoryTurn('learner', text);
+        if (!drillState.sedaActive) {
+          window.DrillChamber.appendHistoryTurn('ai', chamberLastShownQuestion || '');
+          window.DrillChamber.appendHistoryTurn('learner', text);
+        }
         window.DrillChamber.setComposerEnabled(false);
         try {
           await requestDrillTurn(text);
@@ -4963,6 +5464,8 @@ const App = (() => {
     drillState.helpTurnCount = 0;
     drillState.sessionCompletePending = false;
     drillState.sedaSessionId = null;
+    drillState.sedaSessionVersion = null;
+    drillState.sedaPendingSubmission = null;
     drillState.sedaActive = false;
     chamberLastShownQuestion = '';
     if (drillUi) drillUi.style.display = 'none';

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -742,7 +742,7 @@ function renderDrillChamberHtml() {
                 <button class="drill-chamber__voice-button" id="chamber-tutor-voice" type="button" aria-label="Tutor voice off" aria-pressed="false" hidden>
                   <span aria-hidden="true">voice</span>
                 </button>
-                <button class="drill-chamber__send" id="chamber-send" type="button">Check reconstruction</button>
+                <button class="drill-chamber__send" id="chamber-send" type="button">Check my answer</button>
               </div>
             </div>
             <span class="drill-chamber__voice-status" id="chamber-voice-status" aria-live="polite"></span>
@@ -791,7 +791,7 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     totalNodes,
   });
   const visibleEntryEyebrow = options?.isDrilling
-    ? 'Pressure check'
+    ? 'Reconstruction'
     : options?.repairCheckedThisSession && derived.next_action === 'repair'
     ? 'Repair checked'
     : entryEyebrow;

--- a/public/js/drill-chamber.js
+++ b/public/js/drill-chamber.js
@@ -21,9 +21,14 @@ let listening = false;
 let speechBaseText = '';
 let tutorVoiceEnabled = false;
 let lastSpokenQuestion = '';
-const DEFAULT_SEND_LABEL = 'Check reconstruction';
+let pendingVerdictTimer = null;
+let pendingVerdictShown = false;
+const DEFAULT_SEND_LABEL = 'Check my answer';
 const DEFAULT_HINT = 'A sentence is enough.';
 const EMPTY_REPLY_HINT = 'Write a sentence before checking.';
+const CHECKING_REPLY_HINT = 'Checking your answer…';
+const PENDING_VERDICT = 'Answer received • Checking the link you wrote.';
+const PENDING_VERDICT_DELAY_MS = 1200;
 const _originalPlaceholder = 'Write your reconstruction here. Fragments are fine.';
 const MIC_INPUT_PREF_KEY = 'socratink.loop.micInput';
 const TUTOR_VOICE_PREF_KEY = 'socratink.loop.tutorVoice';
@@ -113,6 +118,7 @@ function bind() {
 
 function show({ conceptName, entryName, question }) {
   if (!bind()) return;
+  setLoading(false);
   els.active.querySelectorAll('.drill-chamber__creed').forEach((el) => el.remove());
   clearCompletionAction();
   clearVerdict();
@@ -142,6 +148,7 @@ function show({ conceptName, entryName, question }) {
 function hide() {
   if (!bind()) return;
   stopSpeech();
+  setLoading(false);
   clearCompletionAction();
   els.view.hidden = true;
   document.body.classList.remove('chamber-open');
@@ -207,14 +214,31 @@ function setComposerEnabled(enabled) {
  * The node prompt is already the first question, so loading must never
  * prevent the learner from starting their reconstruction.
  */
-function setLoading(loading) {
+function setLoading(loading, { checkingAnswer = false } = {}) {
   if (!bind()) return;
   if (loading) {
     els.composer.placeholder = _originalPlaceholder;
     els.active?.setAttribute('data-loading', 'true');
+    if (checkingAnswer) {
+      if (els.hint) {
+        els.hint.textContent = CHECKING_REPLY_HINT;
+        els.hint.classList?.remove?.('is-error');
+      }
+      setVoiceStatus(CHECKING_REPLY_HINT);
+      if (pendingVerdictTimer != null) clearTimeout(pendingVerdictTimer);
+      pendingVerdictTimer = setTimeout(() => {
+        pendingVerdictTimer = null;
+        pendingVerdictShown = true;
+        renderVerdict(PENDING_VERDICT);
+      }, PENDING_VERDICT_DELAY_MS);
+    }
   } else {
+    if (pendingVerdictTimer != null) clearTimeout(pendingVerdictTimer);
+    pendingVerdictTimer = null;
+    if (pendingVerdictShown) clearVerdict();
     els.composer.placeholder = _originalPlaceholder;
     els.active?.removeAttribute('data-loading');
+    resetComposerHint();
   }
 }
 
@@ -251,12 +275,22 @@ function clearCompletionAction() {
 
 function clearVerdict() {
   if (!bind() || !els.verdict) return;
+  if (pendingVerdictTimer != null) clearTimeout(pendingVerdictTimer);
+  pendingVerdictTimer = null;
+  pendingVerdictShown = false;
   els.verdict.textContent = '';
   els.verdict.hidden = true;
 }
 
 function appendVerdict(text) {
   if (!bind() || !els.verdict) return;
+  if (pendingVerdictTimer != null) clearTimeout(pendingVerdictTimer);
+  pendingVerdictTimer = null;
+  pendingVerdictShown = false;
+  renderVerdict(text);
+}
+
+function renderVerdict(text) {
   const copy = String(text || '').trim();
   if (!copy) return;
   els.verdict.textContent = '';

--- a/public/js/drill-verdict.js
+++ b/public/js/drill-verdict.js
@@ -3,20 +3,33 @@ function learnerSnippet(userText) {
   return text.length > 72 ? `${text.slice(0, 69)}...` : text;
 }
 
-export function verdictCopy({ classification, userText, sedaComplete = false } = {}) {
+export function verdictCopy({
+  classification,
+  userText,
+  recordable = true,
+  sedaComplete = false,
+} = {}) {
   const snippet = learnerSnippet(userText);
-  const x = snippet ? `your line "${snippet}"` : 'the attempt';
-  if (sedaComplete) return `Checked • Recorded • ${x} is on record. • Study is ready.`;
-  if (classification === 'strong' || classification === 'solid') {
-    return `Checked • Solid enough to compare • You named ${x}. • Study will show what to add.`;
+  const learnerLine = snippet ? `Your line: “${snippet}”` : 'Your attempt is on record.';
+  if (!recordable) {
+    return `Response received • Keep going • ${learnerLine} • Use the next question to add one cause-and-effect link.`;
   }
-  if (classification === 'partial' || classification === 'deep') {
-    return `Checked • Partly there • You have ${x}. • Study will target the missing link.`;
+  if (sedaComplete) return 'Checked • Recorded • Your attempt is on record. • Study is ready.';
+  if (classification === 'strong' || classification === 'solid') {
+    return `Checked • Solid enough to compare • ${learnerLine} • Study will show what to add.`;
+  }
+  if (
+    classification === 'partial'
+    || classification === 'deep'
+    || classification === 'thin'
+    || classification === 'shallow'
+  ) {
+    return `Checked • Partly there • ${learnerLine} • Study will target the missing link.`;
   }
   if (classification === 'wrong_direction' || classification === 'misconception') {
-    return `Checked • Wrong angle • You focused on ${x}. • Study will reset the mechanism.`;
+    return `Checked • Wrong angle • ${learnerLine} • Study will show a different starting point.`;
   }
-  return `Checked • Gap found • ${x} exposed what to study next. • Study will target it.`;
+  return `Checked • Gap found • ${learnerLine} • Study will target what you just exposed.`;
 }
 
 export function nextSedaPromptAfterVerdict(promptText, previousPrompt, userText) {

--- a/public/js/launch-pad.js
+++ b/public/js/launch-pad.js
@@ -21,7 +21,7 @@
 // can retry without re-typing the threshold.
 
 import { emitTelemetry } from './telemetry.js';
-import { submitConceptCreate } from './ai_service.js?v=1';
+import { submitConceptCreate } from './ai_service.js?v=5';
 import { AudioFX } from './audio.js?v=4';
 
 // Same printable-key heuristic the door uses (app.js) so launch-pad audio
@@ -300,6 +300,10 @@ export async function runLaunchPadAction(event, App, controls = {}) {
       learnerGoal: shell.goal,
       startingSketch: threshold,
       source: null,
+      // The typed SEDA handoff owns the authoritative first route. This call
+      // only persists a fast graph-neutral shell so the Door does not pay for
+      // two model-generated routes before the learner can write again.
+      routeOwner: 'seda',
     });
   } catch (err) {
     if (err && err.status === 422) {

--- a/public/js/seda-evidence-projection.js
+++ b/public/js/seda-evidence-projection.js
@@ -19,10 +19,22 @@ function sedaEventAttemptId(sessionId, index) {
 
 function mapClassification(classification) {
   if (classification === 'solid' || classification === 'strong') return 'strong';
-  if (classification === 'deep' || classification === 'partial') return 'partial';
-  if (classification === 'shallow' || classification === 'thin') return 'thin';
+  if (
+    classification === 'deep'
+    || classification === 'shallow'
+    || classification === 'partial'
+  ) return 'partial';
   if (classification === 'misconception' || classification === 'wrong_direction') return 'wrong_direction';
-  return null;
+  return classification ? 'thin' : null;
+}
+
+function gapsForEarlyAttempt(evaluation) {
+  const correction = typeof evaluation?.gap_description === 'string'
+    ? evaluation.gap_description.trim()
+    : '';
+  return correction
+    ? [{ mechanism: 'target mechanism', correction }]
+    : [];
 }
 
 function latestColdAttemptEvent(data) {
@@ -50,20 +62,23 @@ function attemptedNodeRecord(record) {
   return attempted.length === 1 ? attempted[0] : null;
 }
 
-function restampedAttempts({ backendRecord, sessionId, now, offset }) {
-  return backendRecord.attempts.map((attempt, index) => ({
-    id: sedaAttemptId(sessionId, index),
-    at: now,
-    user_text: attempt.user_text,
-    classification: attempt.classification,
-    gaps: Array.isArray(attempt.gaps) ? attempt.gaps : [],
-    grader_version: attempt.grader_version || 'seda-loop',
-    // Positional provenance, matching training-store.js: projection re-stamps
-    // every attempt to one real sitting, so the backend's simulated cold/spaced
-    // timing is derived from position here, never copied verbatim (a backend
-    // "spaced" label would otherwise falsely imply a real spaced return).
-    kind: offset + index === 0 ? 'cold' : 'spaced',
-  }));
+function restampedAttempts({ backendRecord, sessionId, now, offset, startIndex = 0 }) {
+  return backendRecord.attempts.slice(startIndex).map((attempt, localIndex) => {
+    const backendIndex = startIndex + localIndex;
+    return {
+      id: sedaAttemptId(sessionId, backendIndex),
+      at: now,
+      user_text: attempt.user_text,
+      classification: attempt.classification,
+      gaps: Array.isArray(attempt.gaps) ? attempt.gaps : [],
+      grader_version: attempt.grader_version || 'seda-loop',
+      // Positional provenance, matching training-store.js: projection re-stamps
+      // every attempt to one real sitting, so the backend's simulated cold/spaced
+      // timing is derived from position here, never copied verbatim (a backend
+      // "spaced" label would otherwise falsely imply a real spaced return).
+      kind: offset + localIndex === 0 ? 'cold' : 'spaced',
+    };
+  });
 }
 
 function restampedRepairs({ backendRecord, sessionId, now }) {
@@ -131,9 +146,7 @@ export function projectLatestSedaAttemptEvent({
             at: now,
             user_text: coldAttempt.text,
             classification: coldAttempt.classification,
-            gaps: Array.isArray(coldAttempt.event?.evaluation?.gaps)
-              ? coldAttempt.event.evaluation.gaps
-              : [],
+            gaps: gapsForEarlyAttempt(coldAttempt.event?.evaluation),
             grader_version: coldAttempt.event?.evaluation?.prompt_version
               || coldAttempt.event?.evaluation?.grader_version
               || 'seda-loop',
@@ -172,11 +185,42 @@ export function projectCompletedSedaRecord({
     return null;
   }
 
+  // A recordable cold event may already have been projected to unlock study
+  // before the SEDA case completed. Reconcile that provisional event into the
+  // canonical completed-session attempt instead of appending the same learner
+  // answer twice under a second id.
+  const eventPrefix = `seda-${sessionId}-event-`;
+  const eventAttemptIndex = existingAttempts.findIndex(
+    (attempt) => String(attempt?.id || '').startsWith(eventPrefix),
+  );
+  const reconciledAttempts = [...existingAttempts];
+  let completedStartIndex = 0;
+  if (eventAttemptIndex >= 0) {
+    const [completedCold] = restampedAttempts({
+      backendRecord,
+      sessionId,
+      now,
+      offset: eventAttemptIndex,
+    });
+    reconciledAttempts[eventAttemptIndex] = {
+      ...completedCold,
+      at: existingAttempts[eventAttemptIndex]?.at || now,
+      kind: existingAttempts[eventAttemptIndex]?.kind || completedCold.kind,
+    };
+    completedStartIndex = 1;
+  }
+
   const projected = {
     ...existing,
     attempts: [
-      ...existingAttempts,
-      ...restampedAttempts({ backendRecord, sessionId, now, offset: existingAttempts.length }),
+      ...reconciledAttempts,
+      ...restampedAttempts({
+        backendRecord,
+        sessionId,
+        now,
+        offset: reconciledAttempts.length,
+        startIndex: completedStartIndex,
+      }),
     ],
     repairs: [
       ...(Array.isArray(existing.repairs) ? existing.repairs : []),

--- a/public/js/seda-route-binding.js
+++ b/public/js/seda-route-binding.js
@@ -1,0 +1,170 @@
+const ROUTE_BOUND_NODE_KEY = 'seda_route_bound_node_id';
+const ROUTE_BOUND_SESSION_KEY = 'seda_route_bound_session_id';
+export const SOURCE_LESS_ROUTE_CONTRACT_VERSION = 1;
+
+function clean(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function invalidRoute(reason) {
+  const error = new Error(`Invalid source-less SEDA route: ${reason}`);
+  error.code = 'route_unavailable';
+  error.reason = reason;
+  return error;
+}
+
+export function hasBoundSourceLessSedaRoute(graphData) {
+  return Boolean(boundSourceLessSedaNodeId(graphData));
+}
+
+export function boundSourceLessSedaNodeId(graphData) {
+  return clean(graphData?.metadata?.[ROUTE_BOUND_NODE_KEY]);
+}
+
+export function boundSourceLessSedaSessionId(graphData) {
+  return clean(graphData?.metadata?.[ROUTE_BOUND_SESSION_KEY]);
+}
+
+export function clearBoundSourceLessSedaRoute(graphData) {
+  const metadata = graphData?.metadata && typeof graphData.metadata === 'object'
+    ? { ...graphData.metadata }
+    : {};
+  delete metadata[ROUTE_BOUND_NODE_KEY];
+  delete metadata[ROUTE_BOUND_SESSION_KEY];
+  return {
+    ...(graphData || {}),
+    metadata: {
+      ...metadata,
+      route_status: 'pending_seda',
+      graph_neutral: true,
+    },
+  };
+}
+
+export function readySourceLessSedaRoute(data) {
+  const result = data?.sourceLessRoute;
+  if (result?.status === 'route_unavailable' || result?.code === 'route_unavailable') {
+    throw invalidRoute(result.reason || 'route_unavailable');
+  }
+  if (!result || typeof result !== 'object') throw invalidRoute('missing sourceLessRoute result');
+  if (result.contractVersion !== SOURCE_LESS_ROUTE_CONTRACT_VERSION) {
+    throw invalidRoute('unsupported sourceLessRoute contractVersion');
+  }
+  if (result.status !== 'ready') throw invalidRoute('sourceLessRoute is not ready');
+  if (data?.awaiting?.key !== 'cold_attempt') {
+    throw invalidRoute('ready route must await cold_attempt');
+  }
+  return {
+    first_node: result.firstNode,
+    provisional_map: result.provisionalMap,
+  };
+}
+
+function appMetadata(existingMap, concept) {
+  const metadata = existingMap?.metadata && typeof existingMap.metadata === 'object'
+    ? existingMap.metadata
+    : {};
+  const values = {
+    starting_map_context: clean(concept?.startingMapContext)
+      || clean(metadata.starting_map_context),
+    source_mode: clean(concept?.sourceMode)
+      || clean(concept?.source_mode)
+      || clean(metadata.source_mode)
+      || 'source_less',
+    map_maturity: clean(metadata.map_maturity) || clean(concept?.mapMaturity),
+    learner_goal: clean(concept?.learnerGoal) || clean(metadata.learner_goal),
+  };
+  return Object.fromEntries(Object.entries(values).filter(([, value]) => value));
+}
+
+function boundNode(target, firstNode) {
+  const scaffold = target?.learner_scaffold && typeof target.learner_scaffold === 'object'
+    ? target.learner_scaffold
+    : {};
+  const evidenceGoal = clean(firstNode.evidence_goal) || clean(scaffold.evidence_goal);
+  return {
+    ...target,
+    id: clean(firstNode.id),
+    label: clean(firstNode.label),
+    mechanism: clean(firstNode.mechanism),
+    study_note: clean(firstNode.mechanism),
+    purpose: evidenceGoal || clean(target?.purpose),
+    learner_scaffold: {
+      ...scaffold,
+      task_label: clean(scaffold.task_label) || clean(firstNode.label),
+      task_cue: clean(scaffold.task_cue) || evidenceGoal,
+      entry_prompt: clean(firstNode.learner_prompt),
+      evidence_goal: evidenceGoal,
+    },
+  };
+}
+
+/** Bind the first source-less Door session to the route SEDA actually chose. */
+export function bindSourceLessSedaRoute({ data, existingMap = null, concept = null } = {}) {
+  const sessionId = clean(data?.sessionId);
+  if (!sessionId) throw invalidRoute('missing sessionId');
+  const route = readySourceLessSedaRoute(data);
+  const firstNode = route.first_node;
+  const routeMap = route.provisional_map;
+  if (!firstNode || typeof firstNode !== 'object') throw invalidRoute('missing first_node');
+  for (const field of ['id', 'label', 'learner_prompt', 'mechanism']) {
+    if (!clean(firstNode[field])) throw invalidRoute(`missing first_node.${field}`);
+  }
+  if (!routeMap || typeof routeMap !== 'object') throw invalidRoute('missing provisional_map');
+  if (!Array.isArray(routeMap.backbone) || routeMap.backbone.length === 0) {
+    throw invalidRoute('provisional_map.backbone must be non-empty');
+  }
+  if (!Array.isArray(routeMap.clusters)) {
+    throw invalidRoute('provisional_map.clusters must be an array');
+  }
+
+  const firstNodeId = clean(firstNode.id);
+  let matches = 0;
+  let nodeType = null;
+  const bindMatch = (node, type) => {
+    if (clean(node?.id) !== firstNodeId) return { ...node };
+    matches += 1;
+    nodeType = type;
+    return boundNode(node, firstNode);
+  };
+  const backbone = routeMap.backbone.map((node) => bindMatch(node, 'backbone'));
+  const clusters = routeMap.clusters.map((cluster) => ({
+    ...cluster,
+    subnodes: Array.isArray(cluster?.subnodes)
+      ? cluster.subnodes.map((node) => bindMatch(node, 'subnode'))
+      : [],
+  }));
+  if (matches !== 1) {
+    throw invalidRoute(matches ? 'first_node.id is duplicated in provisional_map' : 'first_node.id is absent from provisional_map');
+  }
+
+  const evidenceGoal = clean(firstNode.evidence_goal);
+  return {
+    graphData: {
+      ...routeMap,
+      metadata: {
+        ...(routeMap.metadata && typeof routeMap.metadata === 'object' ? routeMap.metadata : {}),
+        ...appMetadata(existingMap, concept),
+        [ROUTE_BOUND_NODE_KEY]: firstNodeId,
+        [ROUTE_BOUND_SESSION_KEY]: sessionId,
+      },
+      backbone,
+      clusters,
+    },
+    nodeContext: {
+      id: firstNodeId,
+      type: nodeType,
+      label: clean(firstNode.label),
+      fullLabel: clean(firstNode.label),
+      detail: clean(firstNode.mechanism),
+      prompt: clean(firstNode.learner_prompt),
+      purpose: evidenceGoal,
+      learner_scaffold: {
+        task_label: clean(firstNode.label),
+        task_cue: evidenceGoal,
+        entry_prompt: clean(firstNode.learner_prompt),
+        evidence_goal: evidenceGoal,
+      },
+    },
+  };
+}

--- a/public/js/seda-visible-prompt.js
+++ b/public/js/seda-visible-prompt.js
@@ -64,12 +64,10 @@ export function learnerVisibleSedaText(text) {
 
 export function visibleSedaPromptFromResponse(data) {
   if (data?.caseComplete) {
-    const state = data?.record?.derived?.[0]?.nodes
-      ? Object.values(data.record.derived[0].nodes)[0]?.state
-      : null;
-    return state
-      ? `Session complete. Evidence record saved: ${state}.`
-      : 'Session complete. Evidence record saved.';
+    // Derived graph states are private routing data. Keep completion copy
+    // controlled so rehydrating another tab cannot expose labels such as
+    // "primed" or "solidified" to the learner.
+    return 'Your attempt is on record. Study is ready.';
   }
 
   const cta = learnerVisibleSedaText(data?.awaiting?.ctaText || data?.awaiting?.ctaLabel || '');

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,4 +6,4 @@
 @import './css/board-first.css?v=6';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=5';
-@import './css/concept-page.css?v=54';
+@import './css/concept-page.css?v=55';

--- a/requirements-loop.txt
+++ b/requirements-loop.txt
@@ -1,0 +1,2 @@
+google-genai==1.74.0
+pydantic==2.13.3

--- a/scripts/check_frontend_cache_pins.py
+++ b/scripts/check_frontend_cache_pins.py
@@ -11,10 +11,17 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 APP_JS = "public/js/app.js"
+LAUNCH_PAD_JS = "public/js/launch-pad.js"
 CSS_INDEX = "public/css/index.css"
 INDEX_HTML = "public/index.html"
 STYLES_CSS = "public/styles.css"
-VERSIONED_PARENT_PATHS = (APP_JS, CSS_INDEX, INDEX_HTML, STYLES_CSS)
+VERSIONED_PARENT_PATHS = (
+    APP_JS,
+    LAUNCH_PAD_JS,
+    CSS_INDEX,
+    INDEX_HTML,
+    STYLES_CSS,
+)
 _VERSIONED_REFERENCE_RE = re.compile(
     r"(?P<quote>['\"])(?P<asset>[^'\"]+?)\?v=(?P<pin>[0-9]+)(?:[&#][^'\"]*)?(?P=quote)"
 )

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -194,6 +194,16 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               }
               assert(rejected, `${message}: did not reject`);
             };
+            const throws = (fn, pattern, message) => {
+              let rejected = false;
+              try {
+                fn();
+              } catch (err) {
+                rejected = true;
+                assert(pattern.test(String(err?.message || err)), message);
+              }
+              assert(rejected, `${message}: did not throw`);
+            };
 
             const html = await import('/js/html.js');
             assert(html.escHtml(`<&>"'`) === '&lt;&amp;&gt;&quot;&#39;', 'html escaping');
@@ -949,6 +959,93 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               'drill verdict fallback prompt',
             );
 
+            const aiService = await import('/js/ai_service.js');
+            throws(
+              () => aiService.createSedaTurnSubmission(
+                'answer', -1, '11111111-1111-4111-8111-111111111111'
+              ),
+              /nonnegative SEDA expectedVersion/,
+              'seda turn version guard',
+            );
+            throws(
+              () => aiService.sendSedaTurn('session-id', null),
+              /SEDA turn submission is required/,
+              'seda turn submission guard',
+            );
+
+            const routeBinding = await import('/js/seda-route-binding.js');
+            const baseRoute = {
+              contractVersion: 1,
+              status: 'ready',
+              firstNode: {
+                id: 'route-node', label: 'Route node',
+                mechanism: 'A retained change affects the next response.',
+                learner_prompt: 'What changes the later response?',
+              },
+              provisionalMap: {
+                metadata: {},
+                backbone: [{ id: 'route-backbone', principle: 'A retained change matters.' }],
+                clusters: [{ id: 'route-cluster', subnodes: [{ id: 'route-node' }] }],
+              },
+            };
+            throws(
+              () => routeBinding.readySourceLessSedaRoute({
+                awaiting: { key: 'cold_attempt' },
+                sourceLessRoute: { ...baseRoute, contractVersion: 99 },
+              }),
+              /unsupported sourceLessRoute contractVersion/,
+              'route contract version guard',
+            );
+            throws(
+              () => routeBinding.readySourceLessSedaRoute({
+                awaiting: { key: 'launch_attempt' }, sourceLessRoute: baseRoute,
+              }),
+              /ready route must await cold_attempt/,
+              'route awaiting-state guard',
+            );
+            throws(
+              () => routeBinding.bindSourceLessSedaRoute({
+                data: {
+                  sessionId: 'route-session', awaiting: { key: 'cold_attempt' },
+                  sourceLessRoute: {
+                    ...baseRoute,
+                    provisionalMap: { ...baseRoute.provisionalMap, backbone: [] },
+                  },
+                },
+              }),
+              /backbone must be non-empty/,
+              'route backbone guard',
+            );
+            throws(
+              () => routeBinding.bindSourceLessSedaRoute({
+                data: {
+                  sessionId: 'route-session', awaiting: { key: 'cold_attempt' },
+                  sourceLessRoute: {
+                    ...baseRoute,
+                    provisionalMap: { ...baseRoute.provisionalMap, clusters: null },
+                  },
+                },
+              }),
+              /clusters must be an array/,
+              'route cluster guard',
+            );
+            throws(
+              () => routeBinding.bindSourceLessSedaRoute({
+                data: {
+                  sessionId: 'route-session', awaiting: { key: 'cold_attempt' },
+                  sourceLessRoute: {
+                    ...baseRoute,
+                    provisionalMap: {
+                      ...baseRoute.provisionalMap,
+                      backbone: [{ id: 'route-node' }],
+                    },
+                  },
+                },
+              }),
+              /first_node.id is duplicated/,
+              'duplicate route node guard',
+            );
+
             const sedaProjection = await import('/js/seda-evidence-projection.js');
             same(
               sedaProjection.projectLatestSedaAttemptEvent({
@@ -989,8 +1086,8 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
                 nodeId: 'n',
                 sessionId: 'sess-browser',
                 data: { events: [{ type: 'cold_attempt', text: 'No usable classification', evaluation: { classification: 'unknown' } }] },
-              }) === null,
-              'seda projection skips unmapped classifications',
+              }).node_records.n.attempts[0].classification === 'thin',
+              'seda projection mirrors canonical unknown-to-thin storage',
             );
             const duplicateProjection = sedaProjection.projectLatestSedaAttemptEvent({
               training: {
@@ -1009,6 +1106,40 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               data: { events: [{ type: 'cold_attempt', text: 'Already captured', evaluation: { classification: 'solid' } }] },
             });
             assert(duplicateProjection === null, 'seda projection skips duplicate event attempt ids');
+            const earlyProjection = sedaProjection.projectLatestSedaAttemptEvent({
+              conceptId: 'reconcile-concept',
+              nodeId: 'reconcile-node',
+              sessionId: 'reconcile-session',
+              now: '2026-07-09T05:00:00.000Z',
+              data: { events: [{
+                type: 'cold_attempt', text: 'Something remains.',
+                evaluation: { classification: 'shallow', gap_description: 'Name what remains.' },
+              }] },
+            });
+            const reconciledProjection = sedaProjection.projectCompletedSedaRecord({
+              training: earlyProjection,
+              conceptId: 'reconcile-concept',
+              nodeId: 'reconcile-node',
+              sessionId: 'reconcile-session',
+              now: '2026-07-09T05:05:00.000Z',
+              record: { training: { node_records: { backend: {
+                attempts: [
+                  {
+                    user_text: 'Something remains.', classification: 'partial',
+                    gaps: [{ mechanism: 'target mechanism', correction: 'Name what remains.' }],
+                  },
+                  { user_text: 'It responds sooner.', classification: 'strong', gaps: [] },
+                ],
+                repairs: [],
+              } } } },
+            });
+            same(
+              reconciledProjection.node_records['reconcile-node'].attempts.map(
+                (attempt) => attempt.id
+              ),
+              ['seda-reconcile-session-0', 'seda-reconcile-session-1'],
+              'seda projection reconciles early event with completed record',
+            );
 
             const conceptPage = await import('/js/concept-page-view.js');
             const conceptConstellation = await import('/js/concept-constellation-view.js');

--- a/tests/e2e/test_drill_chamber.py
+++ b/tests/e2e/test_drill_chamber.py
@@ -441,18 +441,26 @@ def test_drill_chamber_opens_inline_inside_concept_view(
     expect(clean_page.locator("#chamber-composer")).not_to_have_attribute(
         "placeholder", "Preparing your first question"
     )
-    expect(clean_page.locator("#chamber-send")).to_have_text("Check reconstruction")
-    expect(clean_page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Pressure check")
+    expect(clean_page.locator("#chamber-send")).to_have_text("Check my answer")
+    expect(clean_page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Reconstruction")
     expect(clean_page.locator("#drill-chamber-view")).to_contain_text(
         "Reconstruct Entry A from memory"
     )
     expect(clean_page.locator("#drill-chamber-view")).not_to_contain_text(
         "ANSWER KEY SHOULD NOT APPEAR"
     )
-    clean_page.evaluate("window.DrillChamber.setLoading(true)")
+    clean_page.evaluate(
+        "window.DrillChamber.setLoading(true, { checkingAnswer: true })"
+    )
     expect(clean_page.locator("#chamber-composer")).to_be_enabled()
     expect(clean_page.locator("#chamber-composer")).to_have_attribute(
         "placeholder", "Write your reconstruction here. Fragments are fine."
+    )
+    expect(clean_page.locator("#chamber-verdict")).to_contain_text(
+        "Answer received", timeout=2_000
+    )
+    expect(clean_page.locator("#chamber-verdict")).to_contain_text(
+        "Checking the link you wrote."
     )
     clean_page.evaluate("window.DrillChamber.setLoading(false)")
     expect(clean_page.locator(".node-strip")).to_be_visible()
@@ -499,6 +507,68 @@ def test_drill_chamber_opens_inline_inside_concept_view(
     expect(clean_page.locator(".concept-page-b2__route-item.is-active")).to_have_attribute(
         "data-entry-id", "entry-b"
     )
+
+
+def test_mobile_first_session_actions_fit_without_horizontal_shift(
+    clean_page: Page, base_url: str
+) -> None:
+    """Primary Door and chamber actions remain tappable at narrow widths."""
+    clean_page.set_viewport_size({"width": 390, "height": 844})
+    _enter_app_shell_as_guest(clean_page, base_url)
+
+    for width in (390, 320):
+        clean_page.set_viewport_size({"width": width, "height": 700})
+        door_box = clean_page.locator("#hero-door-submit").bounding_box()
+        assert door_box is not None
+        assert door_box["height"] >= 44
+
+    _seed_concept_with_graph(clean_page)
+    clean_page.evaluate("window.App.openLibraryConcept('drill-test-concept')")
+    clean_page.evaluate(
+        """window.App.startDrill({
+            id: 'entry-a',
+            label: 'Entry A',
+            fullLabel: 'Entry A',
+            detail: 'Describe what Entry A means in your own words.',
+        })"""
+    )
+    expect(clean_page.locator("#drill-chamber-view")).to_be_visible()
+    clean_page.evaluate(
+        """() => {
+            document.getElementById('chamber-mic').hidden = false;
+            document.getElementById('chamber-tutor-voice').hidden = false;
+        }"""
+    )
+
+    for width in (390, 320):
+        clean_page.set_viewport_size({"width": width, "height": 700})
+        geometry = clean_page.evaluate(
+            """() => {
+                const box = (selector) => {
+                    const rect = document.querySelector(selector).getBoundingClientRect();
+                    return { left: rect.left, right: rect.right, height: rect.height };
+                };
+                const map = document.getElementById('map-view');
+                const header = document.querySelector('.main-header');
+                return {
+                    actions: box('.drill-chamber__composer-actions'),
+                    send: box('#chamber-send'),
+                    mic: box('#chamber-mic'),
+                    voice: box('#chamber-tutor-voice'),
+                    exit: box('#chamber-exit'),
+                    headerHeight: header.getBoundingClientRect().height,
+                    mapPaddingTop: parseFloat(getComputedStyle(map).paddingTop),
+                    mapClientWidth: map.clientWidth,
+                    mapScrollWidth: map.scrollWidth,
+                };
+            }"""
+        )
+        assert geometry["send"]["left"] >= geometry["actions"]["left"]
+        assert geometry["send"]["right"] <= geometry["actions"]["right"] + 0.5
+        assert abs(geometry["mapPaddingTop"] - geometry["headerHeight"]) <= 0.5
+        assert geometry["mapScrollWidth"] <= geometry["mapClientWidth"]
+        for target in ("send", "mic", "voice", "exit"):
+            assert geometry[target]["height"] >= 44
 
 
 def test_drill_start_from_non_map_view_routes_to_inline_concept(

--- a/tests/e2e/test_gestalt_hybrid_launch_qa.py
+++ b/tests/e2e/test_gestalt_hybrid_launch_qa.py
@@ -2,12 +2,13 @@
 
 Run against a local dev server:
 
-    SOCRATINK_E2E_LOCAL_GUEST=1 pytest tests/e2e/test_gestalt_hybrid_launch_qa.py -v
+    SOCRATINK_E2E_LOCAL_GUEST=1 SOCRATINK_TUI_FAKE_LLM=1 \
+      pytest tests/e2e/test_gestalt_hybrid_launch_qa.py -v
 
-This test uses the real Ignition and Launch Pad UI. It mocks only the two AI
-network seams so the pass is fast and deterministic while still catching
-frontend regressions, console errors, failed requests, and unexpected 4xx/5xx
-responses.
+This test uses the real Ignition and Launch Pad UI. It mocks extraction and the
+retired drill seam while the app-local SEDA route uses the deterministic fake
+bridge, so the pass still catches frontend regressions, console errors, failed
+requests, and unexpected 4xx/5xx responses.
 """
 
 from __future__ import annotations
@@ -231,30 +232,53 @@ def test_source_less_launch_pad_end_to_end_qa(
     canvas = clean_page.locator(".concept-page-b2__gestalt")
     expect(canvas).to_be_visible(timeout=10_000)
     expect(clean_page.locator("#drill-chamber-view")).to_be_visible(timeout=10_000)
-    expect(clean_page.locator("#chamber-question")).to_contain_text(
-        "What do you think the thermostat checks before it calls for heat?",
-        timeout=20_000,
-    )
     seda_state = clean_page.wait_for_function(
         """() => {
           const key = Object.keys(localStorage).find((k) => k.startsWith('socratink:seda-session:v1:'));
           if (!key) return null;
           const value = JSON.parse(localStorage.getItem(key));
-          return value?.sessionId && value?.latest ? value : null;
+          return value?.sessionId && value?.latest?.awaiting?.key === 'cold_attempt'
+            ? value
+            : null;
         }""",
         timeout=20_000,
     ).json_value()
-    assert seda_state["latest"]["awaiting"]["key"] in {"learner_goal", "launch_attempt"}
+    assert seda_state["latest"]["awaiting"]["key"] == "cold_attempt"
+    bound_surface = clean_page.evaluate(
+        """(nodeId) => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts') || '[]')
+            .find((item) => item.id === conceptId);
+          const graph = JSON.parse(concept?.graphData || 'null');
+          const nodes = [
+            ...(graph?.backbone || []),
+            ...(graph?.clusters || []).flatMap((cluster) => cluster?.subnodes || []),
+          ];
+          const node = nodes.find((item) => item?.id === nodeId);
+          return {
+            prompt: node?.learner_scaffold?.entry_prompt || '',
+            taskLabel: node?.learner_scaffold?.task_label || node?.label || '',
+            mechanism: node?.study_note || node?.mechanism || '',
+          };
+        }""",
+        seda_state["nodeId"],
+    )
+    assert bound_surface["prompt"]
+    assert bound_surface["taskLabel"]
+    assert bound_surface["mechanism"]
+    expect(clean_page.locator("#chamber-question")).to_have_text(
+        bound_surface["prompt"], timeout=20_000
+    )
     clean_page.locator("#chamber-exit").click()
     expect(clean_page.locator("#drill-chamber-view")).to_be_hidden()
     expect(canvas).to_be_visible(timeout=10_000)
     expect(canvas).not_to_contain_text("Shaped by your sketch")
     expect(canvas.locator(".concept-page-b2__attempt")).to_contain_text(
-        "What do you think the thermostat checks before it calls for heat?"
+        bound_surface["prompt"]
     )
-    expect(canvas).to_contain_text("Compare target")
+    expect(canvas).to_contain_text(bound_surface["taskLabel"])
     expect(canvas).not_to_contain_text("Call for heat")
-    expect(canvas).not_to_contain_text("compares measured room temperature")
+    expect(canvas).not_to_contain_text(bound_surface["mechanism"])
     expect(canvas).not_to_contain_text("Generated description should not leak")
     expect(canvas.locator(".concept-page-b2__route-item")).to_have_count(0)
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -969,9 +969,9 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     page.locator(".concept-page-b2__entry-cta").click()
     expect(page.locator("#drill-chamber-view")).to_be_visible()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Pressure check"
+        "Reconstruction"
     )
-    expect(page.locator("#chamber-send")).to_have_text("Check reconstruction")
+    expect(page.locator("#chamber-send")).to_have_text("Check my answer")
     expect(page.locator(".drill-chamber__hint")).to_have_text("A sentence is enough.")
     expect(
         page.locator(".concept-page-b2__active-entry--drilling #drill-chamber-view")
@@ -1203,21 +1203,37 @@ def test_start_learning_enters_seda_loop_from_product_flow(
     page.locator("#hero-door-submit").click()
 
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
-    expect(page.locator("#chamber-question")).to_contain_text(
-        "Why is the second exposure faster?", timeout=20_000
-    )
+    expect(page.locator("#chamber-question")).not_to_have_text("—", timeout=20_000)
     state = page.wait_for_function(
         """() => {
           const conceptId = localStorage.getItem('learnops_active');
           const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
           if (!key) return null;
           const value = JSON.parse(localStorage.getItem(key));
-          return value?.sessionId && value?.latest ? value : null;
+          return value?.sessionId && value?.latest?.awaiting?.key === 'cold_attempt'
+            ? value
+            : null;
         }""",
-        timeout=20_000,
+        timeout=45_000,
     ).json_value()
     assert state["sessionId"]
-    assert state["latest"]["awaiting"]["key"] == "launch_attempt"
+    assert state["latest"]["awaiting"]["key"] == "cold_attempt"
+    bound_study_note = page.evaluate(
+        """(nodeId) => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts') || '[]')
+            .find((item) => item.id === conceptId);
+          const graph = JSON.parse(concept?.graphData || 'null');
+          const nodes = [
+            ...(graph?.backbone || []),
+            ...(graph?.clusters || []).flatMap((cluster) => cluster?.subnodes || []),
+          ];
+          const node = nodes.find((item) => item?.id === nodeId);
+          return node?.study_note || node?.mechanism || '';
+        }""",
+        state["nodeId"],
+    )
+    assert bound_study_note
     page.locator("#chamber-send").click()
     expect(page.locator("#chamber-hint")).to_have_text(
         "Write a sentence before checking."
@@ -1233,7 +1249,7 @@ def test_start_learning_enters_seda_loop_from_product_flow(
           const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
           if (!key) return null;
           const value = JSON.parse(localStorage.getItem(key));
-          return value?.latest?.awaiting?.key !== 'launch_attempt' ? value : null;
+          return value?.latest?.awaiting?.key !== 'cold_attempt' ? value : null;
         }""",
         timeout=45_000,
     ).json_value()
@@ -1272,47 +1288,97 @@ def test_start_learning_enters_seda_loop_from_product_flow(
         })"""
     )
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
-    expect(page.locator("#chamber-question")).to_contain_text(
-        "What persists after the first exposure?", timeout=20_000
+    expect(page.locator("#chamber-question")).to_have_text(
+        "This learning route cannot be resumed. Your recorded work is still on the map.",
+        timeout=20_000,
     )
+    expect(page.locator("#chamber-send")).to_have_text("Return to map")
     different_node_state = page.wait_for_function(
         """() => {
           const conceptId = localStorage.getItem('learnops_active');
           const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
           if (!key) return null;
           const value = JSON.parse(localStorage.getItem(key));
-          return value?.nodeId === 'c1_s2' && value?.sessionId ? value : null;
+          return value?.nodeId === 'c1_s1' && value?.sessionId ? value : null;
         }""",
         timeout=20_000,
     ).json_value()
-    assert different_node_state["sessionId"] != state["sessionId"]
-    page.locator("#chamber-exit").click()
+    assert different_node_state["sessionId"] == state["sessionId"]
+    page.locator("#chamber-send").click()
     page.reload()
-    expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible(
-        timeout=20_000
+    persisted_attempt = page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:training:v1:${conceptId}` : null;
+          if (!key) return null;
+          const training = JSON.parse(localStorage.getItem(key) || 'null');
+          return training?.node_records?.c1_s1?.attempts?.[0] || null;
+        }""",
+        timeout=20_000,
+    ).json_value()
+    assert persisted_attempt["user_text"] == (
+        "Memory cells remain after the first exposure and make the second response faster."
+    )
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
+        "Reveal notes and compare", timeout=20_000
     )
     page.on("request", remember_resume_drill)
-    resume_text = "Memory cells stay available and respond faster on the next exposure."
-    page.locator(".concept-page-b2__attempt-input").fill(resume_text)
-    with page.expect_request(
-        lambda request: (
-            request.method == "POST"
-            and "/api/session/" in request.url
-            and request.url.endswith("/turn")
-            and request.post_data_json == {"text": resume_text}
-        )
-    ) as resume_turn:
-        page.locator(".concept-page-b2__attempt-save").click()
-    assert resume_turn.value.post_data_json == {"text": resume_text}
-    expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
+    page.locator(".concept-page-b2__entry-cta").click()
+    expect(page.locator(".concept-page-b2__study-note")).to_contain_text(
+        bound_study_note,
+        timeout=20_000,
+    )
     assert resume_drill_requests == []
     expect(page.locator("#nav-loop")).to_have_count(0)
 
 
-def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
+def _seda_route_event(
+    *,
+    node_id: str = "c1_s1",
+    label: str = "Memory cells",
+    prompt: str = "Why is the second exposure faster?",
+    mechanism: str = "Memory cells persist after exposure.",
+) -> dict:
+    """Small valid route event for source-less SEDA browser stubs."""
+    cluster_id = node_id.split("_s", 1)[0]
+    return {
+        "type": "route_generated",
+        "first_node": {
+            "id": node_id,
+            "kc_id": node_id,
+            "label": label,
+            "mechanism": mechanism,
+            "learner_prompt": prompt,
+            "evidence_goal": "Explain one causal link from memory.",
+        },
+        "node_ids": [node_id],
+        "provisional_map": {
+            "metadata": {"core_thesis": f"{label} changes the later response."},
+            "backbone": [{"id": "b-route", "principle": "A retained change affects a later response."}],
+            "clusters": [{
+                "id": cluster_id,
+                "label": label,
+                "subnodes": [{"id": node_id, "label": label}],
+            }],
+        },
+    }
+
+
+def _seda_route_result(**kwargs) -> dict:
+    """Versioned app-facing route result; raw events are audit-only."""
+    event = _seda_route_event(**kwargs)
+    return {
+        "contractVersion": 1,
+        "status": "ready",
+        "firstNode": event["first_node"],
+        "provisionalMap": event["provisional_map"],
+    }
+
+
+def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
     clean_page: Page, base_url: str
 ) -> None:
-    """A non-final SEDA turn should show feedback, then require an explicit continue."""
+    """The Door sketch bootstraps SEDA; the first room answer earns study."""
     page = clean_page
     _enter_app_shell_as_guest(page, base_url)
 
@@ -1330,9 +1396,9 @@ def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
                         "subnodes": [{
                             "id": "c1_s1",
                             "label": "Memory cells",
-                            "mechanism": "Memory cells persist after exposure.",
+                            "mechanism": "Door mechanism A should be replaced.",
                             "learner_scaffold": {
-                                "entry_prompt": "Why is the second exposure faster?",
+                                "entry_prompt": "Door prompt A should be replaced.",
                                 "task_cue": "Explain the role of memory cells.",
                             },
                         }],
@@ -1347,6 +1413,7 @@ def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
             content_type="application/json",
             body=json.dumps({
                 "sessionId": "mid-loop-session",
+                "sessionVersion": 1,
                 "status": "awaiting_input",
                 "awaiting": {"key": "launch_attempt", "ctaText": "Try your first explanation."},
                 "learnerTranscript": [],
@@ -1355,28 +1422,45 @@ def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
             }),
         )
 
-    turn_requests = {"count": 0}
+    door_sketch = "The first exposure leaves memory cells."
+    room_answer = (
+        "Memory cells remain after the first exposure and make the second response faster."
+    )
+    routed_prompt = "Route prompt B: why does the later response happen faster?"
+    routed_mechanism = (
+        "Route mechanism B: memory cells persist and activate sooner on re-exposure."
+    )
+    turn_texts: list[str] = []
+    turn_payloads: list[dict] = []
 
     def fulfill_turn(route) -> None:
-        turn_requests["count"] += 1
-        if turn_requests["count"] == 2:
+        turn_payloads.append(route.request.post_data_json)
+        turn_texts.append(route.request.post_data_json["text"])
+        if len(turn_texts) == 1:
             route.fulfill(
                 status=200,
                 content_type="application/json",
                 body=json.dumps({
                     "sessionId": "mid-loop-session",
+                    "sessionVersion": 2,
                     "status": "awaiting_input",
-                    "awaiting": {"key": "compare", "ctaText": "Compare your answer with the note."},
+                    "awaiting": {
+                        "key": "cold_attempt",
+                        "ctaText": "Why is the second exposure faster?",
+                    },
                     "learnerTranscript": [],
-                    "events": [{
-                        "type": "cold_attempt",
-                        "text": "Memory cells remain and respond faster next time.",
-                        "evaluation": {
-                            "classification": "solid",
-                            "gaps": [],
-                            "grader_version": "qa",
-                        },
-                    }],
+                    "events": [_seda_route_event(
+                        node_id="c9_s1",
+                        label="Routed memory target",
+                        prompt=routed_prompt,
+                        mechanism=routed_mechanism,
+                    )],
+                    "sourceLessRoute": _seda_route_result(
+                        node_id="c9_s1",
+                        label="Routed memory target",
+                        prompt=routed_prompt,
+                        mechanism=routed_mechanism,
+                    ),
                     "caseComplete": False,
                     "record": None,
                 }),
@@ -1387,10 +1471,444 @@ def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
             content_type="application/json",
             body=json.dumps({
                 "sessionId": "mid-loop-session",
+                "sessionVersion": 3,
                 "status": "awaiting_input",
-                "awaiting": {"key": "missing_link", "ctaText": "Name the missing link."},
+                "awaiting": {
+                    "key": "compare",
+                    "ctaText": "Compare your answer with the note.",
+                },
                 "learnerTranscript": [],
-                "events": [],
+                "events": [{
+                    "type": "cold_attempt",
+                    "kc_id": "c9_s1",
+                    "text": room_answer,
+                    "evaluation": {
+                        "classification": "deep",
+                        "agent_response": (
+                            "You connected memory cells to the faster response, "
+                            "but not why they react sooner."
+                        ),
+                        "gap_description": "Name why memory cells respond faster.",
+                        "grader_version": "qa",
+                    },
+                }],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    page.route("**/api/extract", fulfill_extract)
+    page.route(re.compile(r".*/api/session$"), fulfill_session)
+    page.route(
+        re.compile(r".*/api/session/mid-loop-session/turn$"),
+        fulfill_turn,
+    )
+    page.evaluate(
+        """() => {
+          window.__sedaQuestionHistory = [];
+          const remember = () => {
+            const question = document.getElementById('chamber-question');
+            const value = question?.textContent?.trim();
+            if (value) window.__sedaQuestionHistory.push(value);
+          };
+          new MutationObserver(remember).observe(document.body, {
+            childList: true, characterData: true, subtree: true,
+          });
+          remember();
+        }"""
+    )
+    page.locator("#nav-ignition").click()
+    page.locator("#hero-single-input-field").fill("why vaccines create immune memory")
+    page.locator("#hero-cold-guess-field").fill(door_sketch)
+    page.locator("#hero-door-submit").click()
+
+    expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
+    page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
+          if (!key) return false;
+          const value = JSON.parse(localStorage.getItem(key) || 'null');
+          if (value?.sessionId !== 'mid-loop-session'
+            || value?.latest?.awaiting?.key !== 'cold_attempt'
+            || value?.nodeId !== 'c9_s1') return false;
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts') || '[]')
+            .find((item) => item.id === conceptId);
+          const graph = JSON.parse(concept?.graphData || 'null');
+          return graph?.clusters?.[0]?.subnodes?.[0]?.id === 'c9_s1';
+        }""",
+        timeout=20_000,
+    )
+    assert turn_texts == [door_sketch]
+    bootstrap_attempts = page.evaluate(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:training:v1:${conceptId}` : null;
+          const training = key ? JSON.parse(localStorage.getItem(key) || 'null') : null;
+          return Object.values(training?.node_records || {})
+            .flatMap((record) => record?.attempts || []).length;
+        }"""
+    )
+    assert bootstrap_attempts == 0
+    expect(page.locator("#chamber-question")).to_have_text(
+        routed_prompt
+    )
+    question_history = page.evaluate("window.__sedaQuestionHistory")
+    assert "Preparing your first question…" in question_history
+    assert "Door prompt A should be replaced." not in question_history
+    expect(page.locator("#chamber-entry-name")).to_have_text("Routed memory target")
+    page.locator("#chamber-composer").fill(room_answer)
+    expect(page.locator("#chamber-send")).to_be_enabled()
+    page.locator("#chamber-composer").press("Control+Enter")
+    expect(page.locator("#chamber-verdict")).to_have_text(
+        re.compile(r"Checked.*Partly there"), timeout=2_000
+    )
+    expect(page.locator("#chamber-verdict")).not_to_contain_text(
+        "You connected memory cells to the faster response, but not why they react sooner."
+    )
+    expect(page.locator("#chamber-send")).to_have_text("See what to study")
+    expect(page.locator("#chamber-composer")).to_be_disabled()
+    expect(page.locator("#chamber-question")).to_have_text(routed_prompt)
+    assert turn_texts == [door_sketch, room_answer]
+    assert [payload["expectedVersion"] for payload in turn_payloads] == [1, 2]
+    projected = page.wait_for_function(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = conceptId ? `socratink:training:v1:${conceptId}` : null;
+          if (!key) return null;
+          const value = JSON.parse(localStorage.getItem(key) || 'null');
+          const record = value?.node_records?.c9_s1;
+          return record?.attempts?.length ? record.attempts[0] : null;
+        }""",
+        timeout=20_000,
+    ).json_value()
+    assert projected["classification"] == "partial"
+    assert projected["kind"] == "cold"
+    assert projected["gaps"] == [{
+        "mechanism": "target mechanism",
+        "correction": "Name why memory cells respond faster.",
+    }]
+    assert page.evaluate(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const key = `socratink:training:v1:${conceptId}`;
+          const training = JSON.parse(localStorage.getItem(key) || 'null');
+          return Boolean(training?.node_records?.c1_s1);
+        }"""
+    ) is False
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_be_hidden()
+    expect(page.locator(".concept-page-b2__study-note")).to_contain_text(
+        routed_mechanism, timeout=20_000
+    )
+
+
+def test_late_source_less_route_cannot_overwrite_a_newly_selected_concept(
+    clean_page: Page, base_url: str
+) -> None:
+    """A delayed route is discarded after exit instead of mutating active state."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate(
+        """() => {
+          const safeGraph = {
+            metadata: { core_thesis: 'Keep this graph unchanged.', sentinel: 'safe' },
+            backbone: [{ id: 'b1', principle: 'Safe principle', dependent_clusters: ['c1'] }],
+            clusters: [{
+              id: 'c1', label: 'Safe cluster', description: 'Safe description',
+              subnodes: [{ id: 'c1_s1', label: 'Safe node', mechanism: 'Safe mechanism.' }],
+            }],
+            relationships: { domain_mechanics: [], learning_prerequisites: [] },
+            frameworks: [],
+          };
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: 'safe-concept', name: 'Safe concept', createdAt: Date.now(),
+            state: 'growing', graphData: JSON.stringify(safeGraph),
+          }]));
+          localStorage.setItem('learnops_active', 'safe-concept');
+        }"""
+    )
+
+    page.route(
+        "**/api/extract",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "route_owner": "seda",
+                "provisional_map": {
+                    "metadata": {
+                        "core_thesis": "Pending source-less shell.",
+                        "route_status": "pending_seda",
+                        "graph_neutral": True,
+                    },
+                    "backbone": [{
+                        "id": "b1", "principle": "Pending shell",
+                        "dependent_clusters": ["c1"],
+                    }],
+                    "clusters": [{
+                        "id": "c1", "label": "Pending", "description": "Pending",
+                        "subnodes": [{
+                            "id": "c1_s1", "label": "Pending",
+                            "mechanism": "Learner sketch only.",
+                            "learner_scaffold": {"entry_prompt": "Provisional prompt must stay hidden."},
+                        }],
+                    }],
+                    "relationships": {"domain_mechanics": [], "learning_prerequisites": []},
+                    "frameworks": [],
+                },
+            }),
+        ),
+    )
+    session_id = "66666666-6666-4666-8666-666666666666"
+    page.route(
+        re.compile(r".*/api/session$"),
+        lambda route: route.fulfill(
+            status=201,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 1,
+                "status": "awaiting_input",
+                "awaiting": {"key": "launch_attempt", "ctaText": "First try"},
+                "caseComplete": False,
+            }),
+        ),
+    )
+    held_turns = []
+    page.route(
+        re.compile(rf".*/api/session/{session_id}/turn$"),
+        lambda route: held_turns.append(route),
+    )
+
+    page.locator("#nav-ignition").click()
+    page.locator("#hero-single-input-field").fill("why immune memory persists")
+    page.locator("#hero-cold-guess-field").fill(
+        "The first exposure leaves something ready for the next one."
+    )
+    page.locator("#hero-door-submit").click()
+    expect(page.locator("#chamber-question")).to_have_text(
+        "Preparing your first question…", timeout=20_000
+    )
+    for _ in range(100):
+        if held_turns:
+            break
+        page.wait_for_timeout(50)
+    assert held_turns, "bootstrap turn never reached the held route"
+    source_concept_id = page.evaluate("localStorage.getItem('learnops_active')")
+    assert source_concept_id != "safe-concept"
+
+    page.locator("#chamber-exit").click()
+    page.evaluate("window.App.selectConcept('safe-concept')")
+    expect(page.locator("#drill-chamber-view")).to_be_hidden()
+    held_turns[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "sessionId": session_id,
+            "sessionVersion": 2,
+            "status": "awaiting_input",
+            "awaiting": {"key": "cold_attempt", "ctaText": "Authoritative prompt"},
+            "sourceLessRoute": _seda_route_result(
+                node_id="route-node", prompt="Authoritative prompt",
+            ),
+            "events": [_seda_route_event(
+                node_id="route-node", prompt="Authoritative prompt",
+            )],
+            "caseComplete": False,
+        }),
+    )
+    page.wait_for_timeout(300)
+
+    snapshot = page.evaluate(
+        """(sourceId) => {
+          const concepts = JSON.parse(localStorage.getItem('learnops_concepts') || '[]');
+          const safe = concepts.find((concept) => concept.id === 'safe-concept');
+          const source = concepts.find((concept) => concept.id === sourceId);
+          const safeGraph = JSON.parse(safe.graphData);
+          const sourceGraph = JSON.parse(source.graphData);
+          return {
+            activeId: localStorage.getItem('learnops_active'),
+            safeSentinel: safeGraph.metadata.sentinel,
+            safeBoundNode: safeGraph.metadata.seda_route_bound_node_id || null,
+            sourceBoundNode: sourceGraph.metadata.seda_route_bound_node_id || null,
+            sourceSession: localStorage.getItem(`socratink:seda-session:v1:${sourceId}`),
+          };
+        }""",
+        source_concept_id,
+    )
+    assert snapshot == {
+        "activeId": "safe-concept",
+        "safeSentinel": "safe",
+        "safeBoundNode": None,
+        "sourceBoundNode": None,
+        "sourceSession": None,
+    }
+
+    normal_drill_requests: list[dict] = []
+
+    def reject_normal_drill(route) -> None:
+        normal_drill_requests.append(route.request.post_data_json)
+        route.fulfill(
+            status=500,
+            content_type="application/json",
+            body=json.dumps({"error": "placeholder_shell_must_not_drill"}),
+        )
+
+    page.route("**/api/drill", reject_normal_drill)
+    page.goto(f"{base_url}/session/{source_concept_id}")
+    draft_after_reload = "This draft was written against the saved shell."
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible(
+        timeout=20_000
+    )
+    page.locator(".concept-page-b2__attempt-input").fill(draft_after_reload)
+    page.locator(".concept-page-b2__attempt-save").click()
+    expect(page.locator("#chamber-question")).to_have_text(
+        "Preparing your first question…", timeout=20_000
+    )
+    for _ in range(100):
+        if len(held_turns) >= 2:
+            break
+        page.wait_for_timeout(50)
+    assert len(held_turns) == 2
+    assert normal_drill_requests == []
+    assert held_turns[1].request.post_data_json["text"] == (
+        "The first exposure leaves something ready for the next one."
+    )
+
+    held_turns[1].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "sessionId": session_id,
+            "sessionVersion": 2,
+            "status": "awaiting_input",
+            "awaiting": {"key": "cold_attempt", "ctaText": "Recovered route prompt"},
+            "sourceLessRoute": _seda_route_result(
+                node_id="route-node", prompt="Recovered route prompt",
+            ),
+            "events": [_seda_route_event(
+                node_id="route-node", prompt="Recovered route prompt",
+            )],
+            "caseComplete": False,
+        }),
+    )
+    expect(page.locator("#chamber-question")).to_have_text(
+        "Recovered route prompt", timeout=20_000
+    )
+    expect(page.locator("#chamber-composer")).to_have_value(draft_after_reload)
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Not recorded against this question."
+    )
+    recovered = page.evaluate(
+        """(sourceId) => {
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts') || '[]')
+            .find((item) => item.id === sourceId);
+          const graph = JSON.parse(concept.graphData);
+          const training = JSON.parse(
+            localStorage.getItem(`socratink:training:v1:${sourceId}`) || 'null'
+          );
+          return {
+            boundNode: graph.metadata.seda_route_bound_node_id,
+            attempts: Object.values(training?.node_records || {})
+              .flatMap((record) => record.attempts || []).length,
+          };
+        }""",
+        source_concept_id,
+    )
+    assert recovered == {"boundNode": "route-node", "attempts": 0}
+
+
+def test_seda_support_turn_is_neutral_and_records_no_evidence(
+    clean_page: Page, base_url: str
+) -> None:
+    """A support turn stays graph-neutral and returns to a new prompt."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+
+    def fulfill_extract(route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {"core_thesis": "Immune memory speeds later response."},
+                    "backbone": [{
+                        "id": "b1",
+                        "principle": "Immune memory persists.",
+                        "learner_scaffold": {
+                            "entry_prompt": "Why is the second exposure faster?",
+                            "task_cue": "Explain one causal link.",
+                        },
+                    }],
+                    "clusters": [],
+                },
+            }),
+        )
+
+    def fulfill_session(route) -> None:
+        route.fulfill(
+            status=201,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "support-turn-session",
+                "sessionVersion": 1,
+                "status": "awaiting_input",
+                "awaiting": {"key": "launch_attempt", "ctaText": "Try your first explanation."},
+                "learnerTranscript": [],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    door_sketch = "The first exposure leaves memory cells."
+    support_text = "I need one more cue."
+    turn_texts: list[str] = []
+    turn_payloads: list[dict] = []
+
+    def fulfill_turn(route) -> None:
+        turn_payloads.append(route.request.post_data_json)
+        turn_texts.append(route.request.post_data_json["text"])
+        if len(turn_texts) == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "sessionId": "support-turn-session",
+                    "sessionVersion": 2,
+                    "status": "awaiting_input",
+                    "awaiting": {
+                        "key": "cold_attempt",
+                        "ctaText": "Why is the second exposure faster?",
+                    },
+                    "learnerTranscript": [],
+                    "events": [_seda_route_event()],
+                    "sourceLessRoute": _seda_route_result(),
+                    "caseComplete": False,
+                    "record": None,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "support-turn-session",
+                "sessionVersion": 3,
+                "status": "awaiting_input",
+                "awaiting": {
+                    "key": "cold_attempt",
+                    "ctaText": "Try one concrete cause.",
+                },
+                "learnerTranscript": [],
+                "events": [{
+                    "type": "cold_help_turn",
+                    "text": support_text,
+                    "answer_mode": "help_request",
+                    "score_eligible": False,
+                    "graph_neutral": True,
+                    "agent_response": "Try one concrete cause.",
+                }],
                 "caseComplete": False,
                 "record": None,
             }),
@@ -1401,55 +1919,43 @@ def test_seda_mid_loop_turn_keeps_composer_gated_until_continue(
     page.route(re.compile(r".*/api/session/[^/]+/turn$"), fulfill_turn)
     page.locator("#nav-ignition").click()
     page.locator("#hero-single-input-field").fill("why vaccines create immune memory")
-    page.locator("#hero-cold-guess-field").fill("The first exposure leaves memory cells.")
+    page.locator("#hero-cold-guess-field").fill(door_sketch)
     page.locator("#hero-door-submit").click()
 
-    expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
     page.wait_for_function(
         """() => {
           const conceptId = localStorage.getItem('learnops_active');
           const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
-          if (!key) return false;
-          const value = JSON.parse(localStorage.getItem(key) || 'null');
-          return value?.sessionId === 'mid-loop-session'
-            && value?.latest?.awaiting?.key === 'launch_attempt';
+          const value = key ? JSON.parse(localStorage.getItem(key) || 'null') : null;
+          return value?.latest?.awaiting?.key === 'cold_attempt';
         }""",
         timeout=20_000,
     )
-    page.locator("#chamber-composer").fill(
-        "Memory cells remain after the first exposure and make the second response faster."
+    page.locator("#chamber-composer").fill(support_text)
+    page.locator("#chamber-send").click()
+
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Use the next question to add one cause-and-effect link.", timeout=2_000
     )
-    expect(page.locator("#chamber-send")).to_be_enabled()
-    page.locator("#chamber-composer").press("Control+Enter")
-    expect(page.locator("#chamber-question")).to_contain_text(
-        "Name the missing link.", timeout=20_000
-    )
-    assert turn_requests["count"] == 1
-    expect(page.locator("#chamber-verdict")).to_contain_text("Checked", timeout=20_000)
+    expect(page.locator("#chamber-verdict")).to_contain_text("Response received")
+    expect(page.locator("#chamber-verdict")).not_to_contain_text("Gap found")
+    expect(page.locator("#chamber-verdict")).not_to_contain_text("Study")
     expect(page.locator("#chamber-send")).to_have_text("Keep going")
     expect(page.locator("#chamber-composer")).to_be_disabled()
-    page.locator("#chamber-send").click()
-    expect(page.locator("#chamber-composer")).to_be_enabled()
-    page.locator("#chamber-composer").fill(
-        "Memory cells remain and respond faster next time."
-    )
-    page.locator("#chamber-composer").press("Control+Enter")
-    expect(page.locator("#chamber-verdict")).to_contain_text("Checked", timeout=20_000)
-    expect(page.locator("#chamber-send")).to_have_text("See what to study")
-    projected = page.wait_for_function(
+    assert turn_texts == [door_sketch, support_text]
+    assert [payload["expectedVersion"] for payload in turn_payloads] == [1, 2]
+    attempt_count = page.evaluate(
         """() => {
           const conceptId = localStorage.getItem('learnops_active');
           const key = conceptId ? `socratink:training:v1:${conceptId}` : null;
-          if (!key) return null;
-          const value = JSON.parse(localStorage.getItem(key) || 'null');
-          const record = value?.node_records?.c1_s1;
-          return record?.attempts?.length ? record.attempts[0] : null;
-        }""",
-        timeout=20_000,
-    ).json_value()
-    assert projected["classification"] == "strong"
-    assert projected["kind"] == "cold"
-    assert turn_requests["count"] == 2
+          const training = key ? JSON.parse(localStorage.getItem(key) || 'null') : null;
+          return Object.values(training?.node_records || {})
+            .flatMap((record) => record?.attempts || []).length;
+        }"""
+    )
+    assert attempt_count == 0
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-composer")).to_be_enabled()
 
 
 def test_seda_start_failure_offers_retry_from_product_flow(
@@ -1495,14 +2001,68 @@ def test_seda_start_failure_offers_retry_from_product_flow(
             content_type="application/json",
             body=json.dumps({
                 "sessionId": "retry-session",
+                "sessionVersion": 1,
                 "awaiting": {"key": "launch_attempt", "ctaText": "Try your first explanation."},
                 "learnerTranscript": [],
                 "caseComplete": False,
             }),
         )
 
+    bootstrap_turns: list[str] = []
+    turn_payloads: list[dict] = []
+
+    def fulfill_turn(route) -> None:
+        payload = route.request.post_data_json
+        turn_payloads.append(payload)
+        bootstrap_turns.append(payload["text"])
+        if len(bootstrap_turns) == 2:
+            route.fulfill(
+                status=503,
+                content_type="application/json",
+                body=json.dumps({"detail": "Loop turn unavailable."}),
+            )
+            return
+        if len(bootstrap_turns) > 2:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "sessionId": "retry-session",
+                    "sessionVersion": 3,
+                    "status": "awaiting_input",
+                    "awaiting": {"key": "cold_attempt", "ctaText": "Try one concrete cause."},
+                    "events": [{
+                        "type": "cold_help_turn", "text": payload["text"],
+                        "answer_mode": "help_request", "score_eligible": False,
+                        "graph_neutral": True, "agent_response": "Try one concrete cause.",
+                    }],
+                    "caseComplete": False,
+                    "record": None,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "retry-session",
+                "sessionVersion": 2,
+                "status": "awaiting_input",
+                "awaiting": {
+                    "key": "cold_attempt",
+                    "ctaText": "Why is the second exposure faster?",
+                },
+                "learnerTranscript": [],
+                "events": [_seda_route_event()],
+                "sourceLessRoute": _seda_route_result(),
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
     page.route("**/api/extract", fulfill_extract)
     page.route(re.compile(r".*/api/session$"), fulfill_session)
+    page.route(re.compile(r".*/api/session/[^/]+/turn$"), fulfill_turn)
     page.locator("#nav-ignition").click()
     page.locator("#hero-single-input-field").fill("why vaccines create immune memory")
     page.locator("#hero-cold-guess-field").fill("The first exposure leaves memory cells.")
@@ -1516,12 +2076,1115 @@ def test_seda_start_failure_offers_retry_from_product_flow(
     )
     expect(page.locator("#chamber-send")).to_have_text("Try again")
     page.locator("#chamber-send").click()
-    expect(page.locator("#chamber-question")).to_contain_text(
-        "Reconstruct Immune memory persists. from memory before checking the source.",
+    expect(page.locator("#chamber-question")).to_have_text(
+        "Why is the second exposure faster?",
         timeout=20_000,
     )
     expect(page.locator("#chamber-composer")).to_be_enabled()
     assert session_attempts["count"] == 2
+    assert bootstrap_turns == ["The first exposure leaves memory cells."]
+
+    learner_answer = "Memory cells make the next response faster."
+    page.locator("#chamber-composer").fill(learner_answer)
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-verdict")).to_have_text(
+        re.compile(r"Answer kept.*Not recorded.*The learning loop did not respond\."),
+        timeout=20_000,
+    )
+    expect(page.locator("#chamber-send")).to_have_text("Try sending again")
+    expect(page.locator("#chamber-composer")).to_be_disabled()
+    expect(page.locator("#chamber-composer")).to_have_value(learner_answer)
+    expect(page.locator("#chamber-active")).not_to_have_attribute(
+        "data-loading", "true"
+    )
+    expect(page.locator("#chamber-hint")).to_have_text("A sentence is enough.")
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Use the next question to add one cause-and-effect link.", timeout=2_000
+    )
+    assert [payload["text"] for payload in turn_payloads] == [
+        "The first exposure leaves memory cells.", learner_answer, learner_answer,
+    ]
+    assert turn_payloads[1]["requestId"] == turn_payloads[2]["requestId"]
+    assert turn_payloads[0]["requestId"] != turn_payloads[1]["requestId"]
+    assert [payload["expectedVersion"] for payload in turn_payloads] == [1, 2, 2]
+
+
+def test_missing_source_less_route_preserves_sketch_and_builds_fresh_question(
+    clean_page: Page, base_url: str
+) -> None:
+    """A typed route failure offers a fresh route without evidence or lost Door work."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+
+    page.route(
+        "**/api/extract",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "provisional_map": {
+                    "metadata": {"core_thesis": "Immune memory changes later response."},
+                    "backbone": [{"id": "b1", "principle": "Something persists."}],
+                    "clusters": [],
+                },
+            }),
+        ),
+    )
+    session_requests: list[dict] = []
+
+    def fulfill_session(route) -> None:
+        session_requests.append(route.request.post_data_json)
+        session_number = len(session_requests)
+        route.fulfill(
+            status=201,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": f"route-recovery-{session_number}",
+                "sessionVersion": 1,
+                "status": "awaiting_input",
+                "awaiting": {"key": "launch_attempt", "ctaText": "First try"},
+                "learnerTranscript": [],
+                "caseComplete": False,
+            }),
+        )
+
+    turn_requests: list[dict] = []
+    routed_prompt = "Why does retained memory speed the later response?"
+
+    def fulfill_turn(route) -> None:
+        turn_requests.append(route.request.post_data_json)
+        if len(turn_requests) == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "sessionId": "route-recovery-1",
+                    "sessionVersion": 2,
+                    "status": "awaiting_input",
+                    "awaiting": {"key": "cmd", "ctaText": "Choose what to do next."},
+                    "sourceLessRoute": {
+                        "contractVersion": 1,
+                        "status": "route_unavailable",
+                        "code": "route_unavailable",
+                        "reason": "generation_failed",
+                        "retryable": True,
+                    },
+                    "events": [{
+                        "type": "bridge_error", "phase": "route",
+                        "action": "generate-route", "graph_neutral": True,
+                        "score_eligible": False,
+                    }],
+                    "caseComplete": False,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "route-recovery-2",
+                "sessionVersion": 2,
+                "status": "awaiting_input",
+                "awaiting": {"key": "cold_attempt", "ctaText": routed_prompt},
+                "sourceLessRoute": _seda_route_result(prompt=routed_prompt),
+                "events": [_seda_route_event(prompt=routed_prompt)],
+                "caseComplete": False,
+            }),
+        )
+
+    page.route(re.compile(r".*/api/session$"), fulfill_session)
+    page.route(re.compile(r".*/api/session/[^/]+/turn$"), fulfill_turn)
+    door_sketch = "The first exposure leaves something behind."
+    page.locator("#nav-ignition").click()
+    page.locator("#hero-single-input-field").fill("why vaccines create immune memory")
+    page.locator("#hero-cold-guess-field").fill(door_sketch)
+    page.locator("#hero-door-submit").click()
+
+    expect(page.locator("#chamber-question")).to_have_text(
+        "We could not build the first question. Your starting sketch is saved.",
+        timeout=20_000,
+    )
+    expect(page.locator("#chamber-send")).to_have_text("Build the first question again")
+    expect(page.locator("#chamber-composer")).to_be_disabled()
+    assert page.evaluate(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const training = JSON.parse(localStorage.getItem(`socratink:training:v1:${conceptId}`) || 'null');
+          return Object.values(training?.node_records || {})
+            .flatMap((record) => record?.attempts || []).length;
+        }"""
+    ) == 0
+
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-question")).to_have_text(routed_prompt, timeout=20_000)
+    expect(page.locator("#chamber-composer")).to_be_enabled()
+    saved_sketch = page.evaluate(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          return JSON.parse(localStorage.getItem('learnops_concepts'))
+            .find((concept) => concept.id === conceptId)?.startingMapContext;
+        }"""
+    )
+    assert saved_sketch == door_sketch
+    assert session_requests == [
+        {"sourceLessDoorBootstrap": True},
+        {"sourceLessDoorBootstrap": True},
+    ]
+    assert [request["text"] for request in turn_requests] == [door_sketch, door_sketch]
+    assert all(re.fullmatch(r"[0-9a-f-]{36}", request["requestId"], re.I) for request in turn_requests)
+    assert turn_requests[0]["requestId"] != turn_requests[1]["requestId"]
+    assert [request["expectedVersion"] for request in turn_requests] == [1, 1]
+
+
+def test_unbound_source_less_map_with_evidence_is_never_replaced(
+    clean_page: Page, base_url: str
+) -> None:
+    """Legacy node-keyed evidence blocks automatic first-route replacement."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    page.evaluate(
+        """(() => {
+          const conceptId = 'unbound-evidence-route';
+          const graphData = JSON.stringify({
+            metadata: {
+              core_thesis: 'Memory changes later response.',
+              starting_map_context: 'Something remains after exposure.',
+              source_mode: 'source_less',
+              route_status: 'pending_seda',
+              graph_neutral: true,
+            },
+            backbone: [{
+              id: 'legacy-node', label: 'Legacy target',
+              mechanism: 'A prior mechanism.',
+              learner_scaffold: { entry_prompt: 'What remains after exposure?' },
+            }, {
+              id: 'prior-node', label: 'Prior evidence target',
+              mechanism: 'Earlier work stays keyed here.',
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Unbound evidence QA', createdAt: Date.now(),
+            state: 'growing', startingMapContext: 'Something remains after exposure.',
+            sourceMode: 'source_less', graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch',
+            node_records: {
+              'prior-node': { attempts: [{
+                id: 'legacy-attempt', kind: 'cold', at: '2026-07-09T10:00:00.000Z',
+                user_text: 'My earlier reconstruction.', classification: 'partial',
+                gaps: [], grader_version: 'qa',
+              }], repairs: [] },
+            },
+          }));
+        })()"""
+    )
+    session_requests: list[str] = []
+    page.on(
+        "request",
+        lambda request: session_requests.append(request.url)
+        if "/api/session" in request.url
+        else None,
+    )
+    page.goto(f"{base_url}/session/unbound-evidence-route")
+    page.evaluate(
+        """window.App.reopenStudy({
+          id: 'legacy-node', label: 'Legacy target', fullLabel: 'Legacy target',
+          learner_scaffold: { entry_prompt: 'What remains after exposure?' },
+        })"""
+    )
+
+    expect(page.locator("#chamber-question")).to_have_text(
+        "This learning route cannot be resumed. Your recorded work is still on the map.",
+        timeout=20_000,
+    )
+    expect(page.locator("#chamber-send")).to_have_text("Return to map")
+    assert session_requests == []
+    unchanged = page.evaluate(
+        """() => {
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts'))[0];
+          const graph = JSON.parse(concept.graphData);
+          const training = JSON.parse(
+            localStorage.getItem('socratink:training:v1:unbound-evidence-route')
+          );
+          return {
+            nodeId: graph.backbone[0].id,
+            boundNodeId: graph.metadata.seda_route_bound_node_id || null,
+            attempt: training.node_records['prior-node'].attempts[0].user_text,
+          };
+        }"""
+    )
+    assert unchanged == {
+        "nodeId": "legacy-node",
+        "boundNodeId": None,
+        "attempt": "My earlier reconstruction.",
+    }
+    page.locator("#chamber-send").click()
+
+
+@pytest.mark.parametrize(
+    "resume_case",
+    [
+        "unbound_without_confirmation",
+        "missing_bound_session",
+        "bound_session_mismatch",
+        "bound_route_mismatch",
+    ],
+)
+def test_invalid_source_less_resume_state_fails_closed(
+    clean_page: Page, base_url: str, resume_case: str
+) -> None:
+    """Every stale/unconfirmed route shape keeps study closed and evidence empty."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    bound_session_id = "11111111-1111-4111-8111-111111111111"
+    page.evaluate(
+        """({ resumeCase, boundSessionId }) => {
+          const conceptId = `invalid-resume-${resumeCase}`;
+          const metadata = {
+            core_thesis: 'Memory changes the later response.',
+            starting_map_context: 'Something remains after exposure.',
+            source_mode: 'source_less',
+          };
+          if (resumeCase !== 'unbound_without_confirmation') {
+            metadata.seda_route_bound_node_id = 'bound-node';
+          }
+          if (!['unbound_without_confirmation', 'missing_bound_session'].includes(resumeCase)) {
+            metadata.seda_route_bound_session_id = boundSessionId;
+          }
+          const graphData = JSON.stringify({
+            metadata,
+            backbone: [{
+              id: 'bound-node', label: 'Bound target', mechanism: 'Memory cells persist.',
+              learner_scaffold: { entry_prompt: 'Why is the next response faster?' },
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Invalid resume QA', createdAt: Date.now(),
+            state: 'growing', sourceMode: 'source_less',
+            startingMapContext: 'Something remains after exposure.', graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch', node_records: {},
+          }));
+          if (['bound_session_mismatch', 'bound_route_mismatch'].includes(resumeCase)) {
+            localStorage.setItem(`socratink:seda-session:v1:${conceptId}`, JSON.stringify({
+              sessionId: boundSessionId, sessionVersion: 2, nodeId: 'bound-node',
+              latest: { caseComplete: false, sessionVersion: 2 },
+            }));
+          }
+          return conceptId;
+        }""",
+        {"resumeCase": resume_case, "boundSessionId": bound_session_id},
+    )
+
+    if resume_case in {"bound_session_mismatch", "bound_route_mismatch"}:
+        response_session_id = (
+            "22222222-2222-4222-8222-222222222222"
+            if resume_case == "bound_session_mismatch"
+            else bound_session_id
+        )
+        route_node_id = (
+            "different-node" if resume_case == "bound_route_mismatch" else "bound-node"
+        )
+        page.route(
+            re.compile(rf".*/api/session/{bound_session_id}$"),
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "sessionId": response_session_id,
+                    "sessionVersion": 2,
+                    "status": "awaiting_input",
+                    "awaiting": {
+                        "key": "cold_attempt",
+                        "ctaText": "Why is the next response faster?",
+                    },
+                    "sourceLessRoute": _seda_route_result(node_id=route_node_id),
+                    "events": [_seda_route_event(node_id=route_node_id)],
+                    "caseComplete": False,
+                    "record": None,
+                }),
+            ),
+        )
+
+    concept_id = f"invalid-resume-{resume_case}"
+    page.goto(f"{base_url}/session/{concept_id}")
+    page.wait_for_function("() => Boolean(window.App?.reopenStudy)", timeout=20_000)
+    page.evaluate(
+        """() => window.App.reopenStudy({
+          id: 'bound-node', label: 'Bound target', fullLabel: 'Bound target',
+          learner_scaffold: { entry_prompt: 'Why is the next response faster?' },
+        })"""
+    )
+
+    expect(page.locator("#chamber-question")).to_have_text(
+        "We could not build the first question. Your starting sketch is saved.",
+        timeout=20_000,
+    )
+    expect(page.locator("#chamber-send")).to_have_text(
+        "Build the first question again"
+    )
+    expect(page.locator("#chamber-composer")).to_be_disabled()
+    assert page.evaluate(
+        """(conceptId) => {
+          const training = JSON.parse(
+            localStorage.getItem(`socratink:training:v1:${conceptId}`)
+          );
+          return Object.values(training.node_records || {})
+            .flatMap((record) => record.attempts || []).length;
+        }""",
+        concept_id,
+    ) == 0
+
+
+def test_stale_bound_route_with_existing_evidence_returns_to_map(
+    clean_page: Page, base_url: str
+) -> None:
+    """A stale bound session never replaces evidence with a freshly generated route."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    page.evaluate(
+        """(() => {
+          const conceptId = 'stale-bound-route';
+          const graphData = JSON.stringify({
+            metadata: {
+              core_thesis: 'Memory changes later response.',
+              starting_map_context: 'Something remains after the first exposure.',
+              source_mode: 'source_less',
+              seda_route_bound_node_id: 'c9_s1',
+              seda_route_bound_session_id: '11111111-1111-4111-8111-111111111111',
+            },
+            backbone: [{
+              id: 'c9_s1', label: 'Current memory target',
+              mechanism: 'Memory cells persist.',
+              learner_scaffold: { entry_prompt: 'Why is the next response faster?' },
+            }, {
+              id: 'prior-node', label: 'Prior evidence target',
+              mechanism: 'A prior mechanism.',
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Stale route QA', createdAt: Date.now(),
+            state: 'growing', startingMapContext: 'Something remains after the first exposure.',
+            graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:seda-session:v1:${conceptId}`, JSON.stringify({
+            sessionId: '11111111-1111-4111-8111-111111111111',
+            nodeId: 'c9_s1', latest: { caseComplete: false },
+          }));
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch',
+            sketch: { text: 'Something remains after the first exposure.' },
+            node_records: {
+              'prior-node': { attempts: [{
+                id: 'prior-attempt', kind: 'cold', at: '2026-07-09T10:00:00.000Z',
+                user_text: 'My earlier recorded reconstruction.', classification: 'partial',
+                gaps: [], grader_version: 'qa',
+              }], repairs: [] },
+            },
+          }));
+        })()"""
+    )
+    page.route(
+        re.compile(r".*/api/session/[^/]+$"),
+        lambda route: route.fulfill(
+            status=404,
+            content_type="application/json",
+            body=json.dumps({"error": "session not found"}),
+        ),
+    )
+    page.goto(f"{base_url}/session/stale-bound-route")
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible(timeout=20_000)
+    page.locator(".concept-page-b2__attempt-input").fill("A new unsent line.")
+    page.locator(".concept-page-b2__attempt-save").click()
+
+    expect(page.locator("#chamber-question")).to_have_text(
+        "This learning route cannot be resumed. Your recorded work is still on the map.",
+        timeout=20_000,
+    )
+    expect(page.locator("#chamber-send")).to_have_text("Return to map")
+    expect(page.locator("#chamber-composer")).to_be_disabled()
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_be_hidden()
+    expect(page.locator(".concept-page-b2__attempt-input")).to_have_value(
+        "A new unsent line."
+    )
+    preserved = page.evaluate(
+        """() => JSON.parse(
+          localStorage.getItem('socratink:training:v1:stale-bound-route')
+        ).node_records['prior-node'].attempts"""
+    )
+    assert len(preserved) == 1
+    assert preserved[0]["user_text"] == "My earlier recorded reconstruction."
+
+
+def test_stale_tab_conflict_preserves_draft_and_requires_explicit_resubmit(
+    clean_page: Page, base_url: str
+) -> None:
+    """A 409 refreshes the prompt without recording or replaying stale text."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    session_id = "33333333-3333-4333-8333-333333333333"
+    page.evaluate(
+        """(sessionId) => {
+          const conceptId = 'stale-tab-conflict';
+          const graphData = JSON.stringify({
+            metadata: {
+              core_thesis: 'Memory changes later response.',
+              starting_map_context: 'Something remains after exposure.',
+              source_mode: 'source_less',
+              seda_route_bound_node_id: 'bound-node',
+              seda_route_bound_session_id: sessionId,
+            },
+            backbone: [{
+              id: 'bound-node', label: 'Bound target',
+              mechanism: 'Memory cells persist.',
+              learner_scaffold: { entry_prompt: 'Original prompt?' },
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Stale tab QA', createdAt: Date.now(),
+            state: 'growing', sourceMode: 'source_less',
+            startingMapContext: 'Something remains after exposure.', graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:seda-session:v1:${conceptId}`, JSON.stringify({
+            sessionId, sessionVersion: 2, nodeId: 'bound-node',
+            latest: { caseComplete: false, sessionVersion: 2 },
+          }));
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch', node_records: {},
+          }));
+        }""",
+        session_id,
+    )
+    prompt_before = "Why does memory change the later response?"
+    prompt_after = "What persists between the two exposures?"
+    get_count = {"value": 0}
+
+    def fulfill_get(route) -> None:
+        get_count["value"] += 1
+        version = 2 if get_count["value"] == 1 else 3
+        prompt = prompt_before if version == 2 else prompt_after
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": version,
+                "status": "awaiting_input",
+                "awaiting": {"key": "cold_attempt", "ctaText": prompt},
+                "sourceLessRoute": _seda_route_result(
+                    node_id="bound-node", label="Bound target", prompt=prompt,
+                ),
+                "events": [_seda_route_event(
+                    node_id="bound-node", label="Bound target", prompt=prompt,
+                )],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    turn_payloads: list[dict] = []
+    draft = "Memory cells remain ready for the second exposure."
+
+    def fulfill_turn(route) -> None:
+        payload = route.request.post_data_json
+        turn_payloads.append(payload)
+        if len(turn_payloads) == 1:
+            route.fulfill(
+                status=409,
+                content_type="application/json",
+                body=json.dumps({
+                    "error": "session_conflict",
+                    "code": "SessionConflict",
+                    "message": "session changed after this prompt was shown",
+                    "currentVersion": 3,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 4,
+                "status": "awaiting_input",
+                "awaiting": {"key": "compare", "ctaText": "Compare with the note."},
+                "events": [{
+                    "type": "cold_attempt", "kc_id": "bound-node", "text": draft,
+                    "evaluation": {
+                        "classification": "deep", "gaps": [], "grader_version": "qa",
+                    },
+                }],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    page.route(
+        re.compile(rf".*/api/session/{session_id}$"),
+        fulfill_get,
+    )
+    page.route(
+        re.compile(rf".*/api/session/{session_id}/turn$"),
+        fulfill_turn,
+    )
+    page.goto(f"{base_url}/session/stale-tab-conflict")
+    page.wait_for_function("() => Boolean(window.App?.reopenStudy)", timeout=20_000)
+    page.evaluate(
+        """() => {
+          window.App.cancelDrill({ restoreMap: false });
+          window.App.reopenStudy({
+            id: 'bound-node', label: 'Bound target', fullLabel: 'Bound target',
+            learner_scaffold: { entry_prompt: 'Original prompt?' },
+          });
+        }"""
+    )
+    expect(page.locator("#chamber-question")).to_have_text(
+        prompt_before, timeout=20_000
+    )
+    page.locator("#chamber-composer").fill(draft)
+    page.locator("#chamber-send").evaluate("button => button.click()")
+
+    expect(page.locator("#chamber-question")).to_have_text(
+        prompt_after, timeout=20_000
+    )
+    expect(page.locator("#chamber-composer")).to_have_value(draft)
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Session changed in another tab"
+    )
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "check your draft again"
+    )
+    assert page.evaluate(
+        """() => {
+          const training = JSON.parse(
+            localStorage.getItem('socratink:training:v1:stale-tab-conflict')
+          );
+          return Object.values(training.node_records || {})
+            .flatMap((record) => record.attempts || []).length;
+        }"""
+    ) == 0
+
+    page.locator("#chamber-send").evaluate("button => button.click()")
+    expect(page.locator("#chamber-send")).to_have_text(
+        "See what to study", timeout=2_000
+    )
+    assert [payload["expectedVersion"] for payload in turn_payloads] == [2, 3]
+    assert turn_payloads[0]["requestId"] != turn_payloads[1]["requestId"]
+    assert [payload["text"] for payload in turn_payloads] == [draft, draft]
+    assert page.evaluate(
+        """() => JSON.parse(
+          localStorage.getItem('socratink:training:v1:stale-tab-conflict')
+        ).node_records['bound-node'].attempts.length"""
+    ) == 1
+
+
+def test_evidence_persistence_failure_withholds_study_until_idempotent_retry(
+    clean_page: Page, base_url: str
+) -> None:
+    """A server-accepted answer is not called recorded until local evidence saves."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    session_id = "44444444-4444-4444-8444-444444444444"
+    page.evaluate(
+        """(sessionId) => {
+          const conceptId = 'projection-retry';
+          const graphData = JSON.stringify({
+            metadata: {
+              core_thesis: 'Memory changes later response.',
+              starting_map_context: 'Something remains after exposure.',
+              source_mode: 'source_less',
+              seda_route_bound_node_id: 'bound-node',
+              seda_route_bound_session_id: sessionId,
+            },
+            backbone: [{
+              id: 'bound-node', label: 'Bound target',
+              mechanism: 'Memory cells persist.',
+              learner_scaffold: { entry_prompt: 'Why is the later response faster?' },
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Projection retry QA', createdAt: Date.now(),
+            state: 'growing', sourceMode: 'source_less',
+            startingMapContext: 'Something remains after exposure.', graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:seda-session:v1:${conceptId}`, JSON.stringify({
+            sessionId, sessionVersion: 2, nodeId: 'bound-node',
+            latest: { caseComplete: false, sessionVersion: 2 },
+          }));
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch', node_records: {},
+          }));
+        }""",
+        session_id,
+    )
+    prompt = "Why is the later response faster?"
+    page.route(
+        re.compile(rf".*/api/session/{session_id}$"),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 2,
+                "status": "awaiting_input",
+                "awaiting": {"key": "cold_attempt", "ctaText": prompt},
+                "sourceLessRoute": _seda_route_result(
+                    node_id="bound-node", label="Bound target", prompt=prompt,
+                ),
+                "events": [_seda_route_event(
+                    node_id="bound-node", label="Bound target", prompt=prompt,
+                )],
+                "caseComplete": False,
+                "record": None,
+            }),
+        ),
+    )
+    draft = "Memory cells persist and react sooner later."
+    turn_payloads: list[dict] = []
+
+    def fulfill_turn(route) -> None:
+        turn_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 3,
+                "status": "awaiting_input",
+                "awaiting": {"key": "compare", "ctaText": "Compare with the note."},
+                "events": [{
+                    "type": "cold_attempt", "kc_id": "bound-node", "text": draft,
+                    "evaluation": {
+                        "classification": "deep", "gaps": [], "grader_version": "qa",
+                    },
+                }],
+                "caseComplete": False,
+                "record": None,
+            }),
+        )
+
+    page.route(
+        re.compile(rf".*/api/session/{session_id}/turn$"),
+        fulfill_turn,
+    )
+    page.goto(f"{base_url}/session/projection-retry")
+    page.wait_for_function("() => Boolean(window.App?.reopenStudy)", timeout=20_000)
+    page.evaluate(
+        """() => {
+          window.App.cancelDrill({ restoreMap: false });
+          window.App.reopenStudy({
+            id: 'bound-node', label: 'Bound target', fullLabel: 'Bound target',
+            learner_scaffold: { entry_prompt: 'Why is the later response faster?' },
+          });
+        }"""
+    )
+    page.wait_for_function(
+        """() => {
+          const value = JSON.parse(
+            localStorage.getItem('socratink:seda-session:v1:projection-retry') || 'null'
+          );
+          return value?.latest?.sessionVersion === 2
+            && value?.latest?.awaiting?.key === 'cold_attempt';
+        }""",
+        timeout=20_000,
+    )
+    expect(page.locator("#chamber-composer")).to_be_enabled(timeout=20_000)
+    page.evaluate(
+        """() => {
+          const original = Storage.prototype.setItem;
+          let failNextTrainingWrite = true;
+          Storage.prototype.setItem = function(key, value) {
+            if (failNextTrainingWrite && String(key).startsWith('socratink:training:v1:')) {
+              failNextTrainingWrite = false;
+              throw new DOMException('QA quota failure', 'QuotaExceededError');
+            }
+            return original.call(this, key, value);
+          };
+        }"""
+    )
+    page.locator("#chamber-composer").fill(draft)
+    page.locator("#chamber-send").evaluate("button => button.click()")
+
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Not saved in this browser yet.", timeout=5_000
+    )
+    expect(page.locator("#chamber-verdict")).not_to_contain_text("Recorded")
+    expect(page.locator("#chamber-send")).to_have_text("Try saving again")
+    assert page.evaluate(
+        """() => {
+          const training = JSON.parse(
+            localStorage.getItem('socratink:training:v1:projection-retry')
+          );
+          return Object.values(training.node_records || {})
+            .flatMap((record) => record.attempts || []).length;
+        }"""
+    ) == 0
+
+    page.locator("#chamber-send").evaluate("button => button.click()")
+    expect(page.locator("#chamber-send")).to_have_text(
+        "See what to study", timeout=2_000
+    )
+    assert len(turn_payloads) == 2
+    assert turn_payloads[0]["requestId"] == turn_payloads[1]["requestId"]
+    assert [payload["expectedVersion"] for payload in turn_payloads] == [2, 2]
+    assert page.evaluate(
+        """() => JSON.parse(
+          localStorage.getItem('socratink:training:v1:projection-retry')
+        ).node_records['bound-node'].attempts.length"""
+    ) == 1
+
+
+def test_seda_transport_failure_keeps_draft_and_retries_same_turn(
+    clean_page: Page, base_url: str
+) -> None:
+    """A failed network turn keeps visible effort and its idempotency key."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    session_id = "77777777-7777-4777-8777-777777777777"
+    page.evaluate(
+        """(sessionId) => {
+          const conceptId = 'transport-retry';
+          const graphData = JSON.stringify({
+            metadata: {
+              core_thesis: 'Memory changes later response.',
+              starting_map_context: 'Something remains after exposure.',
+              source_mode: 'source_less',
+              seda_route_bound_node_id: 'bound-node',
+              seda_route_bound_session_id: sessionId,
+            },
+            backbone: [{
+              id: 'bound-node', label: 'Bound target', mechanism: 'Memory cells persist.',
+              learner_scaffold: { entry_prompt: 'Why is the later response faster?' },
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Transport retry QA', createdAt: Date.now(),
+            state: 'growing', sourceMode: 'source_less',
+            startingMapContext: 'Something remains after exposure.', graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:seda-session:v1:${conceptId}`, JSON.stringify({
+            sessionId, sessionVersion: 2, nodeId: 'bound-node',
+            latest: { caseComplete: false, sessionVersion: 2 },
+          }));
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch', node_records: {},
+          }));
+        }""",
+        session_id,
+    )
+    prompt = "Why is the later response faster?"
+    page.route(
+        re.compile(rf".*/api/session/{session_id}$"),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 2,
+                "status": "awaiting_input",
+                "awaiting": {"key": "cold_attempt", "ctaText": prompt},
+                "sourceLessRoute": _seda_route_result(
+                    node_id="bound-node", label="Bound target", prompt=prompt,
+                ),
+                "events": [_seda_route_event(
+                    node_id="bound-node", label="Bound target", prompt=prompt,
+                )],
+                "caseComplete": False,
+            }),
+        ),
+    )
+    draft = "Memory cells remain ready and react sooner on the next exposure."
+    turn_payloads: list[dict] = []
+
+    def fulfill_turn(route) -> None:
+        turn_payloads.append(route.request.post_data_json)
+        if len(turn_payloads) == 1:
+            route.fulfill(
+                status=503,
+                content_type="application/json",
+                body=json.dumps({"error": "session_store_unavailable"}),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 3,
+                "status": "awaiting_input",
+                "awaiting": {"key": "compare", "ctaText": "Compare with the note."},
+                "events": [{
+                    "type": "cold_attempt", "kc_id": "bound-node", "text": draft,
+                    "evaluation": {
+                        "classification": "deep", "gaps": [], "grader_version": "qa",
+                    },
+                }],
+                "caseComplete": False,
+            }),
+        )
+
+    page.route(
+        re.compile(rf".*/api/session/{session_id}/turn$"),
+        fulfill_turn,
+    )
+    page.goto(f"{base_url}/session/transport-retry")
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible(
+        timeout=20_000
+    )
+    page.wait_for_function("() => Boolean(window.App?.reopenStudy)", timeout=20_000)
+    page.evaluate(
+        """() => {
+          window.App.cancelDrill({ restoreMap: false });
+          window.App.reopenStudy({
+            id: 'bound-node', label: 'Bound target', fullLabel: 'Bound target',
+            learner_scaffold: { entry_prompt: 'Why is the later response faster?' },
+          });
+        }"""
+    )
+    page.wait_for_function(
+        """() => {
+          const state = JSON.parse(
+            localStorage.getItem('socratink:seda-session:v1:transport-retry') || 'null'
+          );
+          return state?.latest?.sessionVersion === 2
+            && state?.latest?.awaiting?.key === 'cold_attempt'
+            && document.getElementById('chamber-question')?.textContent
+              === 'Why is the later response faster?'
+            && document.getElementById('chamber-composer')?.disabled === false
+            && document.getElementById('chamber-send')?.textContent === 'Check my answer';
+        }""",
+        timeout=20_000,
+    )
+    page.locator("#chamber-composer").fill(draft)
+    page.locator("#chamber-send").evaluate("button => button.click()")
+
+    for _ in range(100):
+        if turn_payloads:
+            break
+        page.wait_for_timeout(25)
+    assert turn_payloads, "failed SEDA turn never reached the transport stub"
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Answer kept", timeout=5_000
+    )
+    expect(page.locator("#chamber-verdict")).to_contain_text("Not recorded")
+    expect(page.locator("#chamber-send")).to_have_text("Try sending again")
+    expect(page.locator("#chamber-composer")).to_have_value(draft)
+    assert page.evaluate(
+        """() => Object.values(JSON.parse(
+          localStorage.getItem('socratink:training:v1:transport-retry')
+        ).node_records || {}).flatMap((record) => record.attempts || []).length"""
+    ) == 0
+
+    page.locator("#chamber-send").click()
+    expect(page.locator("#chamber-send")).to_have_text(
+        "See what to study", timeout=2_000
+    )
+    assert len(turn_payloads) == 2
+    assert turn_payloads[0]["requestId"] == turn_payloads[1]["requestId"]
+    assert [payload["expectedVersion"] for payload in turn_payloads] == [2, 2]
+
+
+def test_stale_bound_route_without_evidence_builds_fresh_route(
+    clean_page: Page, base_url: str
+) -> None:
+    """A stale pre-attempt binding is replaceable without losing the Door sketch."""
+    page = clean_page
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    page.evaluate(
+        """(() => {
+          const conceptId = 'stale-empty-route';
+          const sketch = 'Something remains after the first exposure.';
+          const graphData = JSON.stringify({
+            metadata: {
+              core_thesis: 'Memory changes later response.',
+              starting_map_context: sketch,
+              source_mode: 'source_less',
+              seda_route_bound_node_id: 'old-node',
+              seda_route_bound_session_id: '11111111-1111-4111-8111-111111111111',
+            },
+            backbone: [{
+              id: 'old-node', label: 'Old target', mechanism: 'Old mechanism.',
+              learner_scaffold: { entry_prompt: 'Old question?' },
+            }],
+            clusters: [],
+          });
+          localStorage.setItem('learnops_concepts', JSON.stringify([{
+            id: conceptId, name: 'Stale empty route QA', createdAt: Date.now(),
+            state: 'growing', startingMapContext: sketch, graphData,
+          }]));
+          localStorage.setItem('learnops_active', conceptId);
+          localStorage.setItem(`socratink:seda-session:v1:${conceptId}`, JSON.stringify({
+            sessionId: '11111111-1111-4111-8111-111111111111',
+            nodeId: 'old-node', latest: { caseComplete: false },
+          }));
+          localStorage.setItem(`socratink:training:v1:${conceptId}`, JSON.stringify({
+            concept_id: conceptId, schema_version: 1,
+            source_mode: 'source_less', grounding: 'learner_sketch',
+            sketch: { text: sketch }, node_records: {},
+          }));
+        })()"""
+    )
+    page.route(
+        re.compile(r".*/api/session/11111111-1111-4111-8111-111111111111$"),
+        lambda route: route.fulfill(
+            status=404,
+            content_type="application/json",
+            body=json.dumps({"error": "session not found"}),
+        ),
+    )
+    fresh_sessions: list[dict] = []
+    fresh_turns: list[dict] = []
+    held_fresh_turns = []
+    fresh_prompt = "Fresh question: why is the next response faster?"
+
+    def fulfill_fresh_session(route) -> None:
+        fresh_sessions.append(route.request.post_data_json)
+        session_id = (
+            "22222222-2222-4222-8222-222222222222"
+            if len(fresh_sessions) == 1
+            else "33333333-3333-4333-8333-333333333333"
+        )
+        route.fulfill(
+            status=201,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": session_id,
+                "sessionVersion": 1,
+                "status": "awaiting_input",
+                "awaiting": {"key": "launch_attempt", "ctaText": "First try"},
+                "caseComplete": False,
+            }),
+        )
+
+    def fulfill_fresh_turn(route) -> None:
+        fresh_turns.append(route.request.post_data_json)
+        if len(fresh_turns) == 1:
+            held_fresh_turns.append(route)
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "sessionId": "33333333-3333-4333-8333-333333333333",
+                "sessionVersion": 2,
+                "status": "awaiting_input",
+                "awaiting": {"key": "cold_attempt", "ctaText": fresh_prompt},
+                "sourceLessRoute": _seda_route_result(
+                    node_id="fresh-node", prompt=fresh_prompt,
+                ),
+                "events": [_seda_route_event(node_id="fresh-node", prompt=fresh_prompt)],
+                "caseComplete": False,
+            }),
+        )
+
+    page.route(re.compile(r".*/api/session$"), fulfill_fresh_session)
+    page.route(
+        re.compile(r".*/api/session/[0-9a-f-]+/turn$"),
+        fulfill_fresh_turn,
+    )
+    page.goto(f"{base_url}/session/stale-empty-route")
+    page.locator(".concept-page-b2__attempt-input").fill("An unsent line.")
+    page.locator(".concept-page-b2__attempt-save").click()
+    expect(page.locator("#chamber-send")).to_have_text(
+        "Build the first question again", timeout=20_000
+    )
+    expect(page.locator("#chamber-question")).not_to_contain_text("Try again")
+    page.locator("#chamber-send").click()
+
+    for _ in range(100):
+        if held_fresh_turns:
+            break
+        page.wait_for_timeout(50)
+    assert held_fresh_turns, "fresh route request was not held before reload"
+    pending = page.evaluate(
+        """() => {
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts'))[0];
+          const graph = JSON.parse(concept.graphData);
+          return {
+            routeStatus: graph.metadata.route_status || null,
+            graphNeutral: graph.metadata.graph_neutral ?? null,
+            nodeId: graph.metadata.seda_route_bound_node_id || null,
+            sessionId: graph.metadata.seda_route_bound_session_id || null,
+          };
+        }"""
+    )
+    assert pending == {
+        "routeStatus": "pending_seda",
+        "graphNeutral": True,
+        "nodeId": None,
+        "sessionId": None,
+    }
+
+    page.reload()
+    reloaded_draft = "A draft written after the interrupted route request."
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible(timeout=20_000)
+    page.locator(".concept-page-b2__attempt-input").fill(reloaded_draft)
+    page.locator(".concept-page-b2__attempt-save").click()
+
+    expect(page.locator("#chamber-question")).to_have_text(fresh_prompt, timeout=20_000)
+    expect(page.locator("#chamber-composer")).to_be_enabled()
+    expect(page.locator("#chamber-composer")).to_have_value(reloaded_draft)
+    expect(page.locator("#chamber-verdict")).to_contain_text(
+        "Not recorded against this question."
+    )
+    assert fresh_sessions == [
+        {"sourceLessDoorBootstrap": True},
+        {"sourceLessDoorBootstrap": True},
+    ]
+    assert [turn["text"] for turn in fresh_turns] == [
+        "Something remains after the first exposure.",
+        "Something remains after the first exposure.",
+    ]
+    assert [turn["expectedVersion"] for turn in fresh_turns] == [1, 1]
+    recovered = page.evaluate(
+        """() => {
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts'))[0];
+          const graph = JSON.parse(concept.graphData);
+          const training = JSON.parse(localStorage.getItem('socratink:training:v1:stale-empty-route'));
+          return {
+            sketch: concept.startingMapContext,
+            nodeId: graph.metadata.seda_route_bound_node_id,
+            sessionId: graph.metadata.seda_route_bound_session_id,
+            attempts: Object.values(training.node_records || {})
+              .flatMap((record) => record.attempts || []).length,
+          };
+        }"""
+    )
+    assert recovered == {
+        "sketch": "Something remains after the first exposure.",
+        "nodeId": "fresh-node",
+        "sessionId": "33333333-3333-4333-8333-333333333333",
+        "attempts": 0,
+    }
 
 
 def test_completed_seda_case_projects_visible_evidence(
@@ -1565,6 +3228,7 @@ def test_completed_seda_case_projects_visible_evidence(
             content_type="application/json",
             body=json.dumps({
                 "sessionId": "projection-session-1",
+                "sessionVersion": 1,
                 "status": "awaiting_input",
                 "awaiting": {"key": "launch_attempt", "ctaText": "Try your first explanation."},
                 "learnerTranscript": [],
@@ -1577,6 +3241,7 @@ def test_completed_seda_case_projects_visible_evidence(
     # timestamps (2026-05-15 cold, 2026-05-16 spaced) from lib/seda/constants.mjs.
     completed_record = {
         "sessionId": "projection-session-1",
+        "sessionVersion": 3,
         "status": "complete",
         "awaiting": None,
         "learnerTranscript": [],
@@ -1613,7 +3278,30 @@ def test_completed_seda_case_projects_visible_evidence(
         },
     }
 
+    turn_texts: list[str] = []
+
     def fulfill_turn(route) -> None:
+        turn_texts.append(route.request.post_data_json["text"])
+        if len(turn_texts) == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "sessionId": "projection-session-1",
+                    "sessionVersion": 2,
+                    "status": "awaiting_input",
+                    "awaiting": {
+                        "key": "cold_attempt",
+                        "ctaText": "Why is the second exposure faster?",
+                    },
+                    "learnerTranscript": [],
+                    "events": [_seda_route_event()],
+                    "sourceLessRoute": _seda_route_result(),
+                    "caseComplete": False,
+                    "record": None,
+                }),
+            )
+            return
         route.fulfill(
             status=200,
             content_type="application/json",
@@ -1635,18 +3323,19 @@ def test_completed_seda_case_projects_visible_evidence(
     expect(page.locator("#launch-pad-view")).to_be_hidden()
 
     expect(page.locator("#drill-chamber-view")).to_be_visible(timeout=20_000)
-    # Mirror the proven-stable SEDA choreography: wait until the launch_attempt
-    # turn is wired into localStorage before sending, so the turn cannot race.
+    # The Door sketch is consumed as the launch attempt before the room opens.
+    # The first visible room answer must therefore be the recordable cold turn.
     page.wait_for_function(
         """() => {
           const conceptId = localStorage.getItem('learnops_active');
           const key = conceptId ? `socratink:seda-session:v1:${conceptId}` : null;
           if (!key) return false;
           const value = JSON.parse(localStorage.getItem(key) || 'null');
-          return value?.sessionId && value?.latest?.awaiting?.key === 'launch_attempt';
+          return value?.sessionId && value?.latest?.awaiting?.key === 'cold_attempt';
         }""",
         timeout=20_000,
     )
+    assert turn_texts == ["The first exposure leaves cells that remember the pathogen."]
     page.locator("#chamber-send").click()
     expect(page.locator("#chamber-hint")).to_have_text(
         "Write a sentence before checking."
@@ -3362,30 +5051,51 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
     canvas = clean_page.locator(".concept-page-b2__gestalt")
     expect(canvas).to_be_visible(timeout=8_000)
     expect(clean_page.locator("#drill-chamber-view")).to_be_visible(timeout=10_000)
-    expect(clean_page.locator("#chamber-question")).to_contain_text(
-        "What do you think the thermostat checks before it calls for heat?",
-        timeout=20_000,
-    )
     seda_state = clean_page.wait_for_function(
         """() => {
           const key = Object.keys(localStorage).find((k) => k.startsWith('socratink:seda-session:v1:'));
           if (!key) return null;
           const value = JSON.parse(localStorage.getItem(key));
-          return value?.sessionId && value?.latest ? value : null;
+          return value?.sessionId && value?.latest?.awaiting?.key === 'cold_attempt'
+            ? value
+            : null;
         }""",
         timeout=20_000,
     ).json_value()
-    assert seda_state["latest"]["awaiting"]["key"] == "launch_attempt"
+    assert seda_state["latest"]["awaiting"]["key"] == "cold_attempt"
+    bound_surface = clean_page.evaluate(
+        """(nodeId) => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const concept = JSON.parse(localStorage.getItem('learnops_concepts') || '[]')
+            .find((item) => item.id === conceptId);
+          const graph = JSON.parse(concept?.graphData || 'null');
+          const nodes = [
+            ...(graph?.backbone || []),
+            ...(graph?.clusters || []).flatMap((cluster) => cluster?.subnodes || []),
+          ];
+          const node = nodes.find((item) => item?.id === nodeId);
+          return {
+            prompt: node?.learner_scaffold?.entry_prompt || '',
+            taskLabel: node?.learner_scaffold?.task_label || node?.label || '',
+            mechanism: node?.study_note || node?.mechanism || '',
+          };
+        }""",
+        seda_state["nodeId"],
+    )
+    assert bound_surface["prompt"]
+    expect(clean_page.locator("#chamber-question")).to_have_text(
+        bound_surface["prompt"], timeout=20_000
+    )
     clean_page.locator("#chamber-exit").click()
     expect(clean_page.locator("#drill-chamber-view")).to_be_hidden()
     expect(canvas).to_be_visible(timeout=8_000)
     expect(canvas.locator(".concept-page-b2__attempt")).to_contain_text(
-        "What do you think the thermostat checks before it calls for heat?"
+        bound_surface["prompt"]
     )
     expect(canvas).not_to_contain_text("Shaped by your sketch")
-    expect(canvas).to_contain_text("Compare target")
+    expect(canvas).to_contain_text(bound_surface["taskLabel"])
     expect(canvas).not_to_contain_text("Call for heat")
-    expect(canvas).not_to_contain_text("compares measured room temperature")
+    expect(canvas).not_to_contain_text(bound_surface["mechanism"])
     expect(canvas).not_to_contain_text("Generated description should not leak")
     expect(canvas.locator(".concept-page-b2__route-item")).to_have_count(0)
     expect(canvas.locator(".concept-page-b2__route-marker-item")).to_have_count(0)

--- a/tests/test_app_local_seda_frontend_contract.py
+++ b/tests/test_app_local_seda_frontend_contract.py
@@ -38,6 +38,15 @@ def test_seda_visible_prompt_strips_context_labels() -> None:
         );
         assert.equal(prompt.includes('Concept:'), false);
         assert.equal(prompt.includes('Learner goal:'), false);
+
+        const complete = visibleSedaPromptFromResponse({
+          caseComplete: true,
+          record: {
+            derived: [{ nodes: { n1: { state: 'solidified' } } }],
+          },
+        });
+        assert.equal(complete, 'Your attempt is on record. Study is ready.');
+        assert.doesNotMatch(complete, /solidified|primed|complete/i);
         """
     )
     assert result.returncode == 0, result.stderr
@@ -122,7 +131,12 @@ def test_seda_session_client_uses_app_boundary() -> None:
     result = run_node_module(
         """
         import assert from 'node:assert/strict';
-        import { createSedaSession, getSedaSession, sendSedaTurn } from './public/js/ai_service.js';
+        import {
+          createSedaSession,
+          createSedaTurnSubmission,
+          getSedaSession,
+          sendSedaTurn,
+        } from './public/js/ai_service.js';
 
         const calls = [];
         globalThis.fetch = async (url, options = {}) => {
@@ -133,17 +147,41 @@ def test_seda_session_client_uses_app_boundary() -> None:
           });
         };
 
-        await createSedaSession();
+        await createSedaSession({ sourceLessDoorBootstrap: true });
         await getSedaSession('session/1');
-        await sendSedaTurn('session/1', 'first attempt');
+        const firstSubmission = createSedaTurnSubmission('first attempt', 4);
+        await sendSedaTurn('session/1', firstSubmission);
+        await sendSedaTurn('session/1', firstSubmission);
+        const nextSubmission = createSedaTurnSubmission('next attempt', 5);
+        await sendSedaTurn('session/1', nextSubmission);
 
         assert.equal(calls[0].url, '/api/session');
         assert.equal(calls[0].options.method, 'POST');
+        assert.deepEqual(JSON.parse(calls[0].options.body), { sourceLessDoorBootstrap: true });
         assert.equal(calls[1].url, '/api/session/session%2F1');
         assert.equal(calls[1].options.method, 'GET');
         assert.equal(calls[2].url, '/api/session/session%2F1/turn');
         assert.equal(calls[2].options.method, 'POST');
-        assert.deepEqual(JSON.parse(calls[2].options.body), { text: 'first attempt' });
+        const firstBody = JSON.parse(calls[2].options.body);
+        const retryBody = JSON.parse(calls[3].options.body);
+        const nextBody = JSON.parse(calls[4].options.body);
+        assert.match(firstBody.requestId, /^[0-9a-f-]{36}$/i);
+        assert.deepEqual(firstBody, retryBody);
+        assert.equal(firstBody.text, 'first attempt');
+        assert.equal(firstBody.expectedVersion, 4);
+        assert.equal(nextBody.text, 'next attempt');
+        assert.equal(nextBody.expectedVersion, 5);
+        assert.notEqual(nextBody.requestId, firstBody.requestId);
+        assert.throws(
+          () => sendSedaTurn('session/1', {
+            text: 'bad id', requestId: 'not-a-uuid', expectedVersion: 5,
+          }),
+          /requestId UUID/,
+        );
+        assert.throws(
+          () => createSedaTurnSubmission('bad version', -1),
+          /expectedVersion/,
+        );
         """
     )
     assert result.returncode == 0, result.stderr
@@ -169,6 +207,243 @@ def test_http_session_accepts_blank_optional_learner_goal() -> None:
 
         assert.equal(value, '');
         assert.equal(session.pendingInput, null);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_door_bootstrap_routes_weak_nonempty_sketch_without_weakening_default_loop() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { handleSubstrateGate } from './lib/seda/handlers/substrate-gate.mjs';
+
+        const agentLookup = new Map([['substrate_gate', {
+          id: 'substrate_gate', name: 'Substrate gate', job: 'Judge substrate',
+          required_outputs: [], may_propose_events: [], truth_permission: 'graph-neutral',
+          failure_mode_to_guard: 'answer leakage',
+        }]]);
+        let bridgeCalls = 0;
+        const bridge = {
+          callBridgeResult: () => {
+            bridgeCalls += 1;
+            return ({
+            ok: true,
+            payload: {
+              substrate_gate: {
+                substrate_adequate: false,
+                graph_neutral: true,
+                score_eligible: false,
+                classification: 'slow',
+                seed_text: 'Name one starting link.',
+                refinement_prompt: 'Add one link in your own words.',
+              },
+              llm_call: {},
+            },
+            });
+          },
+        };
+        const ctx = {
+          launchAttempt: 'I only remember that something stays behind.',
+          concept: 'Immune memory', learnerGoal: '', agentLookup,
+          section: (_kind, label) => label,
+          composerCta: null,
+        };
+        let asks = 0;
+        const prompt = { ask: async () => { asks += 1; throw new Error('refinement-required'); } };
+
+        const bootstrapEvents = [];
+        await handleSubstrateGate({
+          events: bootstrapEvents, bridge, prompt, ctx: { ...ctx },
+          options: { sourceLessDoorBootstrap: true },
+        });
+        assert.equal(asks, 0);
+        assert.equal(bootstrapEvents.at(-1).type, 'substrate_confirmed');
+        assert.equal(bootstrapEvents.at(-1).adequacy, 'minimal');
+        assert.equal(bootstrapEvents.at(-1).graph_neutral, true);
+        assert.equal(bootstrapEvents.at(-1).score_eligible, false);
+        assert.equal(bridgeCalls, 0, 'Door bootstrap skips a duplicate substrate call');
+
+        const defaultEvents = [];
+        await assert.rejects(
+          handleSubstrateGate({
+            events: defaultEvents, bridge, prompt, ctx: { ...ctx }, options: {},
+          }),
+          /refinement-required/,
+        );
+        assert.equal(asks, 1);
+        assert.equal(bridgeCalls, 1);
+        assert.equal(defaultEvents.at(-1).type, 'substrate_seed_offered');
+        assert.equal(defaultEvents.some((event) => event.type === 'substrate_confirmed'), false);
+
+        const emptyEvents = [];
+        await assert.rejects(
+          handleSubstrateGate({
+            events: emptyEvents, bridge, prompt,
+            ctx: { ...ctx, launchAttempt: '   ' },
+            options: { sourceLessDoorBootstrap: true },
+          }),
+          /refinement-required/,
+        );
+        assert.equal(asks, 2);
+        assert.equal(bridgeCalls, 2);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_source_less_route_response_is_versioned_and_fails_closed() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { sessionResponse } from './lib/loop-server/session.mjs';
+        import { validateRoutePayload } from './lib/seda/bridge-fail-closed.mjs';
+
+        const route = {
+          first_node: {
+            id: 'c9_s1', label: 'Memory target', mechanism: 'Memory cells persist.',
+            learner_prompt: 'Why is the later response faster?',
+          },
+          provisional_map: {
+            metadata: { core_thesis: 'Memory changes a later response.' },
+            backbone: [{ id: 'b9', principle: 'A retained change affects the next response.' }],
+            clusters: [{ id: 'c9', subnodes: [{ id: 'c9_s1', label: 'Memory target' }] }],
+          },
+        };
+        assert.equal(validateRoutePayload(route), null);
+        assert.equal(
+          validateRoutePayload({ ...route, first_node: { ...route.first_node, mechanism: '' } }),
+          'missing first_node.mechanism',
+        );
+        assert.equal(
+          validateRoutePayload({ ...route, first_node: { ...route.first_node, id: 9 } }),
+          'missing first_node.id',
+        );
+        assert.equal(
+          validateRoutePayload({ ...route, first_node: { ...route.first_node, label: true } }),
+          'missing first_node.label',
+        );
+        assert.equal(
+          validateRoutePayload({
+            ...route,
+            provisional_map: {
+              ...route.provisional_map,
+              clusters: [{ id: 'c9', subnodes: [{ id: 'different' }] }],
+            },
+          }),
+          'first_node.id is absent from provisional_map',
+        );
+
+        const baseSession = {
+          id: 'session-1', status: 'awaiting_input', phase: 'cold_attempt',
+          awaiting: { key: 'cold_attempt', label: 'First question: ' },
+          transcript: [], events: [], llmCalls: [], llm: null,
+          bridgeDiagnosticsDir: null, record: null, ctx: { composerCta: null },
+        };
+        const ready = sessionResponse({
+          ...baseSession,
+          events: [
+            { type: 'launch_attempt', text: 'My sketch.' },
+            { type: 'route_generated', ...route },
+          ],
+        });
+        assert.deepEqual(ready.sourceLessRoute, {
+          contractVersion: 1,
+          status: 'ready',
+          firstNode: route.first_node,
+          provisionalMap: route.provisional_map,
+        });
+
+        const unavailable = sessionResponse({
+          ...baseSession,
+          phase: 'idle', awaiting: { key: 'cmd', label: '> ' },
+          events: [
+            { type: 'launch_attempt', text: 'My sketch.' },
+            { type: 'bridge_error', phase: 'route', action: 'generate-route' },
+          ],
+        });
+        assert.equal(unavailable.sourceLessRoute.status, 'route_unavailable');
+        assert.equal(unavailable.sourceLessRoute.code, 'route_unavailable');
+        assert.equal(unavailable.sourceLessRoute.reason, 'generation_failed');
+        assert.equal(unavailable.sourceLessRoute.contractVersion, 1);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_http_post_launch_and_get_rehydrate_expose_same_ready_route() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import fs from 'node:fs/promises';
+        import os from 'node:os';
+        import path from 'node:path';
+        import { randomUUID } from 'node:crypto';
+
+        process.env.SOCRATINK_TUI_FAKE_LLM = '1';
+        const [{ createLoopServerWithStore }, { createFileSessionStore }] = await Promise.all([
+          import('./lib/loop-server/http-server.mjs'),
+          import('./lib/loop-server/session-store.mjs'),
+        ]);
+        const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'socratink-route-contract-'));
+        const store = createFileSessionStore({ rootDir });
+        const server = createLoopServerWithStore({ sessionStore: store });
+        await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const address = server.address();
+        const base = `http://127.0.0.1:${address.port}`;
+        const post = async (url, body) => {
+          const response = await fetch(`${base}${url}`, {
+            method: 'POST', headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+          const text = await response.text();
+          assert.equal(response.ok, true, text);
+          return JSON.parse(text);
+        };
+
+        try {
+          const started = await post('/api/session', { sourceLessDoorBootstrap: true });
+          assert.equal(started.awaiting.key, 'cmd');
+          const sessionId = started.sessionId;
+          let expectedVersion = started.sessionVersion;
+          const turn = async (text) => {
+            const result = await post(`/api/session/${sessionId}/turn`, {
+              text, requestId: randomUUID(), expectedVersion,
+            });
+            expectedVersion = result.sessionVersion;
+            return result;
+          };
+          const named = await turn('Immune memory');
+          assert.equal(named.awaiting.key, 'learner_goal');
+          const goalSkipped = await turn('');
+          assert.equal(goalSkipped.awaiting.key, 'launch_attempt');
+          const launched = await turn("I don't know yet.");
+
+          assert.equal(launched.awaiting.key, 'cold_attempt');
+          assert.equal(launched.sourceLessRoute.contractVersion, 1);
+          assert.equal(launched.sourceLessRoute.status, 'ready');
+          assert.equal(
+            launched.sourceLessRoute.firstNode.id,
+            launched.sourceLessRoute.provisionalMap.clusters[0].subnodes[0].id,
+          );
+          assert.equal(launched.events.some((event) => event.type === 'substrate_refinement'), false);
+          assert.equal(launched.events.some((event) => event.type === 'cold_attempt'), false);
+
+          const rehydratedResponse = await fetch(`${base}/api/session/${sessionId}`);
+          const rehydratedText = await rehydratedResponse.text();
+          assert.equal(rehydratedResponse.ok, true, rehydratedText);
+          const rehydrated = JSON.parse(rehydratedText);
+          assert.equal(rehydrated.awaiting.key, 'cold_attempt');
+          assert.deepEqual(rehydrated.sourceLessRoute, launched.sourceLessRoute);
+          const stored = await store.load(sessionId);
+          assert.equal(stored.metadata.source_less_door_bootstrap, true);
+        } finally {
+          await new Promise((resolve) => server.close(resolve));
+          await fs.rm(rootDir, { recursive: true, force: true });
+        }
         """
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_async_bridge_client.py
+++ b/tests/test_async_bridge_client.py
@@ -1,0 +1,253 @@
+"""Focused transport proofs for the app-local Python bridge client."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def run_node_module(source: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_async_callers_accept_synchronous_bridge_fakes() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { callBridgeSafely } from './lib/seda/bridge-fail-closed.mjs';
+        import { generateRouteWithRetry } from './lib/seda/route-generation.mjs';
+
+        const safe = await callBridgeSafely({
+          bridge: { callBridgeResult: () => ({ ok: true, payload: { value: 1 } }) },
+          action: 'fake',
+          payload: {},
+        });
+        assert.deepEqual(safe, { ok: true, payload: { value: 1 } });
+
+        let callOptions = null;
+        const route = await generateRouteWithRetry({
+          callBridgeResult: (_action, _payload, options) => {
+            callOptions = options;
+            return {
+              ok: true,
+              payload: {
+                provisional_map: {
+                  backbone: [{ id: 'b1' }],
+                  clusters: [{ id: 'c1', subnodes: [{ id: 'c1_s1' }] }],
+                },
+                first_node: {
+                  id: 'c1_s1',
+                  label: 'Target',
+                  learner_prompt: 'Explain it.',
+                  mechanism: 'A changes B.',
+                },
+              },
+            };
+          },
+          concept: 'Target',
+          learnerGoal: null,
+          launchAttempt: 'My sketch',
+          events: [],
+          section: () => '',
+        });
+        assert.equal(route.route.first_node.id, 'c1_s1');
+        assert.deepEqual(callOptions, { timeoutMs: 25_000 });
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_repeated_route_guardrail_failure_stays_fail_closed() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { generateRouteWithRetry } from './lib/seda/route-generation.mjs';
+
+        const events = [];
+        let calls = 0;
+        const routeResult = await generateRouteWithRetry({
+          callBridgeResult: () => {
+            calls += 1;
+            return {
+              ok: false,
+              error: 'SmallestRouteCapExceeded',
+              message: 'route copies hidden mechanism answer phrases',
+            };
+          },
+          concept: 'Target',
+          learnerGoal: null,
+          launchAttempt: 'My guess may be wrong.',
+          events,
+          section: () => '',
+        });
+
+        assert.equal(calls, 2);
+        assert.equal(routeResult.route, null);
+        assert.equal(routeResult.retryReasons.length, 2);
+        assert.equal(routeResult.bridgeError.type, 'bridge_error');
+        assert.equal(routeResult.bridgeError.phase, 'route');
+        assert.equal(routeResult.bridgeError.action, 'generate-route');
+        assert.equal(routeResult.bridgeError.retryable, true);
+        assert.equal(routeResult.bridgeError.attempts, 2);
+        assert.deepEqual(events.map((event) => event.type), ['route_retry']);
+        assert.doesNotMatch(JSON.stringify(routeResult), /My guess may be wrong/);
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_bridge_subprocess_does_not_block_the_node_event_loop(tmp_path: Path) -> None:
+    bridge = tmp_path / "delayed_bridge.py"
+    bridge.write_text(
+        """
+import json
+import sys
+import time
+
+json.load(sys.stdin)
+time.sleep(0.25)
+print(json.dumps({"bridge": "ready"}))
+""".strip()
+    )
+
+    result = run_node_module(
+        f"""
+        import assert from 'node:assert/strict';
+        import {{ createBridgeClient }} from './lib/bridge/client.mjs';
+
+        const client = createBridgeClient({{
+          workspaceRoot: {json.dumps(str(tmp_path))},
+          bridgePath: {json.dumps(str(bridge))},
+          python: {json.dumps(sys.executable)},
+          timeoutMs: 2_000,
+          maxConcurrency: 1,
+          maxQueue: 0,
+        }});
+        let ticks = 0;
+        const timer = setInterval(() => {{ ticks += 1; }}, 10);
+        const firstCall = client.callBridgeResult('delayed', {{}});
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        const overflow = await client.callBridgeResult('delayed', {{}});
+        const response = await firstCall;
+        clearInterval(timer);
+
+        assert.equal(overflow.ok, false);
+        assert.equal(overflow.error, 'BridgeBusy');
+        assert.equal(response.ok, true);
+        assert.equal(response.payload.bridge, 'ready');
+        assert.ok(ticks >= 5, `event loop only advanced ${{ticks}} times`);
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_bridge_timeout_kills_child_and_writes_fail_closed_diagnostic(
+    tmp_path: Path,
+) -> None:
+    bridge = tmp_path / "stuck_bridge.py"
+    bridge.write_text(
+        """
+import json
+import signal
+import sys
+import time
+
+json.load(sys.stdin)
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+print("started", flush=True)
+time.sleep(5)
+""".strip()
+    )
+    diagnostics = tmp_path / "diagnostics"
+
+    result = run_node_module(
+        f"""
+        import assert from 'node:assert/strict';
+        import {{ createBridgeClient }} from './lib/bridge/client.mjs';
+
+        const client = createBridgeClient({{
+          workspaceRoot: {json.dumps(str(tmp_path))},
+          bridgePath: {json.dumps(str(bridge))},
+          python: {json.dumps(sys.executable)},
+          diagnosticsDir: {json.dumps(str(diagnostics))},
+          timeoutMs: 2_000,
+        }});
+        const startedAt = Date.now();
+        const response = await client.callBridgeResult(
+          'stuck',
+          {{}},
+          {{ timeoutMs: 50 }},
+        );
+
+        assert.equal(response.ok, false);
+        assert.equal(response.error, 'BridgeTimeout');
+        assert.equal(response.timeout_ms, 50);
+        assert.ok(response.duration_ms >= 50);
+        assert.ok(Date.now() - startedAt < 2_500);
+        assert.ok(response.diagnostic?.path);
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    diagnostic_paths = list(diagnostics.glob("*.json"))
+    assert len(diagnostic_paths) == 1
+    diagnostic = json.loads(diagnostic_paths[0].read_text())
+    assert diagnostic["error"] == "BridgeTimeout"
+    assert diagnostic["signal"] == "SIGKILL"
+    assert diagnostic["bridge"]["stdout"].strip() == "started"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_bridge_output_is_bounded_and_fails_closed(tmp_path: Path) -> None:
+    bridge = tmp_path / "noisy_bridge.py"
+    bridge.write_text(
+        """
+import json
+import sys
+
+json.load(sys.stdin)
+print(json.dumps({"payload": "x" * 10_000}), flush=True)
+""".strip()
+    )
+
+    result = run_node_module(
+        f"""
+        import assert from 'node:assert/strict';
+        import {{ createBridgeClient }} from './lib/bridge/client.mjs';
+
+        const client = createBridgeClient({{
+          workspaceRoot: {json.dumps(str(tmp_path))},
+          bridgePath: {json.dumps(str(bridge))},
+          python: {json.dumps(sys.executable)},
+          timeoutMs: 2_000,
+          maxOutputBytes: 128,
+        }});
+        const response = await client.callBridgeResult('noisy', {{}});
+
+        assert.equal(response.ok, false);
+        assert.equal(response.error, 'BridgeOutputTooLarge');
+        """
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_extract_route_source_optional.py
+++ b/tests/test_extract_route_source_optional.py
@@ -115,6 +115,31 @@ def test_short_sketch_no_source_dispatches_to_sketch_path(client):
     assert not fake_extract.called, "must NOT call extract_knowledge_map"
 
 
+def test_seda_owned_source_less_start_skips_lc_and_extract_route_generation(client):
+    with patch("main.LCClient") as fake_lc, \
+         patch("main.generate_smallest_provisional_map") as fake_gen, \
+         patch("main.extract_knowledge_map") as fake_extract:
+        response = client.post("/api/extract", json={
+            "name": "Photosynthesis",
+            "starting_sketch": "Plants use light to make sugar somehow.",
+            "source": None,
+            "route_owner": "seda",
+        })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["route_owner"] == "seda"
+    assert body["provisional_map"]["metadata"]["route_status"] == "pending_seda"
+    assert body["provisional_map"]["metadata"]["graph_neutral"] is True
+    assert "Plants use light" in (
+        body["provisional_map"]["clusters"][0]["subnodes"][0]
+        ["learner_scaffold"]["entry_prompt"]
+    )
+    fake_lc.assert_not_called()
+    fake_gen.assert_not_called()
+    fake_extract.assert_not_called()
+
+
 def test_empty_sketch_no_source_returns_422_missing_sketch(client):
     response = client.post("/api/extract", json={
         "name": "Photosynthesis",

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -48,6 +48,8 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
               remove() {},
             },
             appendChild(child) {
+              this.appended = this.appended || [];
+              this.appended.push(child);
               this.lastChild = child;
             },
             addEventListener(type, handler) {
@@ -93,10 +95,17 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
           },
         };
         globalThis.requestAnimationFrame = (callback) => callback();
-        globalThis.setTimeout = (callback) => {
+        const scheduledTimers = [];
+        globalThis.setTimeout = (callback, delay = 0) => {
+          if (delay === 1200) {
+            const timer = { callback, delay, cleared: false };
+            scheduledTimers.push(timer);
+            return timer;
+          }
           callback();
           return 0;
         };
+        globalThis.clearTimeout = (timer) => { if (timer) timer.cleared = true; };
 
         await import('./public/js/drill-chamber.js');
 
@@ -143,11 +152,42 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
         assert.equal(nodes.get('chamber-send').disabled, true);
 
         nodes.set('chamber-hint', makeNode('chamber-hint'));
+        nodes.set('chamber-verdict', makeNode('chamber-verdict'));
         window.DrillChamber.show({
           conceptName: 'Concept',
           entryName: 'Entry',
           question: 'Question?',
         });
+        window.DrillChamber.setLoading(true);
+        assert.equal(nodes.get('chamber-hint').textContent, 'A sentence is enough.');
+        window.DrillChamber.setLoading(true, { checkingAnswer: true });
+        assert.equal(nodes.get('chamber-hint').textContent, 'Checking your answer…');
+        const pendingTimer = scheduledTimers.at(-1);
+        assert.equal(pendingTimer.delay <= 1500, true);
+        pendingTimer.callback();
+        assert.equal(nodes.get('chamber-verdict').hidden, false);
+        assert.deepEqual(
+          nodes.get('chamber-verdict').appended.slice(-3).map((node) => node.textContent),
+          ['Answer received', '•', 'Checking the link you wrote.']
+        );
+        assert.equal(
+          nodes.get('chamber-verdict').lastChild.textContent,
+          'Checking the link you wrote.'
+        );
+        window.DrillChamber.setLoading(false);
+        assert.equal(nodes.get('chamber-hint').textContent, 'A sentence is enough.');
+        assert.equal(nodes.get('chamber-verdict').hidden, true);
+        window.DrillChamber.setLoading(true, { checkingAnswer: true });
+        scheduledTimers.at(-1).callback();
+        window.DrillChamber.appendVerdict('Checked • Partly there');
+        assert.equal(nodes.get('chamber-verdict').lastChild.textContent, 'Partly there');
+        assert.equal(nodes.get('chamber-verdict').hidden, false);
+        window.DrillChamber.setLoading(true, { checkingAnswer: true });
+        const exitTimer = scheduledTimers.at(-1);
+        assert.equal(nodes.get('chamber-active')['data-loading'], 'true');
+        window.DrillChamber.hide();
+        assert.equal(exitTimer.cleared, true);
+        assert.equal(nodes.get('chamber-active')['data-loading'], undefined);
         nodes.get('chamber-composer').value = '   ';
         nodes.get('chamber-send').click();
         assert.deepEqual(sent, ['learner answer']);
@@ -168,22 +208,60 @@ def test_drill_verdict_helpers_keep_seda_transitions_specific() -> None:
           verdictCopy,
         } from './public/js/drill-verdict.js';
 
+        const duplicateFallback = nextSedaPromptAfterVerdict(
+          'Same question?',
+          'Same question?',
+          'I guessed with my own words.'
+        );
         assert.equal(
-          nextSedaPromptAfterVerdict('Same question?', 'Same question?', 'I guessed with my own words.'),
+          duplicateFallback,
           'You wrote: «I guessed with my own words.». Now: name the missing link in one sentence.'
         );
+        assert.notEqual(duplicateFallback, 'Same question?');
         assert.equal(
           nextSedaPromptAfterVerdict('Explain the mechanism.', 'Same question?', 'My rough answer.'),
           'You wrote: «My rough answer.». Now: Explain the mechanism.'
         );
-        assert.match(
-          verdictCopy({ classification: 'partial', userText: 'The query compares with keys.' }),
-          /Checked • Partly there •/
-        );
-        assert.match(
+        const partialVerdict = verdictCopy({
+          classification: 'partial',
+          userText: 'The query compares with keys.',
+        });
+        assert.match(partialVerdict, /Checked • Partly there •/);
+        assert.match(partialVerdict, /The query compares with keys\\./);
+        assert.doesNotMatch(partialVerdict, /partial/i);
+        assert.match(partialVerdict, /Your line: “The query compares with keys\\.”/);
+        assert.match(partialVerdict, /Study will target the missing link\\./);
+        const unsafeFeedback = verdictCopy({
+          classification: 'partial',
+          userText: 'A rough answer.',
+          specificFeedback: 'Classification: shallow. Score 2.',
+        });
+        assert.doesNotMatch(unsafeFeedback, /Classification|shallow|Score 2/i);
+        assert.match(unsafeFeedback, /Study will target the missing link\\./);
+        for (const classification of ['deep', 'thin', 'shallow']) {
+          const copy = verdictCopy({ classification, userText: 'A rough causal link.' });
+          assert.match(copy, /Checked • Partly there •/);
+          assert.doesNotMatch(copy, new RegExp(classification, 'i'));
+        }
+        const wrongDirection = verdictCopy({
+          classification: 'wrong_direction',
+          userText: 'I started from the output.',
+        });
+        assert.match(wrongDirection, /Study will show a different starting point\\./);
+        assert.doesNotMatch(wrongDirection, /wrong_direction/i);
+        assert.equal(
           verdictCopy({ userText: 'The query compares with keys.', sedaComplete: true }),
-          /Checked • Recorded •/
+          'Checked • Recorded • Your attempt is on record. • Study is ready.'
         );
+        const supportTurn = verdictCopy({
+          userText: 'I need one more cue.',
+          recordable: false,
+        });
+        assert.equal(
+          supportTurn,
+          'Response received • Keep going • Your line: “I need one more cue.” • Use the next question to add one cause-and-effect link.'
+        );
+        assert.doesNotMatch(supportTurn, /Checked|Gap found|Study|Partly there|Wrong angle/);
         """
     )
     assert result.returncode == 0, result.stderr
@@ -464,6 +542,7 @@ def test_launch_pad_action_sends_shell_goal_to_extract() -> None:
         assert.equal(capturedBody.name, 'Sodium channels');
         assert.equal(capturedBody.learner_goal, 'I want to explain why sodium starts the signal.');
         assert.equal(capturedBody.starting_sketch, elements['launch-pad-input'].value);
+        assert.equal(capturedBody.route_owner, 'seda');
         assert.equal(Object.hasOwn(capturedBody, 'api_key'), false);
         assert.equal(calls.length, 2);
         assert.equal(storage.has('socratink:pendingShell'), false);

--- a/tests/test_frontend_cache_pins.py
+++ b/tests/test_frontend_cache_pins.py
@@ -54,6 +54,27 @@ def test_app_bundle_change_requires_index_script_pin_bump() -> None:
     ]
 
 
+def test_ai_service_change_requires_every_direct_import_pin_bump() -> None:
+    checker = _load_checker()
+
+    failures = checker.validate_changed_cache_pins(
+        changed_paths={"public/js/ai_service.js"},
+        old_files={
+            "public/js/app.js": "import './ai_service.js?v=4';",
+            "public/js/launch-pad.js": "import './ai_service.js?v=1';",
+        },
+        new_files={
+            "public/js/app.js": "import './ai_service.js?v=4';",
+            "public/js/launch-pad.js": "import './ai_service.js?v=1';",
+        },
+    )
+
+    assert failures == [
+        "public/js/ai_service.js changed but public/js/app.js still imports ai_service.js?v=4",
+        "public/js/ai_service.js changed but public/js/launch-pad.js still imports ai_service.js?v=1",
+    ]
+
+
 def test_direct_drill_assets_require_index_pin_bumps() -> None:
     checker = _load_checker()
 

--- a/tests/test_loop_backend_proxy.py
+++ b/tests/test_loop_backend_proxy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,6 +28,7 @@ class _GuestAuthService:
             authenticated=True,
             guest_mode=True,
             user=AuthUser(id="anon-test-user"),
+            access_token="supabase-user-token",
         )
 
     def resolve_cookie_secure(self, base_url: str) -> bool:
@@ -114,7 +116,33 @@ def test_loop_proxy_forwards_to_configured_backend(client: TestClient) -> None:
     assert "content-encoding" not in response.headers
     request.assert_called_once()
     assert request.call_args[0][1] == "https://loop.example/loop?q=1"
+    assert request.call_args.kwargs["retries"] is False
+    timeout = request.call_args.kwargs["timeout"]
+    assert timeout.connect_timeout == 5.0
+    assert timeout.read_timeout == 55.0
     upstream.release_conn.assert_called_once()
+
+
+def test_loop_proxy_turns_upstream_timeout_into_retryable_503(
+    client: TestClient,
+) -> None:
+    timeout_error = urllib3.exceptions.ReadTimeoutError(
+        None,
+        "https://loop.example/api/session",
+        "timed out",
+    )
+    with (
+        patch.dict(
+            "os.environ",
+            {"LOOP_BACKEND_URL": "https://loop.example"},
+            clear=False,
+        ),
+        patch("loop_backend_proxy._POOL.request", side_effect=timeout_error),
+    ):
+        response = client.get("/loop", headers={"Accept": "*/*"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Loop backend request timed out."
 
 
 def test_session_proxy_uses_vendored_backend_even_when_external_backend_configured(
@@ -150,7 +178,7 @@ def test_session_proxy_uses_vendored_backend_even_when_external_backend_configur
     assert request.call_args[0][1] == "http://127.0.0.1:9999/api/session"
 
 
-def test_session_proxy_uses_internal_node_function_on_vercel(
+def test_session_proxy_uses_trusted_hosted_loop_service_on_vercel(
     client: TestClient,
 ) -> None:
     upstream = MagicMock()
@@ -166,7 +194,8 @@ def test_session_proxy_uses_internal_node_function_on_vercel(
             patch.dict(
                 "os.environ",
                 {
-                    "LOOP_BACKEND_URL": "https://stale-loop.example",
+                    "LOOP_BACKEND_URL": "https://loop-runtime.example",
+                    "SOCRATINK_LOOP_API_KEY": "loop-token",
                     "SESSION_COOKIE_KEY": "internal-token",
                     "VERCEL": "1",
                 },
@@ -178,7 +207,8 @@ def test_session_proxy_uses_internal_node_function_on_vercel(
                 "/api/session",
                 json={},
                 headers={
-                    "host": "preview.example",
+                    "host": "attacker.example",
+                    "x-forwarded-host": "attacker.example",
                     "x-forwarded-proto": "https",
                     "authorization": "Bearer browser-token",
                     "cookie": "sb_session=sealed",
@@ -189,12 +219,131 @@ def test_session_proxy_uses_internal_node_function_on_vercel(
 
     assert response.status_code == 201
     assert response.json()["sessionId"] == "internal-session"
-    assert request.call_args[0][1] == "https://preview.example/api/internal-loop/api/session"
+    assert request.call_args[0][1] == "https://loop-runtime.example/api/session"
     forwarded = {key.lower(): value for key, value in request.call_args.kwargs["headers"].items()}
     assert forwarded["content-type"] == "application/json"
-    assert forwarded["x-socratink-internal-loop-token"] == "internal-token"
-    assert "authorization" not in forwarded
+    assert forwarded["authorization"] == "Bearer loop-token"
+    assert forwarded["x-socratink-user-access-token"] == "supabase-user-token"
+    assert "x-socratink-internal-loop-token" not in forwarded
     assert "cookie" not in forwarded
+
+
+def test_session_proxy_requires_user_token_for_vercel_internal_store(
+    client: TestClient,
+) -> None:
+    service = _GuestAuthService()
+    service.load_session = lambda _sealed: AuthSessionState(
+        auth_enabled=True,
+        authenticated=True,
+        guest_mode=True,
+        user=AuthUser(id="anon-test-user"),
+    )
+    original_service = main.app.state.auth_service
+    main.app.state.auth_service = service
+    try:
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LOOP_BACKEND_URL": "https://loop-runtime.example",
+                    "SOCRATINK_LOOP_API_KEY": "loop-token",
+                    "SESSION_COOKIE_KEY": "internal-token",
+                    "VERCEL": "1",
+                },
+                clear=False,
+            ),
+            patch("loop_backend_proxy._POOL.request") as request,
+        ):
+            response = client.post("/api/session", json={})
+    finally:
+        main.app.state.auth_service = original_service
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == (
+        "Authenticated session required for durable loop storage."
+    )
+    request.assert_not_called()
+
+
+def test_session_proxy_fails_closed_without_hosted_loop_service(
+    client: TestClient,
+) -> None:
+    original_service = main.app.state.auth_service
+    main.app.state.auth_service = _GuestAuthService()
+    try:
+        with (
+            patch.dict(
+                "os.environ",
+                {"SESSION_COOKIE_KEY": "internal-token", "VERCEL": "1"},
+                clear=False,
+            ),
+            patch("loop_backend_proxy._POOL.request") as request,
+        ):
+            os.environ.pop("LOOP_BACKEND_URL", None)
+            os.environ.pop("SOCRATINK_LOOP_API_KEY", None)
+            response = client.post(
+                "/api/session",
+                json={},
+                headers={"host": "attacker.example"},
+            )
+    finally:
+        main.app.state.auth_service = original_service
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Hosted loop backend is not configured."
+    request.assert_not_called()
+
+
+def test_session_proxy_rejects_request_body_over_64_kib_before_upstream(
+    client: TestClient,
+) -> None:
+    original_service = main.app.state.auth_service
+    main.app.state.auth_service = _GuestAuthService()
+    try:
+        with (
+            patch("loop_backend_proxy._start_local_loop_backend", return_value="http://127.0.0.1:9999"),
+            patch("loop_backend_proxy._POOL.request") as request,
+        ):
+            response = client.post(
+                "/api/session",
+                content=b"x" * (64 * 1024 + 1),
+                headers={"content-type": "application/octet-stream"},
+            )
+    finally:
+        main.app.state.auth_service = original_service
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Loop request body is too large."
+    request.assert_not_called()
+
+
+def test_session_proxy_rejects_insecure_hosted_loop_origin(
+    client: TestClient,
+) -> None:
+    original_service = main.app.state.auth_service
+    main.app.state.auth_service = _GuestAuthService()
+    try:
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "LOOP_BACKEND_URL": "http://attacker.example",
+                    "SOCRATINK_LOOP_API_KEY": "loop-token",
+                    "VERCEL": "1",
+                },
+                clear=False,
+            ),
+            patch("loop_backend_proxy._POOL.request") as request,
+        ):
+            response = client.post("/api/session", json={})
+    finally:
+        main.app.state.auth_service = original_service
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "Hosted loop backend must be a trusted HTTPS origin."
+    )
+    request.assert_not_called()
 
 
 def test_loop_proxy_does_not_forward_accept_encoding(client: TestClient) -> None:
@@ -354,7 +503,11 @@ def test_vendored_loop_backend_runs_pedagogical_session(
             for text in turns:
                 response = client.post(
                     f"/api/session/{session_id}/turn",
-                    json={"text": text},
+                    json={
+                        "text": text,
+                        "requestId": str(uuid.uuid4()),
+                        "expectedVersion": body["sessionVersion"],
+                    },
                 )
                 assert response.status_code == 200
                 body = response.json()

--- a/tests/test_loop_container_packaging.py
+++ b/tests/test_loop_container_packaging.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = ROOT / "Dockerfile.loop"
+DOCKERIGNORE = ROOT / "Dockerfile.loop.dockerignore"
+LOOP_REQUIREMENTS = ROOT / "requirements-loop.txt"
+
+
+def test_loop_container_uses_supported_runtime_and_durable_store_defaults():
+    dockerfile = DOCKERFILE.read_text()
+
+    assert "FROM node:22-bookworm-slim AS node-runtime" in dockerfile
+    assert "FROM python:3.14-slim-bookworm" in dockerfile
+    assert "NODE_ENV=production" in dockerfile
+    assert "SOCRATINK_LOOP_SESSION_STORE=supabase" in dockerfile
+    assert "HOST=0.0.0.0" in dockerfile
+    assert "PYTHON=/app/.venv/bin/python" in dockerfile
+    assert 'CMD ["node", "loop-server.mjs"]' in dockerfile
+    assert "USER socratink" in dockerfile
+
+
+def test_loop_container_context_is_allowlisted_and_cannot_copy_env_files():
+    dockerfile = DOCKERFILE.read_text()
+    ignore_rules = DOCKERIGNORE.read_text().splitlines()
+
+    assert ignore_rules[0] == "**"
+    assert not any(rule == "!.env" or rule.startswith("!.env.") for rule in ignore_rules)
+    assert "COPY . ." not in dockerfile
+    for required_path in (
+        "!requirements-loop.txt",
+        "!loop-server.mjs",
+        "!bridge.py",
+        "!prompt_templates.py",
+        "!bridge_lib/**",
+        "!lib/**",
+        "!pedagogical_agents/contracts.json",
+        "!vendor/python/**",
+    ):
+        assert required_path in ignore_rules
+    assert ignore_rules[-3:] == [
+        "**/__pycache__/",
+        "**/*.pyc",
+        "**/*.pyo",
+    ]
+
+
+def test_loop_bridge_dependencies_match_the_app_pins():
+    app_pins = set((ROOT / "requirements.txt").read_text().splitlines())
+    loop_pins = set(LOOP_REQUIREMENTS.read_text().splitlines())
+
+    assert loop_pins == {"google-genai==1.74.0", "pydantic==2.13.3"}
+    assert loop_pins <= app_pins

--- a/tests/test_loop_session_store.py
+++ b/tests/test_loop_session_store.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+from tests._helpers.node_runner import run_node_module
+
+
+def test_file_store_uses_cas_and_idempotent_turn_replay() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        import os from "node:os";
+        import path from "node:path";
+        import fs from "node:fs/promises";
+        import { createFileSessionStore } from "./lib/loop-server/session-store.mjs";
+
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "socratink-store-test-"));
+        const store = createFileSessionStore({ rootDir: root });
+        const sessionId = "00000000-0000-4000-8000-000000000001";
+        const requestId = "10000000-0000-4000-8000-000000000001";
+        await store.create(sessionId, { sourceLessDoorBootstrap: true });
+
+        const response = { sessionId, sessionVersion: 1, marker: "first" };
+        const committed = await store.appendEvents(
+          sessionId,
+          [{ type: "cold_attempt", text: "first" }],
+          { transcript: [{ level: "log", text: "first" }] },
+          {
+            expectedVersion: 0,
+            requestId,
+            requestHash: "hash-a",
+            response,
+          },
+        );
+        assert.equal(committed.version, 1);
+        assert.equal(committed.events.length, 1);
+        assert.equal(committed.metadata.source_less_door_bootstrap, true);
+        assert.equal(committed.receipts.length, 1);
+
+        const secondRequestId = "10000000-0000-4000-8000-000000000002";
+        const secondResponse = { sessionId, sessionVersion: 2, marker: "second" };
+        await store.appendEvents(
+          sessionId,
+          [{ type: "cold_attempt", text: "second" }],
+          {},
+          {
+            expectedVersion: 1,
+            requestId: secondRequestId,
+            requestHash: "hash-b",
+            response: secondResponse,
+          },
+        );
+        const afterMetadataPatch = await store.updateMetadata(
+          sessionId,
+          { llm: { provider: "test" } },
+          { expectedVersion: 2 },
+        );
+        assert.equal(afterMetadataPatch.receipts.length, 2);
+
+        const replay = await store.appendEvents(
+          sessionId,
+          [{ type: "should_not_append" }],
+          {},
+          {
+            expectedVersion: 0,
+            requestId,
+            requestHash: "hash-a",
+            response,
+          },
+        );
+        assert.deepEqual(replay.replayedResponse, response);
+        assert.equal((await store.load(sessionId)).events.length, 2);
+
+        await assert.rejects(
+          store.appendEvents(sessionId, [], {}, {
+            expectedVersion: 0,
+            requestId,
+            requestHash: "different-hash",
+            response,
+          }),
+          (error) => error.code === "IdempotencyConflict",
+        );
+        await assert.rejects(
+          store.appendEvents(sessionId, [], {}, {
+            expectedVersion: 0,
+            requestId: "10000000-0000-4000-8000-000000000003",
+            requestHash: "hash-c",
+            response,
+          }),
+          (error) => error.code === "SessionConflict",
+        );
+
+        const raceSession = "00000000-0000-4000-8000-000000000002";
+        const raceRequest = "20000000-0000-4000-8000-000000000001";
+        await store.create(raceSession);
+        const raceResponse = { sessionId: raceSession, sessionVersion: 1 };
+        const sameRequestResults = await Promise.all([
+          store.appendEvents(raceSession, [{ type: "turn" }], {}, {
+            expectedVersion: 0,
+            requestId: raceRequest,
+            requestHash: "same-hash",
+            response: raceResponse,
+          }),
+          store.appendEvents(raceSession, [{ type: "turn" }], {}, {
+            expectedVersion: 0,
+            requestId: raceRequest,
+            requestHash: "same-hash",
+            response: raceResponse,
+          }),
+        ]);
+        assert.equal((await store.load(raceSession)).events.length, 1);
+        assert.equal(
+          sameRequestResults.filter((entry) => entry.replayedResponse).length,
+          1,
+        );
+
+        const conflictSession = "00000000-0000-4000-8000-000000000003";
+        await store.create(conflictSession);
+        const differentRequests = await Promise.allSettled([
+          store.appendEvents(conflictSession, [{ type: "a" }], {}, {
+            expectedVersion: 0,
+            requestId: "30000000-0000-4000-8000-000000000001",
+            requestHash: "a",
+            response: { marker: "a" },
+          }),
+          store.appendEvents(conflictSession, [{ type: "b" }], {}, {
+            expectedVersion: 0,
+            requestId: "30000000-0000-4000-8000-000000000002",
+            requestHash: "b",
+            response: { marker: "b" },
+          }),
+        ]);
+        assert.equal(differentRequests.filter((entry) => entry.status === "fulfilled").length, 1);
+        assert.equal(differentRequests.filter((entry) => entry.status === "rejected").length, 1);
+        assert.equal(differentRequests.find((entry) => entry.status === "rejected").reason.code, "SessionConflict");
+        assert.equal((await store.load(conflictSession)).events.length, 1);
+
+        await fs.rm(root, { recursive: true, force: true });
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_file_store_bounds_recent_receipts_by_count_and_bytes() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        import os from "node:os";
+        import path from "node:path";
+        import fs from "node:fs/promises";
+        import {
+          createFileSessionStore,
+          SESSION_STORE_LIMITS,
+        } from "./lib/loop-server/session-store.mjs";
+
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "socratink-receipts-test-"));
+        const store = createFileSessionStore({ rootDir: root });
+        const countSession = "60000000-0000-4000-8000-000000000001";
+        await store.create(countSession);
+        for (let index = 0; index < 20; index += 1) {
+          const suffix = String(index).padStart(12, "0");
+          await store.appendEvents(countSession, [], {}, {
+            expectedVersion: index,
+            requestId: `61000000-0000-4000-8000-${suffix}`,
+            requestHash: `hash-${index}`,
+            response: { marker: index },
+          });
+        }
+        const countBounded = await store.load(countSession);
+        assert.equal(countBounded.receipts.length, SESSION_STORE_LIMITS.receiptEntries);
+        assert.equal(
+          countBounded.receipts[0].request_id,
+          "61000000-0000-4000-8000-000000000004",
+        );
+
+        const bytesSession = "60000000-0000-4000-8000-000000000002";
+        await store.create(bytesSession);
+        for (let index = 0; index < 4; index += 1) {
+          const suffix = String(index).padStart(12, "0");
+          await store.appendEvents(bytesSession, [], {}, {
+            expectedVersion: index,
+            requestId: `62000000-0000-4000-8000-${suffix}`,
+            requestHash: `large-${index}`,
+            response: { marker: index, payload: "x".repeat(700 * 1024) },
+          });
+        }
+        const byteBounded = await store.load(bytesSession);
+        assert.ok(byteBounded.receipts.length < 4);
+        assert.ok(
+          Buffer.byteLength(JSON.stringify(byteBounded.receipts), "utf8")
+            <= SESSION_STORE_LIMITS.receiptBytes,
+        );
+        assert.equal(byteBounded.receipts.at(-1).response.marker, 3);
+
+        await fs.rm(root, { recursive: true, force: true });
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_supabase_store_is_user_scoped_and_cas_safe() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        import { createSupabaseSessionStore } from "./lib/loop-server/supabase-session-store.mjs";
+
+        let row = null;
+        const requests = [];
+        const fakeFetch = async (url, options = {}) => {
+          requests.push({ url: String(url), options });
+          const method = options.method || "GET";
+          const parsed = new URL(url);
+          let body = null;
+          if (method === "POST") {
+            body = JSON.parse(options.body);
+            assert.equal("user_id" in body, false);
+            row = { ...body };
+            return response(201, [row]);
+          }
+          if (method === "GET") return response(200, row ? [row] : []);
+          if (method === "PATCH") {
+            const expected = Number(parsed.searchParams.get("version").replace("eq.", ""));
+            if (!row || row.version !== expected) return response(200, []);
+            body = JSON.parse(options.body);
+            row = { ...row, ...body };
+            return response(200, [row]);
+          }
+          throw new Error(`unexpected ${method}`);
+        };
+        const response = (status, value) => ({
+          ok: status >= 200 && status < 300,
+          status,
+          text: async () => JSON.stringify(value),
+        });
+
+        const store = createSupabaseSessionStore({
+          supabaseUrl: "https://example.supabase.co",
+          publishableKey: "sb_publishable_test",
+          accessToken: "user-jwt",
+          fetchImpl: fakeFetch,
+          now: () => "2026-07-09T12:00:00.000Z",
+        });
+        const sessionId = "40000000-0000-4000-8000-000000000001";
+        const requestId = "41000000-0000-4000-8000-000000000001";
+        await store.create(sessionId);
+        const replayBody = { sessionId, sessionVersion: 1, marker: "stored" };
+        await store.appendEvents(sessionId, [{ type: "route_generated" }], {}, {
+          expectedVersion: 0,
+          requestId,
+          requestHash: "payload-hash",
+          response: replayBody,
+        });
+        const secondRequestId = "41000000-0000-4000-8000-000000000002";
+        const secondReplayBody = { sessionId, sessionVersion: 2, marker: "second" };
+        await store.appendEvents(sessionId, [{ type: "cold_attempt" }], {}, {
+          expectedVersion: 1,
+          requestId: secondRequestId,
+          requestHash: "second-payload-hash",
+          response: secondReplayBody,
+        });
+        await store.updateMetadata(
+          sessionId,
+          { llm: { provider: "test" } },
+          { expectedVersion: 2 },
+        );
+        assert.equal(row.turn_receipts.length, 2);
+        const replay = await store.appendEvents(sessionId, [{ type: "duplicate" }], {}, {
+          expectedVersion: 0,
+          requestId,
+          requestHash: "payload-hash",
+          response: replayBody,
+        });
+        assert.deepEqual(replay.replayedResponse, replayBody);
+        assert.equal(row.events.length, 2);
+        await assert.rejects(
+          store.appendEvents(sessionId, [], {}, {
+            expectedVersion: 0,
+            requestId,
+            requestHash: "different-payload",
+            response: replayBody,
+          }),
+          (error) => error.code === "IdempotencyConflict",
+        );
+
+        const sameRaceId = "40000000-0000-4000-8000-000000000002";
+        const sameRaceRequest = "42000000-0000-4000-8000-000000000001";
+        await store.create(sameRaceId);
+        const sameRaceBody = { sessionId: sameRaceId, sessionVersion: 1 };
+        const sameRace = await Promise.all([
+          store.appendEvents(sameRaceId, [{ type: "turn" }], {}, {
+            expectedVersion: 0,
+            requestId: sameRaceRequest,
+            requestHash: "same-race",
+            response: sameRaceBody,
+          }),
+          store.appendEvents(sameRaceId, [{ type: "turn" }], {}, {
+            expectedVersion: 0,
+            requestId: sameRaceRequest,
+            requestHash: "same-race",
+            response: sameRaceBody,
+          }),
+        ]);
+        assert.equal(row.events.length, 1);
+        assert.equal(sameRace.filter((entry) => entry.replayedResponse).length, 1);
+
+        const conflictRaceId = "40000000-0000-4000-8000-000000000003";
+        await store.create(conflictRaceId);
+        const conflictRace = await Promise.allSettled([
+          store.appendEvents(conflictRaceId, [{ type: "a" }], {}, {
+            expectedVersion: 0,
+            requestId: "43000000-0000-4000-8000-000000000001",
+            requestHash: "a",
+            response: { marker: "a" },
+          }),
+          store.appendEvents(conflictRaceId, [{ type: "b" }], {}, {
+            expectedVersion: 0,
+            requestId: "43000000-0000-4000-8000-000000000002",
+            requestHash: "b",
+            response: { marker: "b" },
+          }),
+        ]);
+        assert.equal(conflictRace.filter((entry) => entry.status === "fulfilled").length, 1);
+        assert.equal(conflictRace.filter((entry) => entry.status === "rejected").length, 1);
+        assert.equal(conflictRace.find((entry) => entry.status === "rejected").reason.code, "SessionConflict");
+        assert.equal(row.events.length, 1);
+
+        for (const request of requests) {
+          assert.equal(request.options.headers.authorization, "Bearer user-jwt");
+          assert.equal(request.options.headers.apikey, "sb_publishable_test");
+          assert.equal(JSON.stringify(request).includes("service_role"), false);
+        }
+        const patch = requests.find((request) => request.options.method === "PATCH");
+        assert.match(patch.url, /version=eq%5C.0|version=eq\.0/);
+
+        assert.throws(
+          () => createSupabaseSessionStore({
+            supabaseUrl: "https://example.supabase.co",
+            publishableKey: "sb_secret_do_not_use",
+            accessToken: "user-jwt",
+          }),
+          (error) => error.code === "StoreConfigurationError",
+        );
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_production_store_fails_closed_without_durable_config() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        const { createSessionStoreResolver } = await import("./lib/loop-server/http-server.mjs");
+        const resolver = createSessionStoreResolver({
+          env: {
+            VERCEL: "1",
+            SOCRATINK_LOOP_SESSION_STORE_DIR: "/tmp/must-not-be-used",
+          },
+        });
+        assert.throws(
+          () => resolver({ headers: {} }),
+          (error) => error.code === "StoreConfigurationError",
+        );
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_console_capture_is_async_context_scoped() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        import { withConsoleCapture } from "./lib/loop-server/console-capture.mjs";
+
+        const a = [];
+        const b = [];
+        const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+        await Promise.all([
+          withConsoleCapture(a, async () => {
+            console.log("a-one");
+            await delay(20);
+            console.log("a-two");
+          }),
+          withConsoleCapture(b, async () => {
+            await delay(5);
+            console.log("b-one");
+            await delay(20);
+            console.log("b-two");
+          }),
+        ]);
+        console.log("outside");
+
+        assert.deepEqual(a.map((entry) => entry.text), ["a-one", "a-two"]);
+        assert.deepEqual(b.map((entry) => entry.text), ["b-one", "b-two"]);
+        assert.equal(a.some((entry) => entry.text === "outside"), false);
+        assert.equal(b.some((entry) => entry.text === "outside"), false);
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_http_session_bootstrap_and_turn_idempotency_contract() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        import os from "node:os";
+        import path from "node:path";
+        import fs from "node:fs/promises";
+
+        delete process.env.SOCRATINK_LOOP_API_KEY;
+        const { createFileSessionStore } = await import("./lib/loop-server/session-store.mjs");
+        const { createLoopServerWithStore } = await import("./lib/loop-server/http-server.mjs");
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "socratink-http-store-"));
+        const store = createFileSessionStore({ rootDir: root });
+        const createCalls = [];
+        let turnAdvanceCount = 0;
+        const createSession = async (options) => {
+          createCalls.push(options);
+          return {
+            id: options.id,
+            events: [...(options.events || [])],
+            status: "awaiting_input",
+            phase: "ignition",
+            awaiting: null,
+            transcript: [],
+          };
+        };
+        const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+        const advance = async (session, text) => {
+          if (text !== undefined) {
+            turnAdvanceCount += 1;
+            await delay(15);
+            session.events.push({ type: "turn", text });
+          } else {
+            session.events.push({ type: "start" });
+          }
+          return {
+            sessionId: session.id,
+            status: session.status,
+            phase: session.phase,
+            awaiting: session.awaiting,
+            transcript: [],
+            events: session.events,
+            marker: text ?? "start",
+          };
+        };
+        const server = createLoopServerWithStore({ sessionStore: store, createSession, advance });
+        await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const base = `http://127.0.0.1:${server.address().port}`;
+        const post = (url, body) => fetch(`${base}${url}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+        try {
+          const started = await post("/api/session", { sourceLessDoorBootstrap: true });
+          assert.equal(started.status, 201);
+          const startedBody = await started.json();
+          assert.equal(startedBody.sessionVersion, 1);
+          const sessionId = startedBody.sessionId;
+          assert.equal(createCalls[0].sourceLessDoorBootstrap, true);
+          assert.equal((await store.load(sessionId)).metadata.source_less_door_bootstrap, true);
+
+          const defaulted = await post("/api/session", { sourceLessDoorBootstrap: "true" });
+          assert.equal(defaulted.status, 201);
+          assert.equal(createCalls[1].sourceLessDoorBootstrap, false);
+
+          const requestId = "50000000-0000-4000-8000-000000000001";
+          const missingRequestId = await post(`/api/session/${sessionId}/turn`, {
+            text: "missing request id",
+            expectedVersion: 1,
+          });
+          assert.equal(missingRequestId.status, 400);
+          assert.equal((await missingRequestId.json()).code, "InvalidRequestId");
+          const missingVersion = await post(`/api/session/${sessionId}/turn`, {
+            text: "missing version",
+            requestId: "50000000-0000-4000-8000-000000000099",
+          });
+          assert.equal(missingVersion.status, 400);
+          assert.equal((await missingVersion.json()).code, "InvalidExpectedVersion");
+          const stale = await post(`/api/session/${sessionId}/turn`, {
+            text: "stale answer",
+            requestId: "50000000-0000-4000-8000-000000000098",
+            expectedVersion: 0,
+          });
+          assert.equal(stale.status, 409);
+          const staleBody = await stale.json();
+          assert.equal(staleBody.code, "SessionConflict");
+          assert.equal(staleBody.currentVersion, 1);
+          assert.equal(turnAdvanceCount, 0);
+          assert.equal((await store.load(sessionId)).events.length, 1);
+
+          const first = await post(`/api/session/${sessionId}/turn`, {
+            text: "first answer",
+            requestId,
+            expectedVersion: 1,
+          });
+          assert.equal(first.status, 200);
+          const firstBody = await first.json();
+          assert.equal(firstBody.sessionVersion, 2);
+          assert.equal(createCalls.at(-1).sourceLessDoorBootstrap, true);
+          const advancesAfterFirst = turnAdvanceCount;
+
+          const second = await post(`/api/session/${sessionId}/turn`, {
+            text: "second answer",
+            requestId: "50000000-0000-4000-8000-000000000002",
+            expectedVersion: 2,
+          });
+          assert.equal(second.status, 200);
+          assert.equal((await second.json()).sessionVersion, 3);
+          assert.equal(turnAdvanceCount, advancesAfterFirst + 1);
+          const advancesAfterSecond = turnAdvanceCount;
+
+          const replay = await post(`/api/session/${sessionId}/turn`, {
+            text: "first answer",
+            requestId,
+            expectedVersion: 1,
+          });
+          assert.equal(replay.status, 200);
+          assert.deepEqual(await replay.json(), firstBody);
+          assert.equal(turnAdvanceCount, advancesAfterSecond);
+
+          const reused = await post(`/api/session/${sessionId}/turn`, {
+            text: "different answer",
+            requestId,
+            expectedVersion: 1,
+          });
+          assert.equal(reused.status, 409);
+          assert.equal((await reused.json()).code, "IdempotencyConflict");
+          assert.equal(turnAdvanceCount, advancesAfterSecond);
+
+          const raceStart = await post("/api/session", {});
+          const raceId = (await raceStart.json()).sessionId;
+          const raceRequest = "51000000-0000-4000-8000-000000000001";
+          const sameRace = await Promise.all([
+            post(`/api/session/${raceId}/turn`, {
+              text: "same", requestId: raceRequest, expectedVersion: 1,
+            }),
+            post(`/api/session/${raceId}/turn`, {
+              text: "same", requestId: raceRequest, expectedVersion: 1,
+            }),
+          ]);
+          assert.deepEqual(sameRace.map((entry) => entry.status), [200, 200]);
+          assert.deepEqual(await sameRace[0].json(), await sameRace[1].json());
+          assert.equal((await store.load(raceId)).events.length, 2);
+
+          const differentRace = await Promise.all([
+            post(`/api/session/${raceId}/turn`, {
+              text: "a",
+              requestId: "52000000-0000-4000-8000-000000000001",
+              expectedVersion: 2,
+            }),
+            post(`/api/session/${raceId}/turn`, {
+              text: "b",
+              requestId: "52000000-0000-4000-8000-000000000002",
+              expectedVersion: 2,
+            }),
+          ]);
+          assert.deepEqual(differentRace.map((entry) => entry.status).sort(), [200, 409]);
+          assert.equal((await store.load(raceId)).events.length, 3);
+
+          process.env.NODE_ENV = "production";
+          try {
+            const unsealedProductionApi = await post("/api/session", {});
+            assert.equal(unsealedProductionApi.status, 503);
+            assert.equal(
+              (await unsealedProductionApi.json()).error,
+              "loop_api_key_required",
+            );
+          } finally {
+            delete process.env.NODE_ENV;
+          }
+        } finally {
+          await new Promise((resolve) => server.close(resolve));
+          await fs.rm(root, { recursive: true, force: true });
+        }
+        """
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_loop_sessions_schema.py
+++ b/tests/test_loop_sessions_schema.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = REPO_ROOT / "db" / "loop_sessions.sql"
+
+
+def test_loop_sessions_schema_is_rls_scoped_and_concurrency_ready() -> None:
+    sql = SCHEMA.read_text()
+
+    assert "user_id UUID NOT NULL DEFAULT auth.uid()" in sql
+    assert "ALTER TABLE public.loop_sessions ENABLE ROW LEVEL SECURITY" in sql
+    assert 'CREATE POLICY "loop_sessions_select_own"' in sql
+    assert 'CREATE POLICY "loop_sessions_insert_own"' in sql
+    assert 'CREATE POLICY "loop_sessions_update_own"' in sql
+    assert 'CREATE POLICY "loop_sessions_delete_own"' in sql
+    assert sql.count("auth.uid() = user_id") >= 4
+    assert "version BIGINT NOT NULL DEFAULT 0" in sql
+    assert "turn_receipts JSONB NOT NULL DEFAULT '[]'::jsonb" in sql
+    assert "last_request_id" not in sql
+    assert "loop_sessions_user_id_idx" in sql
+    assert "loop_sessions_expires_at_idx" in sql
+    assert "purge_expired_loop_sessions" in sql
+    assert "FROM PUBLIC, anon, authenticated" in sql
+
+
+def test_loop_sessions_schema_bounds_journal_and_replay_payloads() -> None:
+    sql = SCHEMA.read_text()
+
+    assert "jsonb_array_length(events) <= 128" in sql
+    assert "octet_length(events::text) <= 524288" in sql
+    assert "octet_length(metadata::text) <= 262144" in sql
+    assert "jsonb_array_length(metadata -> 'transcript_tail') <= 80" in sql
+    assert "jsonb_array_length(turn_receipts) <= 16" in sql
+    assert "octet_length(turn_receipts::text) <= 2097152" in sql
+    assert "REVOKE ALL ON public.loop_sessions FROM PUBLIC, anon" in sql
+    assert "service_role" not in sql.lower()

--- a/tests/test_seda_evidence_projection.py
+++ b/tests/test_seda_evidence_projection.py
@@ -185,6 +185,150 @@ def test_latest_seda_attempt_event_projects_before_case_complete() -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_completed_record_reconciles_early_cold_event_without_duplicate() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import {
+          projectCompletedSedaRecord,
+          projectLatestSedaAttemptEvent,
+        } from './public/js/seda-evidence-projection.js';
+        import { deriveNodeTraining } from './public/js/training-derive.js';
+
+        const early = projectLatestSedaAttemptEvent({
+          training: null,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-1',
+          now: '2026-07-09T05:00:00.000Z',
+          data: { events: [{
+            type: 'cold_attempt',
+            text: 'Memory cells remain after exposure.',
+            evaluation: { classification: 'solid', gaps: [] },
+          }] },
+        });
+        const completedRecord = {
+          training: { node_records: { backend: {
+            attempts: [
+              {
+                user_text: 'Memory cells remain after exposure.',
+                classification: 'strong', gaps: [], grader_version: 'seda',
+              },
+              {
+                user_text: 'They respond faster on re-exposure.',
+                classification: 'strong', gaps: [], grader_version: 'seda',
+              },
+            ],
+            repairs: [],
+          } } },
+        };
+        const reconciled = projectCompletedSedaRecord({
+          training: early,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-1',
+          now: '2026-07-09T05:05:00.000Z',
+          record: completedRecord,
+        });
+
+        const attempts = reconciled.node_records.n.attempts;
+        assert.equal(attempts.length, 2);
+        assert.deepEqual(
+          attempts.map((attempt) => attempt.id),
+          ['seda-sess-1-0', 'seda-sess-1-1'],
+        );
+        assert.equal(
+          attempts.filter((attempt) => attempt.user_text === 'Memory cells remain after exposure.').length,
+          1,
+        );
+        assert.notEqual(
+          deriveNodeTraining(reconciled.node_records.n, {
+            now: '2026-07-09T05:05:00.000Z',
+          }).state,
+          'solidified',
+        );
+        assert.equal(projectCompletedSedaRecord({
+          training: reconciled,
+          conceptId: 'c', nodeId: 'n', sessionId: 'sess-1',
+          record: completedRecord,
+        }), null);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_shallow_early_attempt_matches_completed_classification_and_gap() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import {
+          projectCompletedSedaRecord,
+          projectLatestSedaAttemptEvent,
+        } from './public/js/seda-evidence-projection.js';
+        import { deriveNodeTraining } from './public/js/training-derive.js';
+
+        const gap = 'Name why the retained cells can respond sooner.';
+        const early = projectLatestSedaAttemptEvent({
+          training: null,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-shallow',
+          now: '2026-07-09T05:00:00.000Z',
+          data: { events: [{
+            type: 'cold_attempt',
+            text: 'Something remains after exposure.',
+            evaluation: {
+              classification: 'shallow',
+              gap_description: gap,
+              grader_version: 'seda',
+            },
+          }] },
+        });
+        const earlyAttempt = early.node_records.n.attempts[0];
+        assert.equal(earlyAttempt.classification, 'partial');
+        assert.deepEqual(earlyAttempt.gaps, [{
+          mechanism: 'target mechanism', correction: gap,
+        }]);
+        assert.equal(
+          deriveNodeTraining(early.node_records.n, {
+            now: '2026-07-09T05:00:00.000Z',
+          }).state,
+          'primed',
+        );
+
+        const completed = projectCompletedSedaRecord({
+          training: early,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-shallow',
+          now: '2026-07-09T05:05:00.000Z',
+          record: { training: { node_records: { backend: {
+            attempts: [{
+              user_text: 'Something remains after exposure.',
+              classification: 'partial',
+              gaps: [{ mechanism: 'target mechanism', correction: gap }],
+              grader_version: 'seda',
+            }],
+            repairs: [],
+          } } } },
+        });
+        const completedAttempt = completed.node_records.n.attempts[0];
+        assert.equal(completedAttempt.classification, earlyAttempt.classification);
+        assert.deepEqual(completedAttempt.gaps, earlyAttempt.gaps);
+        assert.equal(
+          deriveNodeTraining(completed.node_records.n, {
+            now: '2026-07-09T05:05:00.000Z',
+          }).state,
+          'primed',
+        );
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_projection_returns_null_without_completed_record() -> None:
     result = run_node_module(
         """

--- a/tests/test_seda_route_binding.py
+++ b/tests/test_seda_route_binding.py
@@ -1,0 +1,163 @@
+"""Source-less SEDA route binding contract."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from tests._helpers.node_runner import run_node_module
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_route_rebinds_map_once_and_preserves_app_metadata() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import {
+          bindSourceLessSedaRoute,
+          boundSourceLessSedaNodeId,
+          boundSourceLessSedaSessionId,
+          clearBoundSourceLessSedaRoute,
+          hasBoundSourceLessSedaRoute,
+        } from './public/js/seda-route-binding.js';
+
+        const existingMap = {
+          metadata: {
+            core_thesis: 'Door map thesis',
+            starting_map_context: 'My rough Door sketch.',
+            source_mode: 'source_less',
+            map_maturity: 'provisional',
+            learner_goal: 'Explain the causal chain.',
+          },
+          backbone: [{ id: 'b1', principle: 'Door map principle.' }],
+          clusters: [],
+        };
+        const data = {
+          sessionId: 'session-9',
+          awaiting: { key: 'cold_attempt' },
+          sourceLessRoute: {
+            contractVersion: 1,
+            status: 'ready',
+            firstNode: {
+              id: 'c9_s1', label: 'Bound target',
+              mechanism: 'Mechanism B happens before the result.',
+              learner_prompt: 'Explain prompt B from memory.',
+              evidence_goal: 'Name the link from B to the result.',
+            },
+            provisionalMap: {
+              metadata: { core_thesis: 'SEDA route thesis' },
+              backbone: [{ id: 'b9', principle: 'Route backbone.' }],
+              clusters: [{
+                id: 'c9', label: 'Route cluster',
+                subnodes: [{ id: 'c9_s1', label: 'Stale route label' }],
+              }],
+            },
+          },
+          events: [{ type: 'route_generated', first_node: { id: 'wrong-node' } }],
+        };
+
+        const bound = bindSourceLessSedaRoute({
+          data,
+          existingMap,
+          concept: {
+            startingMapContext: 'My rough Door sketch.',
+            learnerGoal: 'Explain the causal chain.',
+            sourceMode: 'source_less',
+          },
+        });
+
+        assert.equal(bound.nodeContext.id, 'c9_s1');
+        assert.equal(bound.nodeContext.prompt, 'Explain prompt B from memory.');
+        assert.equal(bound.nodeContext.detail, 'Mechanism B happens before the result.');
+        const target = bound.graphData.clusters[0].subnodes[0];
+        assert.equal(target.label, 'Bound target');
+        assert.equal(target.study_note, 'Mechanism B happens before the result.');
+        assert.equal(target.learner_scaffold.entry_prompt, 'Explain prompt B from memory.');
+        assert.equal(bound.graphData.metadata.core_thesis, 'SEDA route thesis');
+        assert.equal(bound.graphData.metadata.starting_map_context, 'My rough Door sketch.');
+        assert.equal(bound.graphData.metadata.source_mode, 'source_less');
+        assert.equal(bound.graphData.metadata.map_maturity, 'provisional');
+        assert.equal(bound.graphData.metadata.learner_goal, 'Explain the causal chain.');
+        assert.equal(hasBoundSourceLessSedaRoute(existingMap), false);
+        assert.equal(hasBoundSourceLessSedaRoute(bound.graphData), true);
+        assert.equal(boundSourceLessSedaNodeId(bound.graphData), 'c9_s1');
+        assert.equal(boundSourceLessSedaSessionId(bound.graphData), 'session-9');
+        assert.equal(data.sourceLessRoute.provisionalMap.clusters[0].subnodes[0].label, 'Stale route label');
+        const cleared = clearBoundSourceLessSedaRoute(bound.graphData);
+        assert.equal(hasBoundSourceLessSedaRoute(cleared), false);
+        assert.equal(cleared.metadata.starting_map_context, 'My rough Door sketch.');
+        assert.equal(cleared.metadata.route_status, 'pending_seda');
+        assert.equal(cleared.metadata.graph_neutral, true);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_route_fails_closed_when_not_bindable() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { bindSourceLessSedaRoute } from './public/js/seda-route-binding.js';
+
+        assert.throws(
+          () => bindSourceLessSedaRoute({ data: { sessionId: 's', events: [] } }),
+          /missing sourceLessRoute result/,
+        );
+        const baseRoute = {
+          contractVersion: 1,
+          status: 'ready',
+          firstNode: {
+            id: 'c9_s1', label: 'Target', mechanism: 'Mechanism B',
+            learner_prompt: 'Prompt B',
+          },
+          provisionalMap: {
+            metadata: {},
+            backbone: [{ id: 'b9', principle: 'Route backbone.' }],
+            clusters: [{ id: 'c9', subnodes: [{ id: 'different-node' }] }],
+          },
+        };
+        assert.throws(
+          () => bindSourceLessSedaRoute({ data: {
+            sessionId: 's', awaiting: { key: 'cold_attempt' }, sourceLessRoute: baseRoute,
+          } }),
+          /first_node.id is absent/,
+        );
+        assert.throws(
+          () => bindSourceLessSedaRoute({
+            data: {
+              sessionId: 's', awaiting: { key: 'cold_attempt' },
+              sourceLessRoute: {
+                ...baseRoute,
+                firstNode: { ...baseRoute.firstNode, mechanism: '' },
+              },
+            },
+          }),
+          /missing first_node.mechanism/,
+        );
+        assert.throws(
+          () => bindSourceLessSedaRoute({ data: {
+            sessionId: 's', awaiting: { key: 'cold_attempt' },
+            sourceLessRoute: {
+              ...baseRoute,
+              firstNode: { ...baseRoute.firstNode, id: 9 },
+            },
+          } }),
+          /missing first_node.id/,
+        );
+        assert.throws(
+          () => bindSourceLessSedaRoute({ data: {
+            sessionId: 's', awaiting: { key: 'cold_attempt' },
+            sourceLessRoute: {
+              contractVersion: 1,
+              status: 'route_unavailable',
+              code: 'route_unavailable',
+              reason: 'generation_failed',
+            },
+          } }),
+          /generation_failed/,
+        );
+        """
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Context & Intent
- What problem does this solve? A source-less learner could submit real effort and then wait on a silent or ambiguous route instead of seeing an effort verdict and an earned path to study.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Codex first-session momentum and mobile stabilization track.

Implementation Details
- Bind the first chamber prompt to the authoritative SEDA route; add verdict/study actions, draft-safe fail-closed recovery, canonical evidence projection, mobile-safe controls, and focused browser proof.
- Add bounded asynchronous bridge execution, authenticated proxying, idempotent CAS session journals, a user-scoped Supabase store/schema, and a deployable loop container. This crosses the frontend route/evidence boundary and hosted loop-runtime persistence boundary.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? Reviewed: Vercel now fails closed unless a dedicated hosted loop URL/key is configured, and durable state lives in Supabase rather than process-local storage.
- [x] Are there SSRF or error-leakage risks in new external calls? Reviewed: the hosted session origin must be a credential-free HTTPS origin, request/response bodies are bounded, and upstream errors are sanitized.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Ingestion behavior is unchanged and its existing fallback remains intact.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Study remains unavailable until a non-empty recordable chamber attempt is persisted.
- [x] Does the graph still tell the truth (no faking mastery)? Early and completed evidence use the same canonical classification/gaps, and SEDA timestamps are re-stamped so one sitting cannot solidify.
- [x] Is the active cognitive target explicitly clear to the user? The SEDA-selected node owns the visible prompt, verdict, and study note; stale or missing routes fail into explicit recovery UX.

Branch: feat/first-session-verdict
Base: main
Diff summary: 62 files; first-session verdict/study UX, mobile fit, authoritative SEDA routing, durable hosted session runtime, deployment assets, and focused regression coverage.
