### PR TITLE
[codex] Restore mobile concept session escape

### DIFF
--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -1963,15 +1963,8 @@
 }
 
 @media (max-width: 900px) {
-  body[data-map-open="true"] .bottom-nav {
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    transform: translateY(100%);
-  }
-
   body[data-map-open="true"] .concept-page-b2__doc {
-    padding-bottom: 28px;
+    padding-bottom: var(--chrome-h-bottom);
   }
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=171'     layer(components);
+@import '../styles.css?v=172'     layer(components);
 @import '../antigravity.css?v=40' layer(legacy);
 @import 'paper.css?v=20'          layer(paper);

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=189">
+  <link rel="stylesheet" href="/css/index.css?v=190">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=17">
 </head>
 
@@ -435,7 +435,7 @@ I'm fuzzy on…
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=18"></script>
-  <script type="module" src="/js/app.js?v=206"></script>
+  <script type="module" src="/js/app.js?v=207"></script>
   <script type="module" src="/js/floating-room-label.js?v=10"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=10"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3057,7 +3057,7 @@ const App = (() => {
     const mapView = document.getElementById('map-view');
     const heroCard = document.querySelector('.hero-card');
     if (drillState.active || drillState.pending || drillState.node) {
-      cancelDrill();
+      cancelDrill({ restoreMap: false });
     }
     destroyKnowledgeGraphController();
     document.body.classList.remove('is-drilling');
@@ -3302,7 +3302,12 @@ const App = (() => {
 
   function sessionRouteConceptId() {
     const match = window.location.pathname.match(/^\/session\/([^/?#]+)/);
-    return match ? decodeURIComponent(match[1]) : '';
+    if (!match) return '';
+    try {
+      return decodeURIComponent(match[1]);
+    } catch {
+      return '__malformed_session_route__';
+    }
   }
 
   function showSessionRoute(conceptId, { replace = false } = {}) {
@@ -3316,6 +3321,32 @@ const App = (() => {
   function clearSessionRoute() {
     if (!window.history?.pushState || !window.location.pathname.startsWith('/session/')) return;
     window.history.pushState({}, '', '/');
+  }
+
+  function showMissingSessionFallback() {
+    window.history?.replaceState?.({}, '', '/');
+    showIgnition();
+    const errEl = document.getElementById('hero-door-error');
+    if (errEl) {
+      errEl.textContent = 'That session is not saved in this browser.';
+      errEl.hidden = false;
+    }
+  }
+
+  function syncViewFromLocation() {
+    const conceptId = sessionRouteConceptId();
+    if (!conceptId) {
+      showDashboard();
+      return;
+    }
+
+    const concept = loadConcepts().find((item) => item.id === conceptId && item.graphData);
+    if (!concept) {
+      showMissingSessionFallback();
+      return;
+    }
+    activateConceptSelection(concept.id);
+    showMapView(concept);
   }
 
   function showIgnition() {
@@ -3533,12 +3564,7 @@ const App = (() => {
   // Boot routing runs AFTER drillState is initialized because showIgnition()
   // calls teardownMapView() which reads drillState — TDZ-unsafe earlier.
   if (routeConceptId && !routeConcept) {
-    showIgnition();
-    const errEl = document.getElementById('hero-door-error');
-    if (errEl) {
-      errEl.textContent = 'That session is not saved in this browser.';
-      errEl.hidden = false;
-    }
+    showMissingSessionFallback();
   } else if (!toLoad) {
     showIgnition();
   } else {
@@ -3547,6 +3573,7 @@ const App = (() => {
       showMapView(toLoad, { fromBoot: Boolean(routeConcept) });
     }
   }
+  window.addEventListener('popstate', syncViewFromLocation);
 
   function createDrillLogSessionId() {
     if (window.crypto?.randomUUID) return window.crypto.randomUUID();

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,4 +6,4 @@
 @import './css/board-first.css?v=9';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=8';
-@import './css/concept-page.css?v=55';
+@import './css/concept-page.css?v=56';

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -4536,7 +4536,7 @@ def test_mobile_concept_attempt_has_writing_width(
     )
     expect(page.locator(".concept-page-b2__attempt-input")).to_be_visible()
     expect(page.locator("#drawer-toggle")).to_be_visible()
-    expect(page.locator("#bottom-nav")).not_to_be_visible()
+    expect(page.locator("#bottom-nav")).to_be_visible()
     disabled_save_style = page.locator(".concept-page-b2__attempt-save").evaluate(
         """(el) => {
             const style = window.getComputedStyle(el);
@@ -4589,6 +4589,123 @@ def test_mobile_concept_attempt_has_writing_width(
     assert cue_box["x"] > save_box["x"]
     assert save_box["width"] >= 132
     assert truth_note_box["y"] <= cue_box["y"] + cue_box["height"] + 36
+
+
+def test_mobile_concept_nav_exits_and_history_stay_aligned(
+    page: Page, base_url: str
+) -> None:
+    """Concept routes keep primary exits visible and browser history truthful."""
+    page_errors: list[str] = []
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+    page.set_viewport_size({"width": 390, "height": 844})
+    _enter_app_shell_as_guest(page, base_url)
+    page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    _seed_route_margin_concept(page)
+    page.reload()
+    _wait_for_app_settled(page)
+
+    page.locator("#bn-library").click()
+    page.locator(".library-card-vault", has_text="How sodium channels").click()
+    expect(page.locator("#map-view")).to_be_visible()
+    expect(page.locator("#bottom-nav")).to_be_visible()
+    expect(page.locator("#bottom-nav .bottom-nav-item.active")).to_have_count(0)
+
+    page.locator(".concept-page-b2__truth-note").scroll_into_view_if_needed()
+    truth_note_box = page.locator(".concept-page-b2__truth-note").bounding_box()
+    bottom_nav_box = page.locator("#bottom-nav").bounding_box()
+    assert truth_note_box is not None
+    assert bottom_nav_box is not None
+    assert truth_note_box["y"] + truth_note_box["height"] <= bottom_nav_box["y"]
+
+    page.evaluate(
+        """() => App.startDrill({
+            id: 'core-thesis',
+            type: 'core',
+            label: 'Core thesis',
+            detail: 'Explain the current model.',
+        })"""
+    )
+    expect(page.locator("body")).to_have_class(re.compile(r"\bis-drilling\b"))
+    page.locator("#bn-library").click()
+    expect(page.locator("body")).not_to_have_class(re.compile(r"\bis-drilling\b"))
+    expect(page.locator("#library-view")).to_be_visible()
+    expect(page.locator("#map-view")).not_to_be_visible()
+    assert urlparse(page.url).path == "/"
+    page.wait_for_timeout(100)
+    expect(page.locator("#library-view")).to_be_visible()
+    expect(page.locator("#map-view")).not_to_be_visible()
+
+    page.locator(".library-card-vault", has_text="How sodium channels").click()
+    expect(page.locator("#map-view")).to_be_visible()
+    page.locator("#bn-dashboard").click()
+    expect(page.locator(".hero-card")).to_be_visible()
+    expect(page.locator("#map-view")).not_to_be_visible()
+    assert urlparse(page.url).path == "/"
+
+    page.locator("#tile-0").click()
+    expect(page.locator("#map-view")).to_be_visible()
+    assert urlparse(page.url).path == "/session/route-margin-concept"
+    page.evaluate(
+        """() => App.startDrill({
+            id: 'core-thesis',
+            type: 'core',
+            label: 'Core thesis',
+            detail: 'Explain the current model.',
+        })"""
+    )
+    expect(page.locator("body")).to_have_class(re.compile(r"\bis-drilling\b"))
+    history_length = page.evaluate("history.length")
+
+    page.go_back()
+    expect(page.locator("body")).not_to_have_class(re.compile(r"\bis-drilling\b"))
+    expect(page.locator(".hero-card")).to_be_visible()
+    expect(page.locator("#map-view")).not_to_be_visible()
+    expect(page.locator("#bn-dashboard")).to_have_class(re.compile(r"\bactive\b"))
+    assert urlparse(page.url).path == "/"
+    assert page.evaluate("history.length") == history_length
+    page.wait_for_timeout(100)
+    expect(page.locator(".hero-card")).to_be_visible()
+    expect(page.locator("#map-view")).not_to_be_visible()
+
+    page.go_forward()
+    expect(page.locator("#map-view")).to_be_visible()
+    expect(page.locator("#concept-header-title")).to_contain_text(
+        "How sodium channels create an action potential"
+    )
+    expect(page.locator("#bottom-nav .bottom-nav-item.active")).to_have_count(0)
+    assert urlparse(page.url).path == "/session/route-margin-concept"
+    assert page.evaluate("history.length") == history_length
+
+    page.go_back()
+    page.evaluate("localStorage.removeItem('learnops_concepts')")
+    page.go_forward()
+    expect(page.locator("#ignition-view")).to_be_visible()
+    expect(page.locator("#hero-door-error")).to_have_text(
+        "That session is not saved in this browser."
+    )
+    assert urlparse(page.url).path == "/"
+    assert page.evaluate("history.length") == history_length
+
+    history_length_before_missing_boot = page.evaluate("history.length")
+    page.goto(urljoin(base_url + "/", "session/missing-concept"))
+    _wait_for_app_settled(page)
+    expect(page.locator("#ignition-view")).to_be_visible()
+    expect(page.locator("#hero-door-error")).to_have_text(
+        "That session is not saved in this browser."
+    )
+    assert urlparse(page.url).path == "/"
+    assert page.evaluate("history.length") == history_length_before_missing_boot + 1
+
+    history_length_before_malformed_boot = page.evaluate("history.length")
+    page.goto(urljoin(base_url + "/", "session/%E0%A4%A"))
+    _wait_for_app_settled(page)
+    expect(page.locator("#ignition-view")).to_be_visible()
+    expect(page.locator("#hero-door-error")).to_have_text(
+        "That session is not saved in this browser."
+    )
+    assert urlparse(page.url).path == "/"
+    assert page.evaluate("history.length") == history_length_before_malformed_boot + 1
+    assert page_errors == []
 
 
 def test_saved_library_concept_reopens_map_view(


### PR DESCRIPTION
Context & Intent
- What problem does this solve? Mobile concept sessions hid every primary exit, and browser Back changed the URL without rendering the matching surface. Active drill teardown could also re-push the concept route after an exit.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Comprehensive UX audit P0, implemented and reworked through independent engineering and product-design review.
Implementation Details
- Brief overview of technical changes (files touched, key logic). Keeps the existing bottom nav visible with safe-area clearance; synchronizes `/` and `/session/:id` on popstate; treats missing or malformed routes as the existing saved-session fallback; cancels active drills without restoring the map during primary-view teardown; adds focused mobile/history coverage and required frontend cache pins.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). App-shell navigation and drill teardown meet at cancellation only; SEDA routing, training projection, graph derivation, and study reveal logic remain unchanged.
MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? Reviewed: browser history and static asset behavior only; no serverless runtime dependency added.
- [x] Are there SSRF or error-leakage risks in new external calls? Reviewed: no external calls added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Ingestion is untouched.
UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Yes; navigation only, with no earlier content reveal.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; a delayed cancellation proof recorded zero attempts and no SEDA evidence.
- [x] Is the active cognitive target explicitly clear to the user? Yes; the existing concept room and study CTA remain visually dominant over quiet global navigation.
Branch: feat/concept-session-escape
Base: main
Diff summary: 6 files changed, 158 insertions, 21 deletions. Proof: 850 tests and 12 subtests passed; changed frontend JavaScript diff coverage 100%; doctor, syntax, cache pins, focused mobile Playwright, light/dark browser proof, and independent review passed.