### PR TITLE
[codex] Align hosted SEDA smoke timeout

### DIFF
--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -5260,7 +5260,7 @@ def test_source_less_launch_pad_sketch_preserves_gestalt_hybrid_loop(
             ? value
             : null;
         }""",
-        timeout=20_000,
+        timeout=45_000,
     ).json_value()
     assert seda_state["latest"]["awaiting"]["key"] == "cold_attempt"
     bound_surface = clean_page.evaluate(


### PR DESCRIPTION
Context & Intent
- What problem does this solve? The full production smoke raced a correct model-backed source-less route at its 20-second boundary even though the canonical hosted flow permits 45 seconds.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Senior engineering deployment stabilization after the mobile concept-session escape slice.

Implementation Details
- Brief overview of technical changes (files touched, key logic). Change one timeout in tests/e2e/test_smoke.py from 20 seconds to 45 seconds, matching the sibling hosted source-less integration test.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Test harness only; no frontend, route binding, SEDA projection, evidence, API, or deployment runtime code changed.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; the corrected focused test passes against production.
- [x] Are there SSRF or error-leakage risks in new external calls? No new external calls.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is untouched.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Runtime behavior is unchanged.
- [x] Does the graph still tell the truth (no faking mastery)? Fail-closed route binding and evidence projection are unchanged.
- [x] Is the active cognitive target explicitly clear to the user? Learner UI is unchanged.

Branch: feat/hosted-seda-timeout
Base: main
Diff summary: 1 test file changed, 1 insertion, 1 deletion.