### PR TITLE
[codex] Make Desk reconstruction primary

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,48 @@
+# Desk reconstruction instrument — design QA
+
+Date: 2026-07-12
+
+## Visual proof
+
+- Rejected first implementation: `.qa-runs/desk-reconstruction-instrument/final-tactile-390x844.png`
+- Refined mobile capture: `.qa-runs/desk-reconstruction-instrument/revision-refined-390x844.png`
+- Narrow mobile capture: `.qa-runs/desk-reconstruction-instrument/revision-refined-320x720.png`
+- Rejected/refined comparison: `.qa-runs/desk-reconstruction-instrument/rejected-vs-refined-390x844.png`
+
+### Occupied Desk Library frame
+
+- Source visual: `/Users/jondev/dev/socratink/prod/socratink-app-library-session-index/.qa-runs/library-session-index/after-empty-390x844.png`
+- Implementation visual: `.qa-runs/desk-library-frame/final-occupied-artifacts/tests-e2e-test-smoke-py-test-desk-board-expands-after-first-saved-session-chromium/test-finished-1.png`
+- Full-view comparison: `.qa-runs/desk-library-frame/final-library-vs-desk-390x844.png`
+- State and viewport: Library empty and Desk with one concept, both at 390×844.
+- No separate crop is needed. The complete index frame fits in the shared viewport, and a crop would hide the page and navigation alignment used for comparison.
+- First comparison found the crystal tip and glow too close to the index divider. Increasing the occupied board's top margin from 20px to 32px restored a quiet boundary without shrinking the instrument.
+- The final comparison has no visible border, radius, gutter, title-scale, index-row, or overflow mismatch that blocks this slice.
+
+## Viewport checks
+
+- 320×720: helper wraps naturally; the plate stays inside the viewport and above navigation.
+- 390×844: one 184–200px reconstruction plate occupies a balanced central field.
+- 1280×720: the empty Desk fits without an inner scrollbar.
+- The mobile hamburger is suppressed only on the empty Desk and returns on the Door and populated Desk.
+
+## Contract checks
+
+- A completely empty Desk exposes one accessible `Choose a topic` action; eight future-capacity sockets are hidden and inert.
+- The action opens the existing Door. A saved session restores the existing 3×3 board.
+- Partial Desk empty slots remain actionable; populated and Ready/due behavior is unchanged.
+- Tile state may retain documented legacy visual compatibility, but evidence descriptions appear only when persisted training attempts support them.
+- Keyboard and forced-colors focus remain visible; active destinations expose `aria-current="page"`.
+- No scores, mastery/completion language, diagnostic labels, study-before-attempt content, or fabricated training evidence were added.
+
+## Review gates
+
+- Initial adversarial Taste Gate: rejected at 18/40; the nine-slot first-use board was ornamental capacity rather than a learning instrument.
+- Intermediate independent Taste Gate: rejected at 22/40; the single plate was too small, the tap outcome was ambiguous, and mobile chrome competed with the task.
+- Final independent Taste Gate: passed at 34/40 with low cognitive load, no AI-slop verdict, and no remaining P1/P2 issues.
+- Final independent code/contract gate: passed with no P1/P2 regressions.
+- Focused unit, browser-contract, and Desk E2E checks pass; `scripts/doctor.sh`, diff whitespace, and worktree guard are clean.
+
+User approval remains open.
+
+final result: passed

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -896,78 +896,116 @@ html[data-theme="dark"] body.antigravity-theme .settings-toggle[aria-checked="tr
 }
 
 /* ══════════════════════════════════════════════════════════════
-   4b. DESK FRAME — date eyebrow + italic title + state legend
-   Header above the iso-board, legend below. Folded in from the
-   _lab/desk-variants prototype (persona pick: variant D = C-header
-   + A-legend). See docs/superpowers/specs or git log for the
-   capture.
+   4b. DESK FRAME — compact reconstruction heading
    ══════════════════════════════════════════════════════════════ */
 
 body.antigravity-theme .desk-frame {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 8px;
-  margin: 0 auto clamp(12px, 2.5vh, 24px);
-  max-width: 460px;
-}
-
-body.antigravity-theme .desk-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 12px;
-  border-radius: 999px;
-  background: rgba(144, 103, 198, 0.10);
-  border: 1px solid rgba(144, 103, 198, 0.22);
-  color: var(--ag-violet);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-}
-
-html[data-theme="dark"] body.antigravity-theme .desk-eyebrow {
-  background: rgba(158, 139, 255, 0.12);
-  border-color: rgba(158, 139, 255, 0.24);
-}
-
-body.antigravity-theme .desk-eyebrow-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: currentcolor;
-}
-
-body.antigravity-theme .desk-eyebrow-sep {
-  opacity: 0.55;
-}
-
-body.antigravity-theme .desk-eyebrow-date:empty::before {
-  content: "—";
+  align-items: flex-start;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  text-align: left;
+  gap: 10px;
 }
 
 body.antigravity-theme .desk-title {
-  margin: 4px 0 0;
-  font-family: Outfit, Manrope, Inter, sans-serif;
-  font-size: clamp(1.4rem, 1.4vw + 0.8rem, 1.75rem);
-  font-weight: 400;
-  font-style: italic;
-  letter-spacing: -0.018em;
-  line-height: 1.18;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 2vw + 1rem, 2.55rem);
+  font-weight: 700;
+  font-style: normal;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
   color: var(--text-main);
-  text-wrap: balance;
 }
 
 body.antigravity-theme .desk-helper {
   margin: 0;
-  max-width: 38ch;
-  font-size: 14.5px;
-  font-weight: 300;
-  font-style: italic;
-  line-height: 1.55;
+  max-width: 50ch;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  line-height: 1.5;
+  letter-spacing: -0.012em;
   color: var(--text-muted);
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+
+/* Occupied Desk: borrow Library's compact index grammar without turning
+   the isometric board into a card illustration. The frame stays quiet;
+   the evidence-derived crystal remains the visual foreground. */
+body.antigravity-theme .desk-index-header {
+  display: none;
+}
+
+body.antigravity-theme[data-desk-first-use="false"] .hero-card {
+  padding-top: calc(var(--chrome-h-top) + var(--space-5));
+}
+
+body.antigravity-theme[data-desk-first-use="false"] .desk-title {
+  font-size: 1.625rem;
+  letter-spacing: var(--tracking-tight);
+}
+
+body.antigravity-theme[data-desk-first-use="false"] .desk-helper {
+  display: none;
+}
+
+body.antigravity-theme[data-desk-first-use="false"] .hero-card .intro-content {
+  margin-top: var(--space-5);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(var(--paper-0-rgb), 0.34);
+  overflow: visible;
+}
+
+body.antigravity-theme[data-desk-first-use="false"] .desk-index-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  min-height: 48px;
+  padding: 0 var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+  box-sizing: border-box;
+}
+
+body.antigravity-theme .desk-index-title,
+body.antigravity-theme .desk-index-count {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--leading-snug);
+}
+
+body.antigravity-theme .desk-index-count {
+  font-variant-numeric: tabular-nums;
+}
+
+body.antigravity-theme[data-desk-first-use="false"] #grid-container {
+  width: min(420px, calc(100% - 24px));
+  margin: var(--space-8) auto var(--space-6);
+}
+
+body.antigravity-theme[data-desk-first-use="false"] .desk-ready-filter-host {
+  padding: 0 var(--space-4);
+}
+
+@media (max-width: 899px) {
+  body.antigravity-theme[data-desk-first-use="false"] .hero-card {
+    padding-right: var(--space-5);
+    padding-left: var(--space-5);
+  }
+
+  body.antigravity-theme[data-desk-first-use="false"] .desk-ready-filter {
+    min-height: 44px;
+  }
 }
 
 /* ── Ready filter (Linear-style view chip) ─────────────────── */
@@ -1206,48 +1244,6 @@ body.antigravity-theme .desk-due-selection__action:focus-visible {
   outline-offset: 3px;
 }
 
-body.antigravity-theme .desk-legend {
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 14px;
-  margin: clamp(12px, 2.5vh, 24px) auto 0;
-  font-size: 12px;
-  color: var(--text-muted);
-  letter-spacing: 0.01em;
-}
-
-body.antigravity-theme .desk-legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-body.antigravity-theme .desk-legend-facet {
-  width: 10px;
-  height: 10px;
-  border: 1px solid currentcolor;
-  transform: rotate(45deg);
-  box-sizing: border-box;
-}
-
-body.antigravity-theme .desk-legend-item[data-state="locked"]     { color: rgba(141, 134, 201, 0.72); }
-body.antigravity-theme .desk-legend-item[data-state="primed"]     { color: var(--ag-violet); }
-body.antigravity-theme .desk-legend-item[data-state="drilled"]    { color: #B6741E; }
-body.antigravity-theme .desk-legend-item[data-state="solidified"] { color: var(--ag-violet); }
-body.antigravity-theme .desk-legend-item[data-state="solidified"] .desk-legend-facet {
-  background: currentcolor;
-}
-
-html[data-theme="dark"] body.antigravity-theme .desk-legend-item[data-state="primed"],
-html[data-theme="dark"] body.antigravity-theme .desk-legend-item[data-state="solidified"] {
-  color: var(--ag-violet);
-}
-html[data-theme="dark"] body.antigravity-theme .desk-legend-item[data-state="drilled"] {
-  color: #F1B864;
-}
-
 /* ══════════════════════════════════════════════════════════════
    5. SIDEBAR & BOTTOM NAV — quiet refinements
    ══════════════════════════════════════════════════════════════ */
@@ -1316,15 +1312,49 @@ html[data-theme="dark"] body.antigravity-theme .sidebar-nav-item.active:focus-vi
 }
 
 body.antigravity-theme .bottom-nav-item.active {
-  color: var(--ag-violet);
+  color: var(--primary-readable);
+}
+
+body.antigravity-theme .bottom-nav-item.active::before {
+  display: none;
 }
 
 body.antigravity-theme .bottom-nav-item.active .bottom-nav-icon {
-  filter: drop-shadow(0 0 6px rgba(144, 103, 198, 0.40));
+  filter: none;
+  stroke-width: 2.1;
 }
 
 html[data-theme="dark"] body.antigravity-theme .bottom-nav-item.active .bottom-nav-icon {
-  filter: drop-shadow(0 0 6px rgba(158, 139, 255, 0.50));
+  filter: none;
+}
+
+body.antigravity-theme .bottom-nav-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ag-violet) 62%, transparent);
+  outline-offset: 2px;
+  border-radius: 12px;
+  box-shadow: none;
+}
+
+body.antigravity-theme .bottom-nav-label {
+  font-size: 0.75rem;
+  line-height: 1.25;
+}
+
+body.antigravity-theme .bottom-nav-item.active .bottom-nav-label {
+  color: var(--primary-readable);
+  font-weight: 700;
+}
+
+@media (forced-colors: active) {
+  body.antigravity-theme .bottom-nav-item:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  body.antigravity-theme .bottom-nav-item.active,
+  body.antigravity-theme .bottom-nav-item.active .bottom-nav-label {
+    color: LinkText;
+  }
 }
 
 /* ══════════════════════════════════════════════════════════════

--- a/public/css/board-first.css
+++ b/public/css/board-first.css
@@ -1,48 +1,72 @@
-/* Board-first Desk: hide hero-info, snug card around the iso board.
- * Loaded after layout.css in styles.css to override.
- *
- * Two specificity bumps needed:
- * - .hero-card has explicit margin (not auto), so max-width needs auto-margins.
- * - .intro-content is a 2-column grid, so the empty hero-info column kept
- *   reserving space and pushed the board off-center. Override display: flex. */
+/* Board-first Desk: the board is the instrument, not a card inside the page.
+ * Loaded after layout.css in styles.css to override the legacy hero shell. */
 
 /* Hide the left column entirely. */
 .hero-card .hero-info {
   display: none;
 }
 
-/* Tight card centered horizontally with auto margins. */
+/* Remove the giant card feel while preserving the same Desk view container. */
 .hero-card {
-  max-width: 560px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 960px;
+  min-height: 100dvh;
+  margin-top: 0;
+  margin-bottom: 0;
   margin-left: auto;
   margin-right: auto;
-  padding: 56px 40px;
-  align-items: center;
-  justify-content: center;
+  padding: clamp(96px, 13vh, 136px) clamp(40px, 8vw, 92px) 72px;
+  align-items: stretch;
+  justify-content: flex-start;
+  background: transparent;
+  border-radius: 0;
+  box-shadow: none;
 }
 
-/* Mobile keeps a fixed frosted .main-header. layout.css clears it with
-   --chrome-h-top; this file must not wipe that padding or the desk
-   eyebrow slides under the scrim and looks cut off. Extra 28px clears
-   the backdrop-filter bloom past the header box. */
+/* Mobile clears the fixed header and the fixed bottom navigation. */
 @media (max-width: 899px) {
   .hero-card {
-    padding: calc(var(--chrome-h-top) + 28px) 20px 80px;
+    min-height: 100dvh;
+    padding: calc(var(--chrome-h-top) + 42px) 24px var(--chrome-h-bottom);
   }
 }
 
-/* Override the 2-column grid so the now-only child (the iso board) centers
-   in a single column. */
+/* The hidden hero-info must not reserve the old left column. */
 .hero-card .intro-content {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: flex-start;
   width: 100%;
   gap: 0;
 }
 
-/* No competing margins on the grid container. */
 #grid-container {
-  margin: 0;
+  position: relative;
+  align-self: center;
+  margin: clamp(44px, 7vh, 74px) 0 0;
+  padding: 0;
+  overflow: visible;
+}
+
+#grid-container.is-first-use {
+  margin-top: clamp(9rem, 22vh, 11.5rem);
+}
+
+@media (max-width: 899px) {
+  body[data-primary-view="desk"][data-desk-first-use="true"] .drawer-toggle {
+    display: none;
+  }
+}
+
+@media (min-width: 900px) {
+  .hero-card {
+    min-height: calc(100dvh - 72px);
+    padding-bottom: 20px;
+  }
+
+  #grid-container.is-first-use {
+    margin-top: clamp(7rem, 16vh, 10rem);
+  }
 }

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=168'     layer(components);
-@import '../antigravity.css?v=37' layer(legacy);
+@import '../styles.css?v=171'     layer(components);
+@import '../antigravity.css?v=39' layer(legacy);
 @import 'paper.css?v=18'          layer(paper);

--- a/public/css/iso-board-state-surface.css
+++ b/public/css/iso-board-state-surface.css
@@ -7,12 +7,17 @@
 }
 
 #grid-container {
-  width: min(420px, calc(100vw - 32px));
+  width: min(420px, calc(100vw - 20px));
+}
+
+#grid-container.is-first-use {
+  width: clamp(11.5rem, 50vw, 12.5rem);
 }
 
 #grid-svg {
   width: 100%;
   height: auto;
+  overflow: visible;
 }
 
 .tile-group[data-board-state="locked"] {
@@ -65,6 +70,80 @@
 .tile-group.empty,
 .tile-group.empty .tile-hit {
   cursor: pointer;
+}
+
+/* A first-use Desk presents one reconstruction plate. Capacity appears
+   only after the learner has a saved session to place on the full board. */
+#grid-container.is-first-use .tile-group.is-capacity {
+  display: none;
+}
+
+#grid-container.is-first-use #grid-svg {
+  aspect-ratio: 140 / 130;
+  filter: drop-shadow(0 18px 22px rgba(var(--violet-600-rgb), 0.20));
+}
+
+#grid-container.is-first-use .tile-group.empty .tile-top-empty {
+  fill: color-mix(in srgb, var(--surface-high) 84%, var(--cream-50) 16%);
+  stroke: color-mix(in srgb, var(--primary-readable) 46%, var(--cream-50));
+  stroke-width: 1.7;
+  stroke-linejoin: round;
+}
+
+#grid-container.is-first-use .tile-group.empty .tile-top-dash {
+  fill: none;
+  stroke: rgba(var(--paper-0-rgb), 0.88);
+  stroke-width: 1.25;
+  stroke-dasharray: none;
+  opacity: 0.92;
+  transform: scale(0.955);
+  transform-box: fill-box;
+  transform-origin: center;
+  pointer-events: none;
+}
+
+#grid-container.is-first-use .tile-group.empty .tile-left,
+#grid-container.is-first-use .tile-group.empty .tile-right {
+  opacity: 1;
+  stroke: color-mix(in srgb, var(--primary-readable) 18%, var(--cream-50));
+  stroke-width: 1;
+}
+
+#grid-container.is-first-use .tile-group.empty .tile-left {
+  fill: color-mix(in srgb, var(--surface-high) 66%, var(--cream-50) 34%);
+}
+
+#grid-container.is-first-use .tile-group.empty .tile-right {
+  fill: color-mix(in srgb, var(--surface-high) 68%, var(--ink-900) 32%);
+}
+
+.tile-group.is-capacity,
+.tile-group.is-capacity .tile-hit {
+  cursor: default;
+  pointer-events: none;
+}
+
+#grid-container.is-first-use .tile-group.is-primary-empty,
+#grid-container.is-first-use .tile-group.is-primary-empty .tile-hit {
+  cursor: pointer;
+}
+
+#grid-container.is-first-use .tile-group.is-primary-empty .tile-top-empty {
+  fill: color-mix(in srgb, var(--surface-high) 90%, var(--accent-soft) 10%);
+  stroke: var(--primary-readable);
+  stroke-width: 2;
+}
+
+#grid-container.is-first-use .tile-group.is-primary-empty:hover .tile-top-empty,
+#grid-container.is-first-use .tile-group.is-primary-empty:focus-visible .tile-top-empty {
+  fill: color-mix(in srgb, var(--surface-high) 72%, var(--accent-soft-strong) 28%);
+  stroke: var(--primary-readable);
+  stroke-width: 2.8;
+}
+
+#grid-container.is-first-use .tile-group.is-primary-empty:active .tile-top-empty {
+  fill: color-mix(in srgb, var(--surface-high) 60%, var(--accent-soft-strong) 40%);
+  stroke-width: 2.2;
 }
 
 .concept-pin {
@@ -158,9 +237,41 @@
   stroke-linecap: round;
 }
 
+.empty-tile-affordance__label {
+  fill: var(--primary-readable);
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.empty-tile-affordance--primary {
+  opacity: 1;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition:
+    opacity var(--duration-quick) var(--ease-standard),
+    transform var(--duration-micro) var(--ease-standard);
+}
+
+.empty-tile-affordance--primary .empty-tile-affordance__line {
+  stroke: var(--primary-readable);
+  stroke-width: 2.6;
+}
+
 .tile-group.empty:hover .empty-tile-affordance,
 .tile-group.empty:focus-within .empty-tile-affordance {
   opacity: 0.78;
+}
+
+.tile-group.is-primary-empty:hover .empty-tile-affordance--primary,
+.tile-group.is-primary-empty:focus-visible .empty-tile-affordance--primary {
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+.tile-group.is-primary-empty:active .empty-tile-affordance--primary {
+  transform: translateY(1px);
 }
 
 .tile-group.empty:hover .tile-top-empty,
@@ -199,6 +310,64 @@ body.night .tile-group .tile-right {
 body[data-theme="dark"] .empty-tile-affordance__line,
 body.night .empty-tile-affordance__line {
   stroke: rgba(var(--lavender-500-rgb), 0.58);
+}
+
+body[data-theme="dark"] #grid-container.is-first-use .tile-group.empty .tile-top-empty,
+body.night #grid-container.is-first-use .tile-group.empty .tile-top-empty {
+  fill: color-mix(in srgb, var(--cream-50) 72%, var(--paper-0) 28%);
+  stroke: color-mix(in srgb, var(--ink-900) 22%, var(--cream-50));
+}
+
+body[data-theme="dark"] #grid-container.is-first-use .tile-group.empty .tile-left,
+body.night #grid-container.is-first-use .tile-group.empty .tile-left {
+  fill: color-mix(in srgb, var(--cream-50) 72%, var(--paper-0) 28%);
+  opacity: 1;
+}
+
+body[data-theme="dark"] #grid-container.is-first-use .tile-group.empty .tile-right,
+body.night #grid-container.is-first-use .tile-group.empty .tile-right {
+  fill: color-mix(in srgb, var(--cream-50) 66%, var(--ink-900) 12%);
+  opacity: 1;
+}
+
+body[data-theme="dark"] #grid-container.is-first-use .tile-group.is-primary-empty .tile-top-empty,
+body.night #grid-container.is-first-use .tile-group.is-primary-empty .tile-top-empty {
+  stroke: var(--primary-fill-hover);
+}
+
+body[data-theme="dark"] #grid-container.is-first-use .empty-tile-affordance__label,
+body.night #grid-container.is-first-use .empty-tile-affordance__label {
+  fill: var(--primary-fill-hover);
+}
+
+body[data-theme="dark"] #grid-container.is-first-use .empty-tile-affordance__line,
+body.night #grid-container.is-first-use .empty-tile-affordance__line {
+  stroke: var(--primary-fill-hover);
+}
+
+@media (forced-colors: active) {
+  #grid-container.is-first-use .tile-group.is-primary-empty:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 4px;
+  }
+
+  #grid-container.is-first-use .tile-group.is-primary-empty .tile-top-empty {
+    fill: Canvas;
+    stroke: ButtonText;
+  }
+
+  #grid-container.is-first-use .tile-group.is-primary-empty:focus-visible .tile-top-empty {
+    stroke: Highlight;
+    stroke-width: 3px;
+  }
+
+  #grid-container.is-first-use .empty-tile-affordance__line {
+    stroke: ButtonText;
+  }
+
+  #grid-container.is-first-use .empty-tile-affordance__label {
+    fill: ButtonText;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/public/index.html
+++ b/public/index.html
@@ -20,11 +20,11 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=184">
+  <link rel="stylesheet" href="/css/index.css?v=187">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=17">
 </head>
 
-<body>
+<body data-primary-view="desk" data-desk-first-use="true">
   <script>
     try {
       document.body.classList.add('antigravity-theme');
@@ -51,8 +51,8 @@
   <!-- Bottom Mobile Navigation -->
   <nav class="bottom-nav" id="bottom-nav">
     <a class="bottom-nav-item" href="javascript:void(0)" onclick="App.showIgnition()" id="bn-ignition">
-      <svg class="bottom-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>
-      <span class="bottom-nav-label">Start</span>
+      <svg class="bottom-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+      <span class="bottom-nav-label">New</span>
     </a>
     <a class="bottom-nav-item active" href="javascript:void(0)" onclick="App.showDashboard()" id="bn-dashboard">
       <svg class="bottom-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/></svg>
@@ -192,22 +192,20 @@
       </button>
     </div>
 
-    <!-- Hero card: concept info left, crystal grid right -->
+    <!-- Desk: reconstruction inventory with one honest first-use action. -->
     <section class="hero-card intro-page" aria-labelledby="desk-title">
-      <h2 class="visually-hidden" id="desk-title">Desk</h2>
+      <header class="desk-frame">
+        <h2 class="desk-title" id="desk-title">Desk</h2>
+        <p class="desk-helper">Then write what you remember.</p>
+      </header>
 
       <div class="intro-content">
-        <header class="desk-frame">
-          <span class="desk-eyebrow">
-            <span class="desk-eyebrow-dot" aria-hidden="true"></span>
-            On the desk
-            <span class="desk-eyebrow-sep" aria-hidden="true">·</span>
-            <time id="desk-date" class="desk-eyebrow-date"></time>
-          </span>
-          <h2 class="desk-title">Learning sessions.</h2>
-          <p class="desk-helper">Pick up where you were explaining from memory.</p>
-          <div id="desk-ready-filter-host" class="desk-ready-filter-host"></div>
+        <header class="desk-index-header">
+          <h3 class="desk-index-title">Concepts</h3>
+          <span id="desk-concept-count" class="desk-index-count" aria-label="0 concepts">0</span>
         </header>
+
+        <div id="desk-ready-filter-host" class="desk-ready-filter-host"></div>
 
         <div class="hero-info" id="hero-info">
           <div class="hero-meta-row">
@@ -242,7 +240,7 @@
         </div>
 
         <!-- 3×3 isometric crystal grid -->
-        <div id="grid-container" style="position:relative; padding-top:28px; overflow:visible;">
+        <div id="grid-container">
           <!-- Floating spacing button (disabled in the current MVP) -->
           <button id="btn-consolidate-float" class="btn-consolidate-float" type="button" onclick="App.consolidate()"
             style="display:none;" disabled title="Review opens after spacing." aria-label="Review later">
@@ -253,8 +251,8 @@
             </svg>
           </button>
 
-          <svg id="grid-svg" viewBox="0 0 420 320" width="420" height="320" xmlns="http://www.w3.org/2000/svg"
-            style="overflow:visible;">
+          <svg id="grid-svg" viewBox="0 0 420 365" width="420" height="365" xmlns="http://www.w3.org/2000/svg"
+            role="group" aria-label="Concept desk">
             <defs>
               <filter id="glow-filter" x="-40%" y="-40%" width="180%" height="180%">
                 <feGaussianBlur stdDeviation="3" result="blur" />
@@ -262,34 +260,19 @@
               </filter>
             </defs>
             <!-- Paint order: back → front. Transforms are fixed. Content populated by renderGrid(). -->
-            <g id="tile-0" class="tile-group" transform="translate(140,45)" onclick="App.selectTile(0)"></g>
-            <g id="tile-1" class="tile-group" transform="translate(70,85)" onclick="App.selectTile(1)"></g>
-            <g id="tile-2" class="tile-group" transform="translate(210,85)" onclick="App.selectTile(2)"></g>
-            <g id="tile-3" class="tile-group" transform="translate(0,125)" onclick="App.selectTile(3)"></g>
-            <g id="tile-4" class="tile-group" transform="translate(140,125)" onclick="App.selectTile(4)"></g>
-            <g id="tile-5" class="tile-group" transform="translate(280,125)" onclick="App.selectTile(5)"></g>
-            <g id="tile-6" class="tile-group" transform="translate(70,165)" onclick="App.selectTile(6)"></g>
-            <g id="tile-7" class="tile-group" transform="translate(210,165)" onclick="App.selectTile(7)"></g>
-            <g id="tile-8" class="tile-group" transform="translate(140,205)" onclick="App.selectTile(8)"></g>
+            <g id="tile-0" class="tile-group" transform="translate(140,3)" onclick="App.selectTile(0)"></g>
+            <g id="tile-1" class="tile-group" transform="translate(70,61)" onclick="App.selectTile(1)"></g>
+            <g id="tile-2" class="tile-group" transform="translate(210,61)" onclick="App.selectTile(2)"></g>
+            <g id="tile-3" class="tile-group" transform="translate(0,119)" onclick="App.selectTile(3)"></g>
+            <g id="tile-4" class="tile-group" transform="translate(140,119)" onclick="App.selectTile(4)"></g>
+            <g id="tile-5" class="tile-group" transform="translate(280,119)" onclick="App.selectTile(5)"></g>
+            <g id="tile-6" class="tile-group" transform="translate(70,177)" onclick="App.selectTile(6)"></g>
+            <g id="tile-7" class="tile-group" transform="translate(210,177)" onclick="App.selectTile(7)"></g>
+            <g id="tile-8" class="tile-group" transform="translate(140,235)" onclick="App.selectTile(8)"></g>
           </svg>
         </div>
 
         <div id="desk-due-selection-host" class="desk-due-selection-host" aria-live="polite"></div>
-
-        <div class="desk-legend" role="list" aria-label="Tile-state legend">
-          <span class="desk-legend-item" role="listitem" data-state="locked">
-            <span class="desk-legend-facet" aria-hidden="true"></span>locked
-          </span>
-          <span class="desk-legend-item" role="listitem" data-state="primed">
-            <span class="desk-legend-facet" aria-hidden="true"></span>draft saved
-          </span>
-          <span class="desk-legend-item" role="listitem" data-state="drilled">
-            <span class="desk-legend-facet" aria-hidden="true"></span>needs repair
-          </span>
-          <span class="desk-legend-item" role="listitem" data-state="solidified">
-            <span class="desk-legend-facet" aria-hidden="true"></span>solid spaced reconstruction
-          </span>
-        </div>
       </div>
 
     </section>
@@ -452,9 +435,9 @@ I'm fuzzy on…
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=18"></script>
-  <script type="module" src="/js/app.js?v=201"></script>
-  <script type="module" src="/js/floating-room-label.js?v=8"></script>
-  <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
+  <script type="module" src="/js/app.js?v=204"></script>
+  <script type="module" src="/js/floating-room-label.js?v=10"></script>
+  <script type="module" src="/js/iso-board-state-surface.js?v=10"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>
 
   <!-- Feedback Modal -->

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,7 +9,7 @@ import {
 import {
   playAnim,
   renderGrid as renderDeskGrid,
-} from './board-grid.js?v=2';
+} from './board-grid.js?v=5';
 import {
   clearSettingsPanel as clearShellSettingsPanel,
   closeDrawer as closeShellDrawer,
@@ -929,6 +929,28 @@ const App = (() => {
 
   // ── 8. Grid rendering ──────────────────────────────────────
   function renderGrid(concepts = loadConcepts()) {
+    const grid = document.getElementById('grid-container');
+    const gridSvg = document.getElementById('grid-svg');
+    const deskHelper = document.querySelector('.desk-helper');
+    const deskConceptCount = document.getElementById('desk-concept-count');
+    const isFirstUse = concepts.length === 0;
+    if (grid) grid.classList.toggle('is-first-use', isFirstUse);
+    document.body.dataset.deskFirstUse = String(isFirstUse);
+    if (deskConceptCount) {
+      deskConceptCount.textContent = String(concepts.length);
+      deskConceptCount.setAttribute(
+        'aria-label',
+        `${concepts.length} ${concepts.length === 1 ? 'concept' : 'concepts'}`,
+      );
+    }
+    if (gridSvg) {
+      gridSvg.setAttribute('viewBox', isFirstUse ? '140 119 140 130' : '0 0 420 365');
+    }
+    if (deskHelper) {
+      deskHelper.textContent = isFirstUse
+        ? 'Then write what you remember.'
+        : 'Choose a session to reconstruct from memory.';
+    }
     const dueIds = dueConceptIdSet(cachedDueItems);
     renderDeskGrid({
       concepts,
@@ -1712,7 +1734,11 @@ const App = (() => {
 
   function selectTile(tileIdx) {
     const tileEl = tileEls[tileIdx];
-    if (tileEl?.classList.contains('is-filtered-out') || tileEl?.getAttribute('data-ready-filtered') === 'out') {
+    if (
+      tileEl?.classList.contains('is-capacity')
+      || tileEl?.classList.contains('is-filtered-out')
+      || tileEl?.getAttribute('data-ready-filtered') === 'out'
+    ) {
       return;
     }
     const concepts = loadConcepts();
@@ -3127,13 +3153,25 @@ const App = (() => {
 
   function setNavActive(id) {
     currentPrimaryNav = id;
+    document.body.dataset.primaryView = id === 'nav-dashboard'
+      ? 'desk'
+      : id ? id.replace('nav-', '') : 'concept';
     ['nav-dashboard', 'nav-ignition', 'nav-library', 'nav-settings'].forEach((navId) => {
       const el = document.getElementById(navId);
-      if (el) el.classList.toggle('active', navId === currentPrimaryNav);
-      
+      const isActive = navId === currentPrimaryNav;
+      if (el) {
+        el.classList.toggle('active', isActive);
+        if (isActive) el.setAttribute('aria-current', 'page');
+        else el.removeAttribute('aria-current');
+      }
+
       const bnId = navId.replace('nav-', 'bn-');
       const bnEl = document.getElementById(bnId);
-      if (bnEl) bnEl.classList.toggle('active', navId === currentPrimaryNav);
+      if (bnEl) {
+        bnEl.classList.toggle('active', isActive);
+        if (isActive) bnEl.setAttribute('aria-current', 'page');
+        else bnEl.removeAttribute('aria-current');
+      }
     });
     syncConceptListActiveState();
   }
@@ -3147,19 +3185,9 @@ const App = (() => {
     teardownMapView();
     hidePrimaryViews();
     if (heroCard) heroCard.style.display = 'flex';
-    renderDeskDate();
     renderDeskDueSurfaces();
     Bus.emit('dashboard:shown');
     if (window.innerWidth < 900) closeDrawer();
-  }
-
-  function renderDeskDate() {
-    const el = document.getElementById('desk-date');
-    if (!el) return;
-    const d = new Date();
-    const months = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
-    el.textContent = `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
-    el.dateTime = d.toISOString().slice(0, 10);
   }
 
   function collectTrainingByConceptId(concepts = loadConcepts()) {
@@ -3241,6 +3269,12 @@ const App = (() => {
       grid.removeAttribute('data-ready-count');
     }
   }
+
+  Bus.on('desk:external-state-change', () => {
+    renderConceptList();
+    renderIgnitionGate();
+    renderDeskDueSurfaces();
+  });
 
   async function syncLearnerStateIfIdentified() {
     try {

--- a/public/js/board-grid.js
+++ b/public/js/board-grid.js
@@ -22,29 +22,29 @@ export function playAnim(name, tileIdx, { documentRef = document } = {}) {
 // Desk tiles are inventory/navigation. The pin marks that a concept
 // has earned a place here; it does not encode graph-truth evidence.
 export const TILE_PLATFORM = `
-    <polygon class="tile-left"  points="0,40 70,80 70,90 0,50"/>
-    <polygon class="tile-right" points="140,40 70,80 70,90 140,50"/>
-    <polygon class="tile-top"   points="70,0 140,40 70,80 0,40"/>
-    <polygon class="tile-highlight" points="70,0 140,40 70,80 0,40"/>
-    <polygon class="tile-hit"   points="70,0 140,40 70,80 0,40"/>`;
+    <polygon class="tile-left"  points="2,58 70,114 70,127 2,71"/>
+    <polygon class="tile-right" points="138,58 70,114 70,127 138,71"/>
+    <polygon class="tile-top"   points="70,2 138,58 70,114 2,58"/>
+    <polygon class="tile-highlight" points="70,2 138,58 70,114 2,58"/>
+    <polygon class="tile-hit"   points="70,2 138,58 70,114 2,58"/>`;
 
 export const EMPTY_TILE = `
-    <polygon class="tile-left"      points="0,40 70,80 70,90 0,50"/>
-    <polygon class="tile-right"     points="140,40 70,80 70,90 140,50"/>
-    <polygon class="tile-top-empty" points="70,0 140,40 70,80 0,40"/>
-    <polygon class="tile-top-dash"  points="70,0 140,40 70,80 0,40"/>
-    <polygon class="tile-hit"       points="70,0 140,40 70,80 0,40"/>`;
+    <polygon class="tile-left"      points="2,58 70,114 70,127 2,71"/>
+    <polygon class="tile-right"     points="138,58 70,114 70,127 138,71"/>
+    <polygon class="tile-top-empty" points="70,2 138,58 70,114 2,58"/>
+    <polygon class="tile-top-dash"  points="70,2 138,58 70,114 2,58"/>
+    <polygon class="tile-hit"       points="70,2 138,58 70,114 2,58"/>`;
 
 export function conceptPinSVG(idx, state, { isDue = false } = {}) {
   const dueRing = isDue
-    ? `<ellipse class="concept-pin-due-ring" cx="70" cy="43" rx="22" ry="5.5" aria-hidden="true"/>`
+    ? `<ellipse class="concept-pin-due-ring" cx="70" cy="61" rx="22" ry="5.5" aria-hidden="true"/>`
     : '';
   return `
     <g class="concept-marker-anim" id="concept-marker-anim-${idx}">
       <g class="concept-pin" id="concept-pin-${idx}" data-state="${state}" style="pointer-events:none;">
-        <ellipse class="concept-pin-shadow" cx="70" cy="43" rx="17" ry="3.5"/>
+        <ellipse class="concept-pin-shadow" cx="70" cy="61" rx="17" ry="3.5"/>
         ${dueRing}
-        <line class="concept-pin-line" x1="70" y1="-15" x2="70" y2="38"/>
+        <line class="concept-pin-line" x1="70" y1="-15" x2="70" y2="56"/>
         <circle class="concept-pin-head" cx="70" cy="-15" r="8.5"/>
         <circle class="concept-pin-core" cx="70" cy="-15" r="3.1"/>
       </g>
@@ -60,15 +60,20 @@ export function renderGrid({
   readyFilterActive = false,
 }) {
   const dueIds = dueConceptIds instanceof Set ? dueConceptIds : new Set();
+  const isFirstUse = concepts.length === 0;
   tileEls.forEach((tileEl, idx) => {
     const concept = concepts[idx] || null;
     const isSelected = concept && concept.id === activeId;
     const isEmpty = !concept;
     const isDue = Boolean(concept && dueIds.has(concept.id));
     const isFilteredOut = readyFilterActive && (!concept || !isDue);
+    const isPrimaryEmpty = isFirstUse && idx === 4;
+    const isCapacity = isFirstUse && idx !== 4;
 
     tileEl.setAttribute('class', 'tile-group' +
       (isEmpty ? ' empty' : '') +
+      (isPrimaryEmpty ? ' is-primary-empty' : '') +
+      (isCapacity ? ' is-capacity' : '') +
       (isSelected ? ' selected' : '') +
       (isDue ? ' is-due' : '') +
       (isFilteredOut ? ' is-filtered-out' : ''));
@@ -78,22 +83,31 @@ export function renderGrid({
     if (isFilteredOut) tileEl.setAttribute('data-ready-filtered', 'out');
     else tileEl.removeAttribute('data-ready-filtered');
 
-    // Button semantics for keyboard + assistive-tech parity with the
-    // SVG <g onclick> handler. tabindex is set here (not in the
-    // floating-room-label experiment) so it survives every render.
-    // Filtered-out tiles stay in the DOM but leave the tab order.
-    tileEl.setAttribute('role', 'button');
-    tileEl.setAttribute('tabindex', isFilteredOut ? '-1' : '0');
-    if (isFilteredOut) tileEl.setAttribute('aria-disabled', 'true');
-    else tileEl.removeAttribute('aria-disabled');
-    tileEl.setAttribute(
-      'aria-label',
-      isEmpty
-        ? 'Start learning'
-        : isDue
-          ? `Resume ${concept.name}, due for spaced reconstruction`
-          : `Resume ${concept.name}`
-    );
+    // A blank desk has one action, not nine duplicates. The centre socket
+    // starts learning; the other eight are visual capacity and deliberately
+    // stay out of the accessibility tree and tab order. Partial desks retain
+    // the existing behaviour where any unassigned slot can start a session.
+    if (isCapacity) {
+      tileEl.removeAttribute('role');
+      tileEl.removeAttribute('tabindex');
+      tileEl.removeAttribute('aria-label');
+      tileEl.removeAttribute('aria-disabled');
+      tileEl.setAttribute('aria-hidden', 'true');
+    } else {
+      tileEl.removeAttribute('aria-hidden');
+      tileEl.setAttribute('role', 'button');
+      tileEl.setAttribute('tabindex', isFilteredOut ? '-1' : '0');
+      if (isFilteredOut) tileEl.setAttribute('aria-disabled', 'true');
+      else tileEl.removeAttribute('aria-disabled');
+      tileEl.setAttribute(
+        'aria-label',
+        isEmpty
+          ? isPrimaryEmpty ? 'Choose a topic' : 'Start from memory'
+          : isDue
+            ? `Resume ${concept.name}, due for spaced reconstruction`
+            : `Resume ${concept.name}`
+      );
+    }
 
     if (isEmpty) {
       tileEl.innerHTML = EMPTY_TILE;

--- a/public/js/floating-room-label.js
+++ b/public/js/floating-room-label.js
@@ -107,11 +107,15 @@ import { Bus } from './bus.js';
     // they survive every render and stay in sync with the concept name.
 
     const showForTile = () => {
+      if (tileGroup.classList.contains('is-capacity') || tileGroup.classList.contains('is-primary-empty')) {
+        hide(tileGroup);
+        return;
+      }
       const concepts = loadConcepts();
       const concept = concepts[conceptIdx];
       show(tileGroup, concept
         ? { name: concept.name, action: 'Resume', kind: 'room' }
-        : { name: 'Start learning', action: '', kind: 'empty' });
+        : { name: 'Start from memory', action: '', kind: 'empty' });
     };
 
     tileGroup.addEventListener('mouseenter', showForTile);
@@ -128,10 +132,14 @@ import { Bus } from './bus.js';
   function showForTile(tile) {
     const conceptIdx = conceptIndexForTile(tile);
     if (!tile || conceptIdx < 0 || !tile.getClientRects().length) return;
+    if (tile.classList.contains('is-capacity') || tile.classList.contains('is-primary-empty')) {
+      hide(tile);
+      return;
+    }
     const concept = loadConcepts()[conceptIdx];
     show(tile, concept
       ? { name: concept.name, action: 'Resume', kind: 'room' }
-      : { name: 'Start learning', action: '', kind: 'empty' });
+      : { name: 'Start from memory', action: '', kind: 'empty' });
   }
 
   function showForEvent(event) {

--- a/public/js/iso-board-state-surface.js
+++ b/public/js/iso-board-state-surface.js
@@ -59,23 +59,38 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
     let title = tile.querySelector('.iso-board-state-title');
     if (!hint) {
       tile.removeAttribute('data-evidence-hint');
+      tile.removeAttribute('aria-describedby');
       if (title) title.remove();
       return;
     }
 
+    const titleId = `${tile.id}-evidence-hint`;
     tile.dataset.evidenceHint = hint;
+    tile.setAttribute('aria-describedby', titleId);
     if (!title) {
       title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
       title.classList.add('iso-board-state-title');
       tile.insertBefore(title, tile.firstChild);
     }
+    title.id = titleId;
     title.textContent = hint;
   }
 
-  function deriveBoardState(concept) {
+  function deriveBoardProjection(concept) {
     const training = loadTraining(concept?.id);
-    const badge = deriveConceptBadge(concept, training);
-    return boardStateFromBadge(badge) || legacyBoardStateFromConceptState(concept?.state) || 'locked';
+    const trainingBadge = training
+      ? deriveConceptBadge({ ...concept, graphData: null }, training)
+      : null;
+    const trainingState = boardStateFromBadge(trainingBadge);
+    const legacyBadge = deriveConceptBadge(concept, null);
+    const boardState = trainingState
+      || boardStateFromBadge(legacyBadge)
+      || legacyBoardStateFromConceptState(concept?.state)
+      || 'locked';
+    return {
+      boardState,
+      evidenceHint: trainingState ? evidenceHintForBoardState(trainingState) : '',
+    };
   }
 
   function crystalMarkup(state) {
@@ -93,7 +108,14 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
     `;
   }
 
-  function emptyAffordanceMarkup() {
+  function emptyAffordanceMarkup({ primary = false } = {}) {
+    if (primary) {
+      return `
+        <g class="empty-tile-affordance empty-tile-affordance--primary" aria-hidden="true">
+          <text class="empty-tile-affordance__label" x="70" y="63" text-anchor="middle">Choose a topic</text>
+        </g>
+      `;
+    }
     return `
       <g class="empty-tile-affordance" aria-hidden="true">
         <line class="empty-tile-affordance__line" x1="58" y1="40" x2="82" y2="40"></line>
@@ -106,6 +128,8 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
     const concept = concepts[idx] || null;
 
     if (!concept) {
+      const isFirstUse = concepts.length === 0;
+      const isPrimaryEmpty = isFirstUse && idx === 4;
       tile.removeAttribute('data-source-state');
       tile.removeAttribute('data-board-state');
       syncEvidenceHint(tile, '');
@@ -124,16 +148,22 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
         const line = pin.querySelector('.concept-pin-line');
         if (line) line.remove();
       }
-      if (!tile.querySelector('.empty-tile-affordance')) {
-        tile.insertAdjacentHTML('beforeend', emptyAffordanceMarkup());
+      const currentAffordance = tile.querySelector('.empty-tile-affordance');
+      const currentIsPrimary = currentAffordance?.classList.contains('empty-tile-affordance--primary');
+      const shouldShowAffordance = !isFirstUse || isPrimaryEmpty;
+      if (currentAffordance && (!shouldShowAffordance || currentIsPrimary !== isPrimaryEmpty)) {
+        currentAffordance.remove();
+      }
+      if (shouldShowAffordance && !tile.querySelector('.empty-tile-affordance')) {
+        tile.insertAdjacentHTML('beforeend', emptyAffordanceMarkup({ primary: isPrimaryEmpty }));
       }
       return;
     }
 
-    const boardState = deriveBoardState(concept);
+    const { boardState, evidenceHint } = deriveBoardProjection(concept);
     tile.dataset.sourceState = concept.state || '';
     tile.dataset.boardState = boardState;
-    syncEvidenceHint(tile, evidenceHintForBoardState(boardState));
+    syncEvidenceHint(tile, evidenceHint);
 
     // Defensive: drop any stale empty affordance the previous render may
     // have inserted. Canonical renderGrid flow wipes innerHTML before
@@ -152,7 +182,7 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
     const line = pin.querySelector('.concept-pin-line');
     if (line) {
       line.setAttribute('y1', '22');
-      line.setAttribute('y2', '38');
+      line.setAttribute('y2', '56');
     }
 
     let crystal = pin.querySelector('.concept-pin-crystal');
@@ -199,9 +229,8 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
     // renderGrid(), so we never observe our own writes.
     Bus.on('grid:rendered', scheduleRefresh);
 
-    // Filter on STORE_KEY so unrelated cross-tab writes (theme, sound,
-    // motion preferences) don't trigger a board re-render. RAF
-    // throttling helps but the wake-up itself is wasted work.
+    // Route external learner-state changes back through app.js so the
+    // canonical Desk renderer owns markup, due surfaces, and semantics.
     window.addEventListener('storage', (e) => {
       /* c8 ignore start -- browser cross-tab storage events are verified by smoke behavior */
       if (
@@ -209,13 +238,13 @@ import { TRAINING_STORE_KEY_PREFIX } from './training-store.js';
         || e.key === null
         || e.key?.startsWith(TRAINING_STORE_KEY_PREFIX)
       ) {
-        scheduleRefresh();
+        Bus.emit('desk:external-state-change');
       }
       /* c8 ignore stop */
     });
-    window.addEventListener('focus', scheduleRefresh);
+    window.addEventListener('focus', () => Bus.emit('desk:external-state-change'));
     document.addEventListener('visibilitychange', () => {
-      if (!document.hidden) scheduleRefresh();
+      if (!document.hidden) Bus.emit('desk:external-state-change');
     });
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,7 +3,7 @@
 @import './css/crystal.css?v=71';
 @import './css/components.css?v=102';
 @import './css/layout.css?v=111';
-@import './css/board-first.css?v=6';
+@import './css/board-first.css?v=9';
 @import './css/approach-reveals.css?v=6';
-@import './css/iso-board-state-surface.css?v=5';
+@import './css/iso-board-state-surface.css?v=8';
 @import './css/concept-page.css?v=55';

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -800,8 +800,29 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(tileA.getAttribute('aria-label') === 'Resume First', 'tile label');
             assert(tileA.innerHTML.includes('concept-pin-0'), 'tile pin');
             assert(tileB.getAttribute('class') === 'tile-group empty', 'empty tile class');
-            assert(tileB.getAttribute('aria-label') === 'Start learning', 'empty tile label');
+            assert(tileB.getAttribute('aria-label') === 'Start from memory', 'empty tile label');
             same(boardEvents, ['grid:rendered'], 'board event');
+            const firstUseTiles = Array.from({ length: 9 }, () =>
+              document.createElementNS('http://www.w3.org/2000/svg', 'g')
+            );
+            board.renderGrid({
+              concepts: [],
+              tileEls: firstUseTiles,
+              activeId: null,
+              bus: { emit(eventName) { boardEvents.push(eventName); } },
+            });
+            assert(firstUseTiles[4].getAttribute('class') === 'tile-group empty is-primary-empty', 'centre start class');
+            assert(firstUseTiles[4].getAttribute('role') === 'button', 'centre start role');
+            assert(firstUseTiles[4].getAttribute('tabindex') === '0', 'centre start tab stop');
+            assert(firstUseTiles[4].getAttribute('aria-label') === 'Choose a topic', 'centre start label');
+            firstUseTiles.forEach((tile, idx) => {
+              if (idx === 4) return;
+              assert(tile.getAttribute('class') === 'tile-group empty is-capacity', 'capacity class');
+              assert(tile.getAttribute('aria-hidden') === 'true', 'capacity hidden from a11y tree');
+              assert(!tile.hasAttribute('role'), 'capacity has no button role');
+              assert(!tile.hasAttribute('tabindex'), 'capacity has no tab stop');
+              assert(!tile.hasAttribute('aria-label'), 'capacity has no duplicate action label');
+            });
             const animEl = document.createElement('div');
             animEl.id = 'concept-marker-anim-7';
             animEl.classList.add('anim-crack');

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -5716,6 +5716,9 @@ def test_desk_iso_board_state_surface_and_room_labels(
     # A final-concept deletion arriving from another tab must route through
     # the canonical Desk renderer, not leave stale populated markup behind.
     expect(clean_page.locator("#tile-0 .tile-top")).to_have_count(1)
+    clean_page.locator("#tile-0").evaluate(
+        "el => el.insertAdjacentHTML('beforeend', '<g class=\"empty-tile-affordance\"></g>')"
+    )
     clean_page.evaluate(
         """(() => {
             localStorage.setItem('learnops_concepts', '[]');

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -164,6 +164,7 @@ def _wait_for_app_settled(page: Page) -> None:
     """
     page.wait_for_load_state("load")
     expect(page.locator("#concept-list")).to_be_attached()
+    page.wait_for_function("() => Boolean(window.App)")
 
 
 def _fetch_browser_session(page: Page) -> dict:

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -5302,6 +5302,188 @@ def test_active_concept_delete_confirms_then_returns_to_desk(
     )
 
 
+def test_first_use_desk_has_one_start_socket(
+    clean_page: Page, base_url: str, captured: dict
+) -> None:
+    """A blank Desk presents one accessible reconstruction plate."""
+
+    clean_page.set_viewport_size({"width": 390, "height": 844})
+    _enter_app_shell_as_guest(clean_page, base_url)
+    clean_page.evaluate(
+        """(() => {
+            localStorage.removeItem('learnops_concepts');
+            localStorage.removeItem('learnops_active');
+        })()"""
+    )
+    clean_page.reload()
+    _wait_for_app_settled(clean_page)
+    clean_page.evaluate("App.showDashboard()")
+
+    expect(clean_page.locator("#desk-title")).to_have_text("Desk")
+    expect(clean_page.locator(".desk-helper")).to_have_text(
+        "Then write what you remember."
+    )
+    expect(clean_page.locator(".desk-helper")).to_be_visible()
+    expect(clean_page.locator(".desk-index-header")).to_be_hidden()
+    expect(clean_page.locator("#grid-container")).to_have_class(re.compile(r"\bis-first-use\b"))
+    expect(clean_page.locator("#grid-svg")).to_have_attribute("viewBox", "140 119 140 130")
+    expect(clean_page.locator("#tile-4")).to_have_class(re.compile(r"\bis-primary-empty\b"))
+    expect(clean_page.locator("#tile-4")).to_have_attribute("role", "button")
+    expect(clean_page.locator("#tile-4")).to_have_attribute("tabindex", "0")
+    expect(clean_page.locator("#tile-4")).to_have_attribute("aria-label", "Choose a topic")
+    expect(clean_page.locator("#tile-4 .empty-tile-affordance__label")).to_have_text("Choose a topic")
+    expect(clean_page.locator("#tile-4 .empty-tile-affordance__line")).to_have_count(0)
+    expect(clean_page.locator("#bn-ignition .bottom-nav-label")).to_have_text("New")
+    expect(clean_page.locator("body")).to_have_attribute("data-primary-view", "desk")
+    expect(clean_page.locator("body")).to_have_attribute("data-desk-first-use", "true")
+    expect(clean_page.locator("#bn-dashboard")).to_have_attribute("aria-current", "page")
+    expect(clean_page.locator("#nav-dashboard")).to_have_attribute("aria-current", "page")
+    expect(clean_page.locator("#bn-ignition")).not_to_have_attribute("aria-current", re.compile(r".+"))
+    expect(clean_page.locator("#grid-svg .tile-group.is-capacity")).to_have_count(8)
+    expect(clean_page.locator("#grid-svg .tile-group[role='button']")).to_have_count(1)
+    expect(clean_page.locator("#grid-svg .tile-group[tabindex='0']")).to_have_count(1)
+    expect(clean_page.locator("#grid-svg .tile-group.is-capacity[aria-hidden='true']")).to_have_count(8)
+    expect(clean_page.locator("#grid-svg .is-capacity .empty-tile-affordance")).to_have_count(0)
+    expect(clean_page.locator("#tile-4 .empty-tile-affordance--primary")).to_have_count(1)
+    expect(clean_page.locator(".desk-legend")).to_have_count(0)
+    expect(clean_page.locator(".desk-eyebrow")).to_have_count(0)
+
+    mobile_layout = clean_page.evaluate(
+        """(() => {
+            const rect = (selector) => {
+                const b = document.querySelector(selector)?.getBoundingClientRect();
+                return b ? { left: b.left, right: b.right, top: b.top,
+                             bottom: b.bottom, width: b.width, height: b.height } : null;
+            };
+            return {
+                clientWidth: document.documentElement.clientWidth,
+                scrollWidth: document.documentElement.scrollWidth,
+                scrollHeight: document.documentElement.scrollHeight,
+                helper: rect('.desk-helper'),
+                helperFontSize: parseFloat(getComputedStyle(document.querySelector('.desk-helper')).fontSize),
+                helperWhiteSpace: getComputedStyle(document.querySelector('.desk-helper')).whiteSpace,
+                board: rect('#grid-svg'),
+                boardOverflow: getComputedStyle(document.querySelector('#grid-svg')).overflow,
+                start: rect('#tile-4'),
+                nav: rect('#bottom-nav'),
+                navLabelFontSizes: Array.from(document.querySelectorAll('.bottom-nav-label'))
+                    .map((label) => parseFloat(getComputedStyle(label).fontSize)),
+                activeLabelColor: getComputedStyle(document.querySelector('#bn-dashboard .bottom-nav-label')).color,
+                primaryReadableColor: (() => {
+                    const probe = document.createElement('span');
+                    probe.style.color = 'var(--primary-readable)';
+                    document.body.appendChild(probe);
+                    const color = getComputedStyle(probe).color;
+                    probe.remove();
+                    return color;
+                })(),
+                hiddenCapacityCount: Array.from(document.querySelectorAll('.tile-group.is-capacity'))
+                    .filter((tile) => getComputedStyle(tile).display === 'none').length,
+                drawerToggleDisplay: getComputedStyle(document.querySelector('.drawer-toggle')).display,
+            };
+        })()"""
+    )
+    assert mobile_layout["scrollWidth"] == mobile_layout["clientWidth"] == 390
+    assert mobile_layout["scrollHeight"] <= 844
+    assert mobile_layout["helperFontSize"] >= 14
+    assert mobile_layout["helperWhiteSpace"] != "nowrap"
+    assert mobile_layout["boardOverflow"] == "visible"
+    assert mobile_layout["hiddenCapacityCount"] == 8
+    assert 184 <= mobile_layout["board"]["width"] <= 200
+    assert mobile_layout["board"]["left"] >= 0
+    assert mobile_layout["board"]["right"] <= 390
+    assert mobile_layout["board"]["bottom"] <= mobile_layout["nav"]["top"]
+    assert mobile_layout["start"]["width"] >= 44
+    assert mobile_layout["start"]["height"] >= 44
+    assert all(size >= 12 for size in mobile_layout["navLabelFontSizes"])
+    assert mobile_layout["activeLabelColor"] == mobile_layout["primaryReadableColor"]
+    assert mobile_layout["drawerToggleDisplay"] == "none"
+
+    clean_page.set_viewport_size({"width": 320, "height": 720})
+    narrow_layout = clean_page.evaluate(
+        """(() => {
+            const helper = document.querySelector('.desk-helper').getBoundingClientRect();
+            const board = document.querySelector('#grid-svg').getBoundingClientRect();
+            const nav = document.querySelector('#bottom-nav').getBoundingClientRect();
+            return {
+                clientWidth: document.documentElement.clientWidth,
+                scrollWidth: document.documentElement.scrollWidth,
+                helperLeft: helper.left,
+                helperRight: helper.right,
+                boardLeft: board.left,
+                boardRight: board.right,
+                boardBottom: board.bottom,
+                boardWidth: board.width,
+                navTop: nav.top,
+            };
+        })()"""
+    )
+    assert narrow_layout["scrollWidth"] == narrow_layout["clientWidth"] == 320
+    assert narrow_layout["helperLeft"] >= 0
+    assert narrow_layout["helperRight"] <= 320
+    assert narrow_layout["boardLeft"] >= 0
+    assert narrow_layout["boardRight"] <= 320
+    assert narrow_layout["boardBottom"] <= narrow_layout["navTop"]
+    assert 184 <= narrow_layout["boardWidth"] <= 200
+    clean_page.set_viewport_size({"width": 390, "height": 844})
+
+    clean_page.emulate_media(forced_colors="active")
+    clean_page.locator("#tile-4").focus()
+    tile_focus = clean_page.locator("#tile-4").evaluate(
+        "el => ({ style: getComputedStyle(el).outlineStyle, "
+        "width: parseFloat(getComputedStyle(el).outlineWidth) })"
+    )
+    clean_page.locator("#bn-dashboard").focus()
+    nav_focus = clean_page.locator("#bn-dashboard").evaluate(
+        "el => ({ style: getComputedStyle(el).outlineStyle, "
+        "width: parseFloat(getComputedStyle(el).outlineWidth) })"
+    )
+    assert tile_focus["style"] == "solid" and tile_focus["width"] >= 2
+    assert nav_focus["style"] == "solid" and nav_focus["width"] >= 2
+    clean_page.emulate_media(forced_colors="none")
+
+    # The retained inline handler still fails closed for visual-capacity tiles.
+    clean_page.locator("#tile-0").evaluate(
+        "el => el.dispatchEvent(new MouseEvent('click', { bubbles: true }))"
+    )
+    expect(clean_page.locator(".hero-card.intro-page")).to_be_visible()
+    expect(clean_page.locator("#ignition-view")).to_be_hidden()
+
+    clean_page.locator("#tile-4").click()
+    expect(clean_page.locator("#ignition-view")).to_be_visible()
+    expect(clean_page.locator("body")).to_have_attribute("data-primary-view", "ignition")
+    expect(clean_page.locator(".drawer-toggle")).to_be_visible()
+    clean_page.evaluate("App.showDashboard()")
+    expect(clean_page.locator(".desk-index-header")).to_be_hidden()
+    assert captured["console_errors"] == []
+    assert captured["failed_requests"] == []
+
+
+def test_first_use_desk_fits_desktop_without_inner_scroll(
+    clean_page: Page, base_url: str, captured: dict
+) -> None:
+    """The one-screen empty Desk must not create a permanent desktop scrollbar."""
+
+    clean_page.set_viewport_size({"width": 1280, "height": 720})
+    _enter_app_shell_as_guest(clean_page, base_url)
+    clean_page.evaluate(
+        """(() => {
+            localStorage.removeItem('learnops_concepts');
+            localStorage.removeItem('learnops_active');
+        })()"""
+    )
+    clean_page.reload()
+    _wait_for_app_settled(clean_page)
+    clean_page.evaluate("App.showDashboard()")
+
+    card_size = clean_page.locator("#card").evaluate(
+        "el => ({ scrollHeight: el.scrollHeight, clientHeight: el.clientHeight })"
+    )
+    assert card_size["scrollHeight"] <= card_size["clientHeight"]
+    assert captured["console_errors"] == []
+    assert captured["failed_requests"] == []
+
+
 def test_desk_iso_board_state_surface_and_room_labels(
     clean_page: Page, base_url: str, captured: dict
 ) -> None:
@@ -5461,13 +5643,22 @@ def test_desk_iso_board_state_surface_and_room_labels(
         "#tile-1": "Reconstruction evidence is on record.",
         "#tile-2": "A specific gap is ready to repair.",
         "#tile-3": "Spaced reconstruction is on record.",
-        "#tile-6": "Reconstruction evidence is on record.",
-        "#tile-7": "Spaced reconstruction is on record.",
         "#tile-8": "Spaced reconstruction is on record.",
     }
     for selector, hint in expected_hints.items():
         expect(clean_page.locator(selector)).to_have_attribute("data-evidence-hint", hint)
+        tile_id = selector.removeprefix("#")
+        expect(clean_page.locator(selector)).to_have_attribute(
+            "aria-describedby", f"{tile_id}-evidence-hint"
+        )
+        expect(clean_page.locator(f"#{tile_id}-evidence-hint")).to_have_text(hint)
     expect(clean_page.locator("#tile-0")).not_to_have_attribute("data-evidence-hint", re.compile(r".+"))
+    expect(clean_page.locator("#tile-0")).not_to_have_attribute("aria-describedby", re.compile(r".+"))
+    for selector in ("#tile-6", "#tile-7"):
+        expect(clean_page.locator(selector)).not_to_have_attribute("data-evidence-hint", re.compile(r".+"))
+        expect(clean_page.locator(selector)).not_to_have_attribute("aria-describedby", re.compile(r".+"))
+        expect(clean_page.locator(f"{selector} .iso-board-state-title")).to_have_count(0)
+    expect(clean_page.locator("#tile-7")).to_have_attribute("data-board-state", "solidified")
 
     # Button semantics so screen readers announce tiles as actionable.
     expect(clean_page.locator("#tile-1")).to_have_attribute("role", "button")
@@ -5514,28 +5705,40 @@ def test_desk_iso_board_state_surface_and_room_labels(
     expect(empty_tile).to_be_visible()
     expect(empty_tile).to_have_class(re.compile(r"\bempty\b"))
     expect(empty_tile).to_have_attribute(
-        "aria-label", "Start learning"
+        "aria-label", "Start from memory"
     )
 
     empty_tile.focus()
     clean_page.evaluate("App.showDashboard()")
-    expect(clean_page.locator(".room-label")).to_contain_text("Start learning")
+    expect(clean_page.locator(".room-label")).to_contain_text("Start from memory")
+
+    # A final-concept deletion arriving from another tab must route through
+    # the canonical Desk renderer, not leave stale populated markup behind.
+    expect(clean_page.locator("#tile-0 .tile-top")).to_have_count(1)
+    clean_page.evaluate(
+        """(() => {
+            localStorage.setItem('learnops_concepts', '[]');
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'learnops_concepts',
+                newValue: '[]',
+            }));
+        })()"""
+    )
+    expect(clean_page.locator("#grid-container")).to_have_class(re.compile(r"\bis-first-use\b"))
+    expect(clean_page.locator("#grid-svg .tile-group.is-capacity[aria-hidden='true']")).to_have_count(8)
+    expect(clean_page.locator("#grid-svg .tile-group[role='button']")).to_have_count(1)
+    expect(clean_page.locator("#tile-4")).to_have_attribute("aria-label", "Choose a topic")
+    expect(clean_page.locator("#tile-0 .tile-top")).to_have_count(0)
+    expect(clean_page.locator("#tile-0 .tile-top-empty")).to_have_count(1)
+    expect(clean_page.locator("#concept-list .concept-item")).to_have_count(0)
     assert captured["console_errors"] == []
     assert captured["failed_requests"] == []
 
 
-def test_desk_layout_identical_when_empty_or_populated(
+def test_desk_board_expands_after_first_saved_session(
     clean_page: Page, base_url: str, captured: dict
 ) -> None:
-    """Empty desk (0 concepts) renders the same iso board geometry as populated.
-
-    Regression: the layout.css empty-state rule used to hide #grid-container
-    entirely, leaving an empty desk blank. The iso-board state-surface
-    experiment overrides that so the 9-tile board is visible at all sizes
-    of the library — its empty tiles invite creation via the + affordance.
-    This guards that the hero-card, grid-container, svg, and per-tile
-    positions are pixel-identical regardless of how many concepts exist.
-    """
+    """First use shows one plate; one saved session restores the full board."""
 
     # Tile bboxes intentionally NOT compared: populated tiles render a
     # crystal pin that extends above the iso platform, so their full bbox
@@ -5553,17 +5756,38 @@ def test_desk_layout_identical_when_empty_or_populated(
         const gridContainer = document.getElementById('grid-container');
         const grid = document.getElementById('grid-svg');
         const tiles = Array.from(document.querySelectorAll('#grid-svg .tile-group'));
+        const gridBox = grid?.getBoundingClientRect();
         return {
             heroCard: r(heroCard),
             gridContainer: r(gridContainer),
             gridContainerDisplay: gridContainer
                 ? window.getComputedStyle(gridContainer).display : null,
             svg: r(grid),
+            viewBox: grid?.getAttribute('viewBox'),
             tileCount: tiles.length,
+            visibleTileCount: tiles.filter(
+                (tile) => window.getComputedStyle(tile).display !== 'none'
+            ).length,
+            helperText: document.querySelector('.desk-helper')?.textContent,
+            helperDisplay: getComputedStyle(document.querySelector('.desk-helper')).display,
+            indexHeaderDisplay: getComputedStyle(document.querySelector('.desk-index-header')).display,
+            indexTitle: document.querySelector('.desk-index-title')?.textContent,
+            conceptCount: document.querySelector('#desk-concept-count')?.textContent,
+            conceptCountLabel: document.querySelector('#desk-concept-count')?.getAttribute('aria-label'),
+            panel: r(document.querySelector('.intro-content')),
+            primaryView: document.body.dataset.primaryView,
+            deskFirstUse: document.body.dataset.deskFirstUse,
+            drawerToggleDisplay: getComputedStyle(document.querySelector('.drawer-toggle')).display,
             tilePlatformPositions: tiles.map(t => {
                 const top = t.querySelector('.tile-top, .tile-top-empty');
-                const b = top ? r(top) : null;
-                return { id: t.id, platform: b };
+                const b = top?.getBoundingClientRect();
+                const platform = b && gridBox ? {
+                    x: Math.round(b.left - gridBox.left),
+                    y: Math.round(b.top - gridBox.top),
+                    w: Math.round(b.width),
+                    h: Math.round(b.height),
+                } : null;
+                return { id: t.id, platform };
             }),
         };
     })()"""
@@ -5594,30 +5818,63 @@ def test_desk_layout_identical_when_empty_or_populated(
             }}
         }})()"""
 
+    clean_page.set_viewport_size({"width": 390, "height": 844})
     _enter_app_shell_as_guest(clean_page, base_url)
     samples = {}
     for count in [0, 1, 5, 9]:
         clean_page.evaluate(seed_n_concepts(count))
         clean_page.reload()
         _wait_for_app_settled(clean_page)
-        clean_page.locator("#nav-dashboard").click()
+        clean_page.evaluate("App.showDashboard()")
         samples[count] = clean_page.evaluate(sample_script)
 
-    # Reference is the populated state (9 concepts) — that's the layout
-    # contract everyone expects. Empty (0) and partial (1, 5) must match.
+    # Any saved session restores the existing full-board geometry. Only the
+    # completely empty state collapses to the single centre plate.
     ref = samples[9]
     assert ref["tileCount"] == 9, "9-concept desk must render 9 tiles"
+    assert ref["visibleTileCount"] == 9
+    assert ref["viewBox"] == "0 0 420 365"
     assert ref["gridContainerDisplay"] == "block"
     assert ref["heroCard"] is not None
     assert ref["gridContainer"]["w"] > 0 and ref["gridContainer"]["h"] > 0
+    assert ref["helperDisplay"] == "none"
+    assert ref["indexHeaderDisplay"] == "flex"
+    assert ref["indexTitle"] == "Concepts"
+    assert ref["conceptCount"] == "9"
+    assert ref["conceptCountLabel"] == "9 concepts"
 
-    for count, sample in samples.items():
-        if count == 9:
-            continue
+    first_use = samples[0]
+    assert first_use["tileCount"] == 9
+    assert first_use["visibleTileCount"] == 1
+    assert first_use["viewBox"] == "140 119 140 130"
+    assert 184 <= first_use["gridContainer"]["w"] <= 200
+    assert first_use["gridContainerDisplay"] == "block"
+    assert first_use["helperText"] == "Then write what you remember."
+    assert first_use["helperDisplay"] != "none"
+    assert first_use["indexHeaderDisplay"] == "none"
+    assert first_use["primaryView"] == "desk"
+    assert first_use["deskFirstUse"] == "true"
+    assert first_use["drawerToggleDisplay"] == "none"
+
+    for count in (1, 5):
+        sample = samples[count]
         assert sample["tileCount"] == 9, (
             f"desk at {count} concepts must still render all 9 tile slots, "
             f"got {sample['tileCount']}"
         )
+        assert sample["visibleTileCount"] == 9
+        assert sample["viewBox"] == "0 0 420 365"
+        assert sample["helperText"] == "Choose a session to reconstruct from memory."
+        assert sample["helperDisplay"] == "none"
+        assert sample["indexHeaderDisplay"] == "flex"
+        assert sample["indexTitle"] == "Concepts"
+        assert sample["conceptCount"] == str(count)
+        assert sample["conceptCountLabel"] == f"{count} {'concept' if count == 1 else 'concepts'}"
+        assert sample["panel"]["x"] >= 0
+        assert sample["panel"]["x"] + sample["panel"]["w"] <= 390
+        assert sample["primaryView"] == "desk"
+        assert sample["deskFirstUse"] == "false"
+        assert sample["drawerToggleDisplay"] != "none"
         assert sample["gridContainerDisplay"] == "block", (
             f"#grid-container hidden at {count} concepts (was display="
             f"{sample['gridContainerDisplay']!r}); empty desk regression"
@@ -5626,14 +5883,15 @@ def test_desk_layout_identical_when_empty_or_populated(
             f"hero-card geometry differs at {count} concepts: "
             f"got {sample['heroCard']}, expected {ref['heroCard']}"
         )
-        assert sample["gridContainer"] == ref["gridContainer"], (
-            f"grid-container geometry differs at {count}: "
-            f"got {sample['gridContainer']}, expected {ref['gridContainer']}"
-        )
-        assert sample["svg"] == ref["svg"], (
-            f"grid-svg geometry differs at {count}: "
-            f"got {sample['svg']}, expected {ref['svg']}"
-        )
+        for dimension in ("x", "w", "h"):
+            assert sample["gridContainer"][dimension] == ref["gridContainer"][dimension], (
+                f"grid-container {dimension} differs at {count}: "
+                f"got {sample['gridContainer']}, expected {ref['gridContainer']}"
+            )
+            assert sample["svg"][dimension] == ref["svg"][dimension], (
+                f"grid-svg {dimension} differs at {count}: "
+                f"got {sample['svg']}, expected {ref['svg']}"
+            )
         for ref_tile, sample_tile in zip(
             ref["tilePlatformPositions"],
             sample["tilePlatformPositions"],
@@ -5644,6 +5902,39 @@ def test_desk_layout_identical_when_empty_or_populated(
                 f"tile {ref_tile['id']} iso platform drifted at {count} concepts: "
                 f"got {sample_tile['platform']}, expected {ref_tile['platform']}"
             )
+
+    clean_page.set_viewport_size({"width": 320, "height": 720})
+    clean_page.evaluate(seed_n_concepts(1))
+    clean_page.reload()
+    _wait_for_app_settled(clean_page)
+    clean_page.evaluate("App.showDashboard()")
+    narrow = clean_page.evaluate(sample_script)
+    assert narrow["panel"]["x"] >= 0
+    assert narrow["panel"]["x"] + narrow["panel"]["w"] <= 320
+    assert 254 <= narrow["svg"]["w"] <= 262
+    assert clean_page.evaluate(
+        "document.documentElement.scrollWidth <= window.innerWidth"
+    )
+
+    clean_page.set_viewport_size({"width": 1280, "height": 720})
+    clean_page.wait_for_function("window.innerWidth === 1280")
+    desktop = clean_page.evaluate(sample_script)
+    assert desktop["panel"]["x"] >= 0
+    assert desktop["panel"]["x"] + desktop["panel"]["w"] <= 1280
+    assert 360 <= desktop["svg"]["w"] <= 420
+    assert desktop["svg"]["x"] >= 0
+    assert desktop["svg"]["x"] + desktop["svg"]["w"] <= 1280
+    assert clean_page.evaluate(
+        "document.documentElement.scrollWidth <= window.innerWidth"
+    )
+
+    clean_page.set_viewport_size({"width": 390, "height": 844})
+    clean_page.wait_for_function("window.innerWidth === 390")
+    clean_page.evaluate(
+        "() => new Promise(resolve => requestAnimationFrame(() => "
+        "requestAnimationFrame(resolve)))"
+    )
+    expect(clean_page.locator(".desk-index-header")).to_be_visible()
 
     assert captured["console_errors"] == []
     assert captured["failed_requests"] == []

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -5716,9 +5716,6 @@ def test_desk_iso_board_state_surface_and_room_labels(
     # A final-concept deletion arriving from another tab must route through
     # the canonical Desk renderer, not leave stale populated markup behind.
     expect(clean_page.locator("#tile-0 .tile-top")).to_have_count(1)
-    clean_page.locator("#tile-0").evaluate(
-        "el => el.insertAdjacentHTML('beforeend', '<g class=\"empty-tile-affordance\"></g>')"
-    )
     clean_page.evaluate(
         """(() => {
             localStorage.setItem('learnops_concepts', '[]');
@@ -5726,8 +5723,12 @@ def test_desk_iso_board_state_surface_and_room_labels(
                 key: 'learnops_concepts',
                 newValue: '[]',
             }));
+            document.getElementById('tile-0').insertAdjacentHTML(
+                'beforeend', '<g class="empty-tile-affordance"></g>'
+            );
         })()"""
     )
+    expect(clean_page.locator("#tile-0 .empty-tile-affordance")).to_have_count(0)
     expect(clean_page.locator("#grid-container")).to_have_class(re.compile(r"\bis-first-use\b"))
     expect(clean_page.locator("#grid-svg .tile-group.is-capacity[aria-hidden='true']")).to_have_count(8)
     expect(clean_page.locator("#grid-svg .tile-group[role='button']")).to_have_count(1)

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -982,9 +982,29 @@ def test_board_grid_helpers_preserve_tile_markup_and_events() -> None:
         assert.equal(tiles[0].attrs['aria-label'], 'Resume First');
         assert.ok(tiles[0].innerHTML.includes('concept-pin-0'));
         assert.equal(tiles[1].attrs.class, 'tile-group empty');
-        assert.equal(tiles[1].attrs['aria-label'], 'Start learning');
+        assert.equal(tiles[1].attrs['aria-label'], 'Start from memory');
         assert.ok(tiles[1].innerHTML.includes('tile-top-empty'));
         assert.deepEqual(events, ['grid:rendered']);
+
+        const firstUseTiles = Array.from({ length: 9 }, makeTile);
+        renderGrid({
+          concepts: [],
+          tileEls: firstUseTiles,
+          activeId: null,
+          bus: { emit(eventName) { events.push(eventName); } },
+        });
+        assert.equal(firstUseTiles[4].attrs.class, 'tile-group empty is-primary-empty');
+        assert.equal(firstUseTiles[4].attrs.role, 'button');
+        assert.equal(firstUseTiles[4].attrs.tabindex, '0');
+        assert.equal(firstUseTiles[4].attrs['aria-label'], 'Choose a topic');
+        firstUseTiles.forEach((tile, idx) => {
+          if (idx === 4) return;
+          assert.equal(tile.attrs.class, 'tile-group empty is-capacity');
+          assert.equal(tile.attrs['aria-hidden'], 'true');
+          assert.equal(tile.attrs.role, undefined);
+          assert.equal(tile.attrs.tabindex, undefined);
+          assert.equal(tile.attrs['aria-label'], undefined);
+        });
 
         renderGrid({
           concepts: [{ id: 'c1', name: 'First', state: 'growing' }],
@@ -1271,6 +1291,17 @@ def test_new_concept_field_has_unique_accessible_label() -> None:
     assert 'aria-label="What do you already think?"' in index_html
     assert '>Start session</button>' in index_html
     assert 'aria-label="What do you want to explain?"' not in index_html
+
+
+def test_desk_markup_preserves_compact_concept_index() -> None:
+    index_html = (REPO_ROOT / "public" / "index.html").read_text()
+
+    assert '<h2 class="desk-title" id="desk-title">Desk</h2>' in index_html
+    assert '<h3 class="desk-index-title">Concepts</h3>' in index_html
+    assert 'id="desk-concept-count"' in index_html
+    assert 'aria-label="0 concepts"' in index_html
+    assert 'id="grid-container"' in index_html
+    assert 'aria-label="Concept desk"' in index_html
 
 
 def test_feedback_modal_copy_and_button_contract() -> None:


### PR DESCRIPTION
Context & Intent
- What problem does this solve? The empty Desk exposed nine ornamental capacity tiles, while the occupied Desk lacked a compact concept index. This makes the board a clear reconstruction instrument in both states.
- Which agent or track does this stem from? Desk reconstruction instrument and Library Option 2 alignment track.

Implementation Details
- Brief overview of technical changes (files touched, key logic). Focus first use on one accessible centre plate, add the occupied Concepts frame and count, preserve evidence-derived board state, and add focused helper and browser coverage. Local proof: 848 tests and 12 subtests passed through scripts/check-coverage.sh.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Frontend Desk rendering and evidence projection only. No backend routing, learner-evidence writes, persistence schema, Daily Bloom brief, or prototype files are included.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No. It uses existing browser-local state and static frontend assets.
- [x] Are there SSRF or error-leakage risks in new external calls? No external calls or error passthrough were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable. Ingestion is untouched.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Yes. No study content appears before an attempt.
- [x] Does the graph still tell the truth (no faking mastery)? Yes. Board hints remain derived from recorded attempts; same-sitting evidence rules are unchanged.
- [x] Is the active cognitive target explicitly clear to the user? Yes. First use exposes one Choose a topic action; occupied Desk shows a quiet Concepts index.

Branch: feat/desk-reconstruction-instrument
Base: main
Diff summary: 14 files changed, 945 insertions(+), 263 deletions(-)