### PR TITLE
[codex] Preserve repair continuity

### DIFF
--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -699,6 +699,36 @@
   font-size: 16px;
   line-height: 1.48;
 }
+.concept-page-b2__saved-repair {
+  margin: 0 0 14px;
+  padding-left: 14px;
+  border-left: 2px solid rgba(var(--violet-600-rgb), 0.28);
+}
+.concept-page-b2__saved-repair span {
+  display: block;
+  margin-bottom: 6px;
+  color: rgba(var(--violet-600-rgb), 0.94);
+  font-size: 13px;
+  font-weight: 650;
+}
+.concept-page-b2__saved-repair blockquote {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.concept-page-b2__field {
+  display: block;
+  width: 100%;
+}
+.concept-page-b2__field-label {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.35;
+}
 .concept-page-b2__repair-input {
   width: 100%;
   min-height: 132px;
@@ -715,6 +745,18 @@
 .concept-page-b2__repair-input:focus {
   outline: 2px solid rgba(144, 103, 198, 0.28);
   outline-offset: 2px;
+}
+.concept-page-b2__repair-status,
+.concept-page-b2__attempt-status {
+  min-height: 18px;
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.35;
+}
+.concept-page-b2__repair-status:empty,
+.concept-page-b2__attempt-status:empty {
+  display: none;
 }
 .concept-page-b2__repair-error {
   margin: 10px 0 0;
@@ -1834,8 +1876,6 @@
 }
 
 .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-input {
-  grid-column: 2;
-  grid-row: 1 / span 3;
   min-height: clamp(300px, 36vh, 360px);
   border: 1px solid rgba(var(--ink-900-rgb), 0.10);
   border-radius: 16px;
@@ -1849,6 +1889,11 @@
   font-size: 16px;
   line-height: 1.75;
   padding: 22px 24px;
+}
+
+.concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-field {
+  grid-column: 2;
+  grid-row: 1 / span 3;
 }
 
 .concept-page-b2__active-entry--prompt-first .concept-page-b2__attempt-input:focus {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=172'     layer(components);
+@import '../styles.css?v=173'     layer(components);
 @import '../antigravity.css?v=40' layer(legacy);
 @import 'paper.css?v=20'          layer(paper);

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=190">
+  <link rel="stylesheet" href="/css/index.css?v=191">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=17">
 </head>
 
@@ -435,7 +435,7 @@ I'm fuzzy on…
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
   <script src="/js/drill-chamber.js?v=18"></script>
-  <script type="module" src="/js/app.js?v=207"></script>
+  <script type="module" src="/js/app.js?v=208"></script>
   <script type="module" src="/js/floating-room-label.js?v=10"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=10"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -31,7 +31,7 @@ import {
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=33';
+} from './concept-page-view.js?v=34';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
@@ -2098,6 +2098,12 @@ const App = (() => {
     syncInlineAttemptSaveButton(input.closest('.concept-page-b2__attempt'));
   }
 
+  function focusRenderedMoment(selector) {
+    requestAnimationFrame(() => {
+      document.querySelector(selector)?.focus?.();
+    });
+  }
+
   /**
    * Wire event handlers on the work column after a swap or initial mount.
    * Handles the CTA (start drill) and the threshold re-edit affordance.
@@ -2453,6 +2459,7 @@ const App = (() => {
         };
         await trainingStore.saveTraining(training);
         renderActiveEntryWorkColumn(entryId, concept, graphData, training);
+        focusRenderedMoment('.concept-page-b2__study-note');
         return;
       }
       const training = await trainingStore.setStudyRevealed(
@@ -2474,6 +2481,7 @@ const App = (() => {
         training,
         renderOptions,
       );
+      focusRenderedMoment('.concept-page-b2__study-note');
     } catch (err) {
       /* c8 ignore next -- defensive storage/invariant failure branch */
       console.warn('Study reveal failed.', err);
@@ -2484,6 +2492,7 @@ const App = (() => {
     const panel = button?.closest?.('.concept-page-b2__attempt');
     const entryId = button?.dataset?.attemptEntryId || panel?.dataset?.attemptEntryId || null;
     const input = panel?.querySelector?.('.concept-page-b2__attempt-input');
+    const statusEl = panel?.querySelector?.('[data-attempt-status]');
     const errorEl = panel?.querySelector?.('[data-attempt-error]');
     const userText = input?.value || '';
     if (!entryId || !concept?.id) return;
@@ -2497,6 +2506,8 @@ const App = (() => {
     if (errorEl) errorEl.hidden = true;
     button.disabled = true;
     button.setAttribute('aria-disabled', 'true');
+    panel?.setAttribute('aria-busy', 'true');
+    if (statusEl) statusEl.textContent = 'Checking and saving your draft…';
 
     const graphData = parseConceptGraphData(concept) || data || {};
     if (hasPendingSourceLessSedaRoute(concept, graphData)) {
@@ -2584,6 +2595,7 @@ const App = (() => {
         : graphData;
       const mountEl = document.getElementById('map-content');
       if (mountEl) renderConceptPageB2(mountEl, renderGraphData, renderConcept, training, { activeEntryId: entryId });
+      focusRenderedMoment('.concept-page-b2__evidence');
     } catch (err) {
       console.warn('Memory attempt failed.', err);
       button.disabled = false;
@@ -2592,6 +2604,8 @@ const App = (() => {
         errorEl.textContent = 'The system could not record this yet. Try again.';
         errorEl.hidden = false;
       }
+      panel?.removeAttribute('aria-busy');
+      if (statusEl) statusEl.textContent = '';
     }
   }
 
@@ -2599,6 +2613,7 @@ const App = (() => {
     const panel = button?.closest?.('.concept-page-b2__repair');
     const entryId = button?.dataset?.repairEntryId || panel?.dataset?.repairEntryId || null;
     const input = panel?.querySelector?.('.concept-page-b2__repair-input');
+    const statusEl = panel?.querySelector?.('[data-repair-status]');
     const errorEl = panel?.querySelector?.('[data-repair-error]');
     const text = (input?.value || '').trim().slice(0, 1200);
     if (!entryId || !concept?.id) return;
@@ -2608,6 +2623,9 @@ const App = (() => {
       return;
     }
     if (errorEl) errorEl.hidden = true;
+    button.disabled = true;
+    panel?.setAttribute('aria-busy', 'true');
+    if (statusEl) statusEl.textContent = 'Saving your repair…';
 
     try {
       const training = await trainingStore.appendRepair(concept.id, entryId, {
@@ -2619,6 +2637,7 @@ const App = (() => {
       if (mountEl) {
         window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
         renderConceptPageB2(mountEl, data, concept, training, { activeEntryId: entryId });
+        focusRenderedMoment('.concept-page-b2__repair--saved');
       }
     } catch (err) {
       /* c8 ignore next -- defensive storage/invariant failure branch */
@@ -2627,6 +2646,9 @@ const App = (() => {
         errorEl.textContent = 'Repair could not be saved. Try again.';
         errorEl.hidden = false;
       }
+      button.disabled = false;
+      panel?.removeAttribute('aria-busy');
+      if (statusEl) statusEl.textContent = '';
     }
   }
 

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -476,7 +476,7 @@ function renderEvidenceArtifactHtml(derived) {
     : '';
 
   return `
-    <section class="concept-page-b2__evidence${isStudyGate ? ' concept-page-b2__evidence--study-gate' : ''}${isRepairing ? ' concept-page-b2__evidence--compact' : ''}" aria-label="Learner draft evidence">
+    <section class="concept-page-b2__evidence${isStudyGate ? ' concept-page-b2__evidence--study-gate' : ''}${isRepairing ? ' concept-page-b2__evidence--compact' : ''}" aria-label="Learner draft evidence" tabindex="-1">
       <span class="eyebrow concept-page-b2__evidence-eyebrow">${isStudyGate ? 'Your memory draft' : 'Your draft'}</span>
       <blockquote>${escHtml(attempt.user_text)}</blockquote>
       ${bridgeHtml}
@@ -492,6 +492,7 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId, options = {}
     : [{ mechanism: 'missing link', correction: 'Write the part that was missing from your first attempt.' }];
   const entryId = activeEntryId || activeEntry.id || 'core-thesis';
   const repairs = Array.isArray(derived.record?.repairs) ? derived.record.repairs : [];
+  const latestRepairText = String(repairs.at(-1)?.text || '').trim();
   const repairCheckedThisSession = repairs.length && options?.repairCheckedThisSession === true;
   const nextAttemptButton = repairs.length && !repairCheckedThisSession
     ? `<button class="concept-page-b2__entry-cta concept-page-b2__repair-attempt" type="button" data-active-entry-id="${escHtml(entryId)}" data-active-entry-action="drill-gap">Pressure-check this link</button>`
@@ -507,26 +508,35 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId, options = {}
   const inputFormHtml = repairs.length
     ? ''
     : `
-      <textarea
-        class="concept-page-b2__repair-input"
-        data-repair-entry-id="${escHtml(entryId)}"
-        aria-label="Write the missing link"
-        rows="4"
-        maxlength="1200"
-        placeholder="Write the corrected link here."
-      ></textarea>
-      <p class="concept-page-b2__repair-error" data-repair-error hidden>Write the missing link before saving.</p>
+      <label class="concept-page-b2__field">
+        <span class="concept-page-b2__field-label">Your repaired link</span>
+        <textarea
+          class="concept-page-b2__repair-input"
+          data-repair-entry-id="${escHtml(entryId)}"
+          rows="4"
+          maxlength="1200"
+          placeholder="Write the corrected link here."
+        ></textarea>
+      </label>
+      <p class="concept-page-b2__repair-status" data-repair-status role="status" aria-live="polite"></p>
+      <p class="concept-page-b2__repair-error" data-repair-error role="alert" hidden>Write the missing link before saving.</p>
       <button class="concept-page-b2__repair-save" type="button" data-repair-entry-id="${escHtml(entryId)}">Save repair</button>
     `;
 
   return `
-    <section class="concept-page-b2__repair${repairs.length ? ' concept-page-b2__repair--saved' : ''}" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link">
+    <section class="concept-page-b2__repair${repairs.length ? ' concept-page-b2__repair--saved' : ''}" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link" tabindex="-1">
       <span class="eyebrow concept-page-b2__repair-eyebrow">${repairCheckedThisSession ? 'Repair checked' : repairs.length ? 'Repair saved' : 'Repair'}</span>
       <h3>${repairCheckedThisSession ? 'Repair checked for now.' : repairs.length ? 'Pressure-check the repaired link.' : 'Write the missing link.'}</h3>
       <div class="concept-page-b2__repair-target">
         <span>Missing link</span>
         <p>${escHtml(repairTarget)}</p>
       </div>
+      ${latestRepairText ? `
+        <div class="concept-page-b2__saved-repair">
+          <span>Your saved repair</span>
+          <blockquote>${escHtml(latestRepairText)}</blockquote>
+        </div>
+      ` : ''}
       ${helperHtml}
       ${inputFormHtml}
       ${nextAttemptButton}
@@ -570,15 +580,18 @@ function renderAttemptPanelHtml(activeEntryId, activeEntry, options = {}) {
       <span class="eyebrow concept-page-b2__attempt-eyebrow visually-hidden">cold attempt</span>
       <h3>${escHtml(heading)}</h3>
       ${helper ? `<p class="concept-page-b2__attempt-helper">${escHtml(helper)}</p>` : ''}
-      <textarea
-        class="concept-page-b2__attempt-input"
-        data-attempt-entry-id="${escHtml(activeEntryId)}"
-        aria-label="Write what you can reconstruct"
-        rows="6"
-        maxlength="2400"
-        placeholder="${escHtml(placeholder)}"
-      ></textarea>
-      <p class="concept-page-b2__attempt-error" data-attempt-error hidden>${escHtml(errorText)}</p>
+      <label class="concept-page-b2__field concept-page-b2__attempt-field">
+        <span class="concept-page-b2__field-label">Your reconstruction</span>
+        <textarea
+          class="concept-page-b2__attempt-input"
+          data-attempt-entry-id="${escHtml(activeEntryId)}"
+          rows="6"
+          maxlength="2400"
+          placeholder="${escHtml(placeholder)}"
+        ></textarea>
+      </label>
+      <p class="concept-page-b2__attempt-status" data-attempt-status role="status" aria-live="polite"></p>
+      <p class="concept-page-b2__attempt-error" data-attempt-error role="alert" hidden>${escHtml(errorText)}</p>
       <div class="concept-page-b2__attempt-actions">
         <button class="concept-page-b2__attempt-save" type="button" data-attempt-entry-id="${escHtml(activeEntryId)}" disabled aria-disabled="true">${escHtml(buttonLabel)}</button>
         ${cueHtml}
@@ -823,7 +836,7 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     : 'Study note stays hidden while you repair.';
   const studyNoteHtml = derived.record?.study_revealed_at && !isAttempting
     ? `
-      <section class="concept-page-b2__study-note${collapseStudyNote ? ' is-collapsed' : ''}" aria-label="Study note">
+      <section class="concept-page-b2__study-note${collapseStudyNote ? ' is-collapsed' : ''}" aria-label="Study note" tabindex="-1">
         <div class="concept-page-b2__study-note-header">
           <span class="eyebrow concept-page-b2__study-note-eyebrow">Study note</span>
           <button class="concept-page-b2__study-note-toggle" type="button" data-study-note-toggle aria-expanded="${collapseStudyNote ? 'false' : 'true'}">${collapseStudyNote ? 'Show study note' : 'Hide study note'}</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,4 +6,4 @@
 @import './css/board-first.css?v=9';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=8';
-@import './css/concept-page.css?v=56';
+@import './css/concept-page.css?v=57';

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1038,6 +1038,13 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
         "Needs repair"
     )
+    expect(page.locator(".concept-page-b2__repair--saved")).to_be_focused()
+    expect(page.locator(".concept-page-b2__repair--saved")).to_contain_text(
+        "Your saved repair"
+    )
+    expect(page.locator(".concept-page-b2__repair--saved")).to_contain_text(
+        "Threshold opens voltage-gated sodium channels; the gradient drives sodium flow only after that gate opens."
+    )
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
         "Pressure-check this link"
     )
@@ -3725,6 +3732,9 @@ def test_localhost_concept_page_cold_attempt_appends_training_evidence(
         "Cold Attempt QA source"
     )
     expect(page.locator(".concept-page-b2__attempt")).to_be_visible()
+    expect(page.locator(".concept-page-b2__attempt-field")).to_contain_text(
+        "Your reconstruction"
+    )
     expect(page.locator(".concept-page-b2__study-note")).to_have_count(0)
     save_button = page.locator(".concept-page-b2__attempt-save")
     expect(save_button).to_be_disabled()
@@ -3742,6 +3752,7 @@ def test_localhost_concept_page_cold_attempt_appends_training_evidence(
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
         "Draft saved"
     )
+    expect(page.locator(".concept-page-b2__evidence")).to_be_focused()
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
         "Reveal notes and compare"
     )

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1684,6 +1684,9 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(coldHtml.includes('What do you think makes the sodium channel open?'));
         assert.ok(coldHtml.includes('Sodium gate'));
         assert.ok(coldHtml.includes('Save draft'));
+        assert.ok(coldHtml.includes('Your reconstruction'));
+        assert.ok(coldHtml.includes('data-attempt-status'));
+        assert.ok(coldHtml.includes('role="status"'));
         assert.ok(!coldHtml.includes('Shaped by your sketch'));
         assert.ok(!coldHtml.includes('Shaped from your launch attempt, not verified against a source.'));
         assert.ok(!coldHtml.includes('AI-generated answer structure must stay hidden.'));
@@ -2606,6 +2609,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(repairHtml.includes('Write the missing link.'));
         assert.ok(repairHtml.includes('Use your words. One or two sentences is enough.'));
         assert.ok(repairHtml.includes('Save repair'));
+        assert.ok(repairHtml.includes('Your repaired link'));
+        assert.ok(repairHtml.includes('data-repair-status'));
         assert.ok(repairHtml.includes('Study note stays hidden while you repair.'));
         assert.ok(repairHtml.includes('Show study note'));
         const fallbackRepairHtml = renderActiveEntryHtml(
@@ -2670,6 +2675,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(repairedHtml.includes('Pressure-check the repaired link.'));
         assert.ok(repairedHtml.includes('concept-page-b2__repair'));
         assert.ok(repairedHtml.includes('Pressure-check this link'));
+        assert.ok(repairedHtml.includes('Your saved repair'));
+        assert.ok(repairedHtml.includes('Voltage-gated channels open at threshold.'));
         assert.ok(repairedHtml.includes('data-active-entry-action="drill-gap"'));
         assert.ok(!repairedHtml.includes('concept-page-b2__repair-input'));
         assert.ok(!repairedHtml.includes('concept-page-b2__repair-save'));


### PR DESCRIPTION
Context & Intent
- What problem does this solve? Preserve learner-authored reconstruction and repair text across asynchronous attempt, study, and saved-repair transitions while adding visible labels and accessible state handoffs.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? MVP stabilization from the production UX audit and the concept continuity agent slice.
Implementation Details
- Brief overview of technical changes (files touched, key logic). Adds persistent field labels, polite status regions, deliberate post-render focus, visible saved repair text, cache-pin bumps, and focused helper/E2E coverage across eight frontend and test files.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Frontend rendering and interaction orchestration only; no backend drill routing, evidence derivation, persistence schema, or graph mutation changes.
MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; the change is browser-only rendering and focus behavior.
- [x] Are there SSRF or error-leakage risks in new external calls? No new external calls.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is untouched.
UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Yes; no study content appears before the attempt.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; saved repair and Pressure-check remain graph-neutral.
- [x] Is the active cognitive target explicitly clear to the user? Yes; reconstruction and repaired-link fields are persistently labeled.
Branch: feat/concept-exit-artifact-continuity
Base: main
Diff summary: 8 files changed, 126 insertions, 28 deletions; full frontend gate 850 passed plus 12 subtests and 100% diff coverage; doctor passed; relevant browser proof passed. App smoke is 60/62 with two source-less SEDA startup timeouts reproduced unchanged on main.