### PR TITLE
[codex] Make Library a concept index

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,41 @@
+# Library session-index design QA
+
+## Evidence
+
+- Source visual truth: `/Users/jondev/.codex/generated_images/019f484b-83fd-7df3-9811-44867aaf4c95/exec-1d187a0b-609e-43a5-a593-3b5e880a5fc1.png`
+- Browser-rendered implementation: `.qa-runs/library-session-index/after-empty-390x844.png`
+- Full-view comparison: `.qa-runs/library-session-index/reference-vs-implementation.png`
+- Focused comparison: `.qa-runs/library-session-index/reference-vs-implementation-focus.png`
+- Populated regression state: `.qa-runs/library-session-index/after-populated-390x844.png`
+- Desktop state: `.qa-runs/library-session-index/after-empty-1280x720.png`
+- Primary viewport and state: 390 x 844, light theme, local guest, zero concepts
+- Resilience checks: 320 x 720, 768 x 844, and 1280 x 720
+
+## Comparison
+
+- Typography: Inter-based product typography preserves the reference hierarchy. The implementation uses slightly larger small text so copy remains legible on a real 390px viewport.
+- Spacing and layout: one left-aligned page title, one compact index surface, one empty row, and no oversized illustration or dead vertical card space. The 390px surface is 350px wide and 166px tall.
+- Colors and tokens: the reference's warm neutral, ink, and violet treatment maps to existing Socratink surface, text, border, and accent tokens. No new color values, gradients, or glass effects were added.
+- Image and icon fidelity: there is no decorative image. The empty row reuses the existing Library book glyph and removes the witness diamond and route-map CSS art.
+- Copy and content: `Sessions` was deliberately adapted to `Concepts` because the indexed objects are concepts. The count is the rendered concept count. Empty copy makes no evidence, completion, mastery, or study-content claim.
+- Interaction and accessibility: `Start learning` is a real button with a 44px target and visible focus treatment. Heading levels follow the app-shell heading, the count has an accessible label, and the decorative icon is hidden from assistive technology.
+- Responsive behavior: no horizontal overflow at 320, 390, 768, or 1280px. At 320px the action moves below the copy; at 390px it remains visible above the fixed bottom navigation.
+
+## Primary interactions tested
+
+- Opened Library from mobile navigation.
+- Activated `Start learning` and reached Ignition.
+- Seeded a local learner-attempt fixture through the app and confirmed the populated Library still renders learner reconstruction text and training-derived state.
+- Confirmed the focused browser test recorded no same-origin console errors or failed requests.
+
+## Comparison history
+
+- First pass, P2: inherited centering made the page title and empty copy drift from the left-aligned reference. Fix: set explicit left alignment and recapture at 390 x 844.
+- Post-fix evidence: the full and focused comparisons above show the corrected alignment. No P0, P1, or P2 finding remains.
+
+## Findings
+
+- No actionable P0, P1, or P2 findings.
+- Accepted deviations: truthful `Concepts` terminology, larger legible small text, and no chevron because the CTA is a discrete button rather than a whole-row disclosure link.
+
+final result: passed

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -532,7 +532,11 @@ body.antigravity-theme .library-card-vault[data-state="instantiated"] .library-c
   background: rgba(144, 103, 198, 0.10);
   color: var(--ag-violet);
 }
-body.antigravity-theme .library-card-vault[data-state="primed"] .library-card-state,
+body.antigravity-theme .library-card-vault[data-state="primed"] .library-card-state {
+  background: var(--accent-soft);
+  color: var(--primary-readable);
+}
+
 body.antigravity-theme .library-card-vault[data-state="growing"] .library-card-state {
   background: rgba(77, 186, 138, 0.12);
   color: #2F8C6A;
@@ -558,7 +562,6 @@ html[data-theme="dark"] body.antigravity-theme .library-card-vault[data-state="i
   background: rgba(158, 139, 255, 0.14);
   color: var(--ag-violet);
 }
-html[data-theme="dark"] body.antigravity-theme .library-card-vault[data-state="primed"] .library-card-state,
 html[data-theme="dark"] body.antigravity-theme .library-card-vault[data-state="growing"] .library-card-state {
   background: rgba(60, 221, 199, 0.14);
   color: var(--ag-mint);

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -21,4 +21,4 @@
 
 @import '../styles.css?v=168'     layer(components);
 @import '../antigravity.css?v=37' layer(legacy);
-@import 'paper.css?v=18'          layer(paper);
+@import 'paper.css?v=19'          layer(paper);

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -20,5 +20,5 @@
 @layer components, legacy, paper;
 
 @import '../styles.css?v=171'     layer(components);
-@import '../antigravity.css?v=39' layer(legacy);
+@import '../antigravity.css?v=40' layer(legacy);
 @import 'paper.css?v=19'          layer(paper);

--- a/public/css/paper.css
+++ b/public/css/paper.css
@@ -755,6 +755,189 @@
   -webkit-text-fill-color: var(--text-muted);
 }
 
+/* ── Library index ───────────────────────────────────────────
+   The Library is an index of learner-owned concepts, not a promotional
+   empty-state card. Keep the first-use path compact and leave the existing
+   populated evidence cards untouched. */
+
+body.antigravity-theme #library-view {
+  min-height: calc(100dvh - 76px);
+  margin: 0;
+  padding: var(--space-10) clamp(var(--space-6), 5vw, var(--space-16)) var(--space-16);
+  box-sizing: border-box;
+  border-radius: 0;
+  background-color: var(--surface-page-theme);
+  background-image: none;
+}
+
+.library-shell {
+  width: min(100%, 68rem);
+  margin: 0 auto;
+}
+
+.library-page-title {
+  margin: 0 0 var(--space-6);
+  color: var(--text-strong);
+  font-family: var(--font-body);
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  text-align: left;
+}
+
+.library-qa-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: calc(-1 * var(--space-3)) 0 var(--space-4);
+}
+
+.library-section {
+  margin: 0;
+}
+
+.library-section--empty {
+  overflow: hidden;
+  max-width: 54rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(var(--paper-0-rgb), 0.34);
+}
+
+.library-index-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  min-height: 48px;
+  padding: 0 var(--space-4);
+  box-sizing: border-box;
+}
+
+.library-section:not(.library-section--empty) .library-index-header {
+  padding: 0 0 var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.library-index-title,
+.library-index-count {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--leading-snug);
+}
+
+.library-index-count {
+  font-variant-numeric: tabular-nums;
+}
+
+.library-index-empty {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.library-index-empty__icon {
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: var(--text-muted);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.library-index-empty__copy {
+  min-width: 0;
+}
+
+.library-index-empty__title {
+  margin: 0;
+  color: var(--text-strong);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: var(--leading-snug);
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.library-index-empty__description {
+  max-width: 34rem;
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  text-align: left;
+  text-wrap: pretty;
+}
+
+.library-index-empty__action {
+  flex: 0 0 auto;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 var(--space-2);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--primary-readable);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: var(--leading-snug);
+  letter-spacing: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color var(--duration-micro) var(--ease-standard),
+              color var(--duration-micro) var(--ease-standard);
+}
+
+.library-index-empty__action:hover {
+  background: var(--accent-soft);
+}
+
+.library-index-empty__action:focus-visible {
+  outline: none;
+  box-shadow: var(--accent-ring);
+}
+
+.library-vault-grid {
+  margin-top: var(--space-5);
+}
+
+@media (max-width: 899px) {
+  body.antigravity-theme #library-view {
+    min-height: 100dvh;
+    padding: calc(var(--chrome-h-top) + var(--space-5)) var(--space-5)
+      calc(var(--chrome-h-bottom) + var(--space-6));
+  }
+
+  .library-page-title {
+    margin-bottom: var(--space-5);
+    font-size: 1.625rem;
+  }
+}
+
+@media (max-width: 359px) {
+  .library-index-empty {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+
+  .library-index-empty__action {
+    grid-column: 2;
+    justify-self: start;
+    padding: 0;
+  }
+}
+
 /* ── Reduced motion ────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=184">
+  <link rel="stylesheet" href="/css/index.css?v=185">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=17">
 </head>
 
@@ -452,7 +452,7 @@ I'm fuzzy on…
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=18"></script>
-  <script type="module" src="/js/app.js?v=201"></script>
+  <script type="module" src="/js/app.js?v=202"></script>
   <script type="module" src="/js/floating-room-label.js?v=8"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=7"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -47,7 +47,7 @@ import {
   persistPhaseBResumeState as persistStoredPhaseBResumeState,
   persistPhaseBSessionState as persistStoredPhaseBSessionState,
 } from './phase-b-session.js';
-import { buildLibraryHtml } from './library-view.js?v=4';
+import { buildLibraryHtml } from './library-view.js?v=5';
 import { createTrainingStore, TRAINING_SCHEMA_VERSION, TRAINING_STORE_KEY_PREFIX } from './training-store.js';
 import {
   hydrateAndSyncLearnerState,

--- a/public/js/library-view.js
+++ b/public/js/library-view.js
@@ -15,7 +15,7 @@ const ATTEMPT_CLASSIFICATION_RANK = {
 };
 
 function conceptStateLabel(state) {
-  if (state === 'primed') return 'draft saved';
+  if (state === 'primed') return 'primed for study';
   if (state === 'solidified') return 'solid spaced reconstruction';
   return state;
 }

--- a/public/js/library-view.js
+++ b/public/js/library-view.js
@@ -71,29 +71,35 @@ export function getLibraryConceptMeta(concept, training = null) {
 
 export function buildLibraryHtml(concepts, trainingByConceptId = {}, options = {}) {
   const showLocalQaSeed = options?.showLocalQaSeed === true;
+  const conceptCount = concepts.length;
   let html = `
-      <div class="library-kicker">Library</div>
-
-      <div class="library-section">
-        <h2 class="library-section-title">Your Library</h2>
-        <p class="library-section-copy">Your library shows what you've reconstructed, not what you've saved.</p>
+      <div class="library-shell">
+        <h2 class="library-page-title">Library</h2>
         ${showLocalQaSeed ? `
-          <button type="button" class="ig-button" data-local-qa-seed onclick="App.seedLocalQaConcept()">Seed QA concept</button>
-          <button type="button" class="ig-button" data-local-repair-qa-seed onclick="App.seedLocalRepairQaConcept()">Seed repair QA</button>
+          <div class="library-qa-actions">
+            <button type="button" class="ig-button" data-local-qa-seed onclick="App.seedLocalQaConcept()">Seed QA concept</button>
+            <button type="button" class="ig-button" data-local-repair-qa-seed onclick="App.seedLocalRepairQaConcept()">Seed repair QA</button>
+          </div>
         ` : ''}
+        <section class="library-section${conceptCount === 0 ? ' library-section--empty' : ''}" aria-labelledby="library-concepts-title">
+          <header class="library-index-header">
+            <h3 class="library-index-title" id="library-concepts-title">Concepts</h3>
+            <span class="library-index-count" aria-label="${conceptCount} ${conceptCount === 1 ? 'concept' : 'concepts'}">${conceptCount}</span>
+          </header>
     `;
 
-  if (concepts.length === 0) {
+  if (conceptCount === 0) {
     html += `
-        <div class="library-empty library-empty--ignition">
-          <div class="witness-anchor" aria-hidden="true">
-            <svg viewBox="0 0 28 28" width="28" height="28">
-              <polygon class="witness-anchor__shape" points="14,2 26,14 14,26 2,14"/>
-            </svg>
+        <div class="library-index-empty">
+          <svg class="library-index-empty__icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 7v14"/>
+            <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/>
+          </svg>
+          <div class="library-index-empty__copy">
+            <h4 class="library-index-empty__title">Your first reconstruction starts here</h4>
+            <p class="library-index-empty__description">Write from memory. Your reconstruction will appear here.</p>
           </div>
-          <h3 class="library-empty-headline">Start a learning session.</h3>
-          <p class="library-empty-sub">Drop a topic. The loop makes the gap inspectable.</p>
-          <button type="button" class="ig-button" onclick="App.showIgnition()">Start learning</button>
+          <button type="button" class="library-index-empty__action" onclick="App.showIgnition()">Start learning</button>
         </div>`;
   } else {
     html += `<div class="library-vault-grid">` + concepts.map(c => {
@@ -125,6 +131,6 @@ export function buildLibraryHtml(concepts, trainingByConceptId = {}, options = {
     }).join('') + `</div>`;
   }
 
-  html += `</div>`;
+  html += `</section></div>`;
   return html;
 }

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -507,7 +507,10 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             };
             assert(library.getLibraryConceptMeta({ graphData: '{' }).thesis.includes('first reconstruction'), 'library malformed fallback');
             assert(library.getLibraryConceptMeta({ graphData: graph }, training).thesis === 'Learner-owned reconstruction.', 'library learner evidence');
-            assert(library.buildLibraryHtml([]).includes('Start a learning session.'), 'library empty state');
+            const emptyLibraryHtml = library.buildLibraryHtml([]);
+            assert(emptyLibraryHtml.includes('Your first reconstruction starts here'), 'library empty state');
+            assert(emptyLibraryHtml.includes('library-index-count'), 'library empty count');
+            assert(!emptyLibraryHtml.includes('witness-anchor'), 'library has no decorative witness art');
             const libraryHtml = library.buildLibraryHtml([
               { id: 'c-1', name: '<Unsafe>', state: 'growing', graphData: graph },
             ], { 'c-1': training });
@@ -524,7 +527,7 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(libraryHtml.includes('3 entries'), 'library entry count');
             window.App.showLibrary();
             assert(document.getElementById('library-view').classList.contains('visible'), 'library view visible');
-            assert(document.getElementById('library-content').textContent.includes('Start a learning session.'), 'library app path');
+            assert(document.getElementById('library-content').textContent.includes('Your first reconstruction starts here'), 'library app path');
 
             const trainingStoreModule = await import('/js/training-store.js');
             assert(trainingStoreModule.TRAINING_SCHEMA_VERSION === 1, 'training schema version');

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -567,7 +567,7 @@ def test_library_card_uses_training_evidence_not_ai_summary(
     card = page.locator(".library-card-vault", has_text="Training Truth QA")
     expect(card).to_be_visible()
     expect(card).to_have_attribute("data-state", "primed")
-    expect(card.locator(".library-card-state")).to_have_text("draft saved")
+    expect(card.locator(".library-card-state")).to_have_text("primed for study")
     expect(card.locator(".library-card-summary")).to_have_text(
         "Learner-owned reconstruction visible in Library."
     )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -497,6 +497,58 @@ def _seed_training_truth_concept(page: Page) -> None:
     )
 
 
+def test_empty_library_is_compact_mobile_concept_index(
+    clean_page: Page, base_url: str, captured
+) -> None:
+    """First-use Library stays quiet, truthful, and immediately actionable."""
+    clean_page.set_viewport_size({"width": 390, "height": 844})
+    _enter_app_shell_as_guest(clean_page, base_url)
+    _wait_for_app_settled(clean_page)
+    clean_page.evaluate(
+        """(() => {
+            localStorage.removeItem('learnops_concepts');
+            window.App.showLibrary();
+        })()"""
+    )
+
+    content = clean_page.locator("#library-content")
+    expect(content.locator(".library-page-title")).to_have_text("Library")
+    expect(content.locator(".library-index-title")).to_have_text("Concepts")
+    expect(content.locator(".library-index-count")).to_have_text("0")
+    expect(content.locator(".library-index-count")).to_have_attribute(
+        "aria-label", "0 concepts"
+    )
+    expect(content.locator(".library-index-empty__title")).to_have_text(
+        "Your first reconstruction starts here"
+    )
+    expect(content.locator(".library-index-empty__description")).to_have_text(
+        "Write from memory. Your reconstruction will appear here."
+    )
+    expect(content.locator(".witness-anchor")).to_have_count(0)
+    expect(content).not_to_contain_text("Your Library")
+    expect(content).not_to_contain_text("Drop a topic")
+
+    empty_index = content.locator(".library-section--empty")
+    empty_box = empty_index.bounding_box()
+    action = content.locator(".library-index-empty__action")
+    action_box = action.bounding_box()
+    bottom_nav_box = clean_page.locator("#bottom-nav").bounding_box()
+    assert empty_box is not None
+    assert action_box is not None
+    assert bottom_nav_box is not None
+    assert empty_box["height"] < 240
+    assert round(action_box["height"]) >= 44
+    assert empty_box["y"] + empty_box["height"] < bottom_nav_box["y"]
+    assert clean_page.evaluate(
+        "document.documentElement.scrollWidth <= window.innerWidth"
+    )
+
+    action.click()
+    expect(clean_page.locator("#ignition-view")).to_be_visible()
+    assert captured["console_errors"] == []
+    assert captured["failed_requests"] == []
+
+
 def test_library_card_uses_training_evidence_not_ai_summary(
     page: Page, base_url: str
 ) -> None:
@@ -4529,7 +4581,7 @@ def test_saved_library_concept_reopens_map_view(
     expect(clean_page.locator(".concept-item.active")).to_have_count(1)
 
     clean_page.locator("#nav-library").click()
-    your_library = clean_page.locator("#library-content .library-section", has_text="Your Library")
+    your_library = clean_page.locator("#library-content .library-section", has_text="Concepts")
     your_library.locator(".library-card-vault", has_text="Test Concept").click()
 
     expect(clean_page.locator("#concept-header-title")).to_contain_text("Test Concept")

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -816,7 +816,10 @@ def test_library_view_helpers_preserve_card_metadata_and_empty_state() -> None:
         );
 
         const emptyHtml = buildLibraryHtml([]);
-        assert.ok(emptyHtml.includes('Start a learning session.'));
+        assert.ok(emptyHtml.includes('Your first reconstruction starts here'));
+        assert.ok(emptyHtml.includes('Write from memory. Your reconstruction will appear here.'));
+        assert.ok(emptyHtml.includes('aria-label="0 concepts"'));
+        assert.ok(!emptyHtml.includes('witness-anchor'));
         assert.ok(emptyHtml.includes('App.showIgnition()'));
         assert.ok(!emptyHtml.includes('App.seedLocalQaConcept()'));
 

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -859,7 +859,7 @@ def test_library_view_helpers_preserve_card_metadata_and_empty_state() -> None:
           { id: 'legacy-primed', name: 'Legacy Primed', state: 'growing', graphData: legacyPrimedGraph },
         ], {});
         assert.ok(legacyPrimedHtml.includes('data-state="primed"'));
-        assert.ok(legacyPrimedHtml.includes('>draft saved<'));
+        assert.ok(legacyPrimedHtml.includes('>primed for study<'));
 
         const legacyNeedsRepairGraph = JSON.stringify({
           metadata: {},


### PR DESCRIPTION
Context & Intent
- What problem does this solve? Replaces the oversized promotional Library empty state with a compact, mobile-ready concept index that makes the first reconstruction action clear.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? MVP stabilization and the approved Library session-index redesign.

Implementation Details
- Brief overview of technical changes (files touched, key logic). Updates the Library renderer and styles, clarifies the primed for study badge, bumps frontend cache pins, and adds focused helper and Playwright coverage.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Frontend presentation only; no backend routing, persistence, training-write, or evidence-projection boundaries changed.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; it is static client rendering and CSS.
- [x] Are there SSRF or error-leakage risks in new external calls? No; no external calls were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is unchanged.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Yes; the Library points learners to write from memory and reveals no study content.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; summaries and state badges remain derived from learner evidence.
- [x] Is the active cognitive target explicitly clear to the user? Yes; the empty index states that the first reconstruction starts here.

Branch: feat/library-session-index
Base: main
Diff summary: 9 files changed, 281 insertions, 31 deletions across Library rendering, responsive styling, cache pins, and focused frontend/e2e tests.