### PR TITLE
[codex] Start local smoke server automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ starting Uvicorn to catch missing `.env` / `.env.local` auth configuration.
 
 ## Testing
 
-End-to-End browser smoke tests are powered by Playwright and Pytest. To run them, make sure the development server is running in the background, or point the tests to the live production server.
+End-to-End browser smoke tests are powered by Playwright and Pytest. The local
+runner reuses a healthy development server or starts and stops one itself. You
+can also point it to the live production server.
 
 ```bash
 # Test against local dev server (http://localhost:8000)

--- a/scripts/qa-smoke.sh
+++ b/scripts/qa-smoke.sh
@@ -9,9 +9,10 @@
 #   SOCRATINK_BASE_URL=... bash scripts/qa-smoke.sh
 #
 # What it does:
-#   1. Ensures pytest-playwright + chromium are available.
-#   2. Runs tests/e2e/test_smoke.py against the target URL.
-#   3. Exits 0 on pass, non-zero on fail (with verbose pytest output).
+#   1. Starts a local app when the loopback target is not already healthy.
+#   2. Ensures pytest-playwright + chromium are available.
+#   3. Runs tests/e2e/test_smoke.py against the target URL.
+#   4. Exits 0 on pass, non-zero on fail (with verbose pytest output).
 #
 # Designed to be invoked by humans, by Claude Code, or by Gemini CLI.
 
@@ -19,6 +20,20 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
+
+LOCAL_SERVER_PID=""
+LOCAL_LOOP_STORE=""
+
+cleanup() {
+  if [ -n "$LOCAL_SERVER_PID" ]; then
+    kill "$LOCAL_SERVER_PID" 2>/dev/null || true
+    wait "$LOCAL_SERVER_PID" 2>/dev/null || true
+  fi
+  if [ -n "$LOCAL_LOOP_STORE" ]; then
+    rm -rf "$LOCAL_LOOP_STORE"
+  fi
+}
+trap cleanup EXIT
 
 if [ ! -x ".venv/bin/python" ]; then
   echo "[qa-smoke] ERROR: .venv is missing. Run: bash scripts/bootstrap-python.sh" >&2
@@ -28,6 +43,7 @@ fi
 PYTHON_BIN=".venv/bin/python"
 PYTEST_BIN=".venv/bin/pytest"
 PLAYWRIGHT_BIN=".venv/bin/playwright"
+UVICORN_BIN=".venv/bin/uvicorn"
 
 # 1. Resolve target URL: positional arg > SOCRATINK_BASE_URL env var > local default.
 if [ $# -ge 1 ]; then
@@ -65,5 +81,66 @@ if ! "$PYTHON_BIN" -c "from playwright.sync_api import sync_playwright; sync_pla
   "$PLAYWRIGHT_BIN" install chromium
 fi
 
-# 3. Run the suite.
-exec "$PYTEST_BIN" tests/e2e/test_smoke.py -v --tb=short
+# 3. Start a missing loopback app; remote targets remain caller-owned.
+LOCAL_PORT=$("$PYTHON_BIN" - "$TARGET" <<'PY' || true
+import sys
+from urllib.parse import urlparse
+
+target = urlparse(sys.argv[1])
+if target.scheme == "http" and target.hostname in {"localhost", "127.0.0.1"}:
+    print(target.port or 80)
+PY
+)
+
+if [ -n "$LOCAL_PORT" ]; then
+  HEALTH_URL="${TARGET%/}/api/health"
+  if ! "$PYTHON_BIN" - "$HEALTH_URL" <<'PY'
+import sys
+import urllib.request
+
+try:
+    with urllib.request.urlopen(sys.argv[1], timeout=2) as response:
+        raise SystemExit(0 if response.status == 200 else 1)
+except Exception:
+    raise SystemExit(1)
+PY
+  then
+    if [ ! -x "$UVICORN_BIN" ]; then
+      echo "[qa-smoke] ERROR: local app is unavailable and uvicorn is missing. Run: bash scripts/bootstrap-python.sh" >&2
+      exit 1
+    fi
+    echo "[qa-smoke] starting local app at $TARGET"
+    mkdir -p .qa-runs
+    LOCAL_LOOP_STORE="$REPO_ROOT/.qa-runs/qa-smoke-loop-sessions-$$"
+    mkdir -p "$LOCAL_LOOP_STORE"
+    SOCRATINK_DEV_AUTOGUEST="${SOCRATINK_DEV_AUTOGUEST:-1}" \
+    SOCRATINK_E2E_LOCAL_GUEST="${SOCRATINK_E2E_LOCAL_GUEST:-1}" \
+    SOCRATINK_TUI_FAKE_LLM="${SOCRATINK_TUI_FAKE_LLM:-1}" \
+    SOCRATINK_LOOP_SESSION_STORE_DIR="${SOCRATINK_LOOP_SESSION_STORE_DIR:-$LOCAL_LOOP_STORE}" \
+    PYTHON="${PYTHON:-$REPO_ROOT/$PYTHON_BIN}" \
+    "$REPO_ROOT/$UVICORN_BIN" main:app --host 127.0.0.1 --port "$LOCAL_PORT" \
+      >.qa-runs/qa-smoke-uvicorn.log 2>&1 &
+    LOCAL_SERVER_PID="$!"
+
+    "$PYTHON_BIN" - "$HEALTH_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+deadline = time.time() + 30
+last_error = None
+while time.time() < deadline:
+    try:
+        with urllib.request.urlopen(sys.argv[1], timeout=2) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception as exc:  # noqa: BLE001 - shell diagnostic path
+        last_error = exc
+        time.sleep(1)
+raise SystemExit(f"local app did not become healthy: {last_error}")
+PY
+  fi
+fi
+
+# 4. Run the suite.
+"$PYTEST_BIN" tests/e2e/test_smoke.py -v --tb=short

--- a/tests/test_qa_smoke_script.py
+++ b/tests/test_qa_smoke_script.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QA_SMOKE = REPO_ROOT / "scripts" / "qa-smoke.sh"
+
+
+def test_local_smoke_runner_owns_missing_server_lifecycle() -> None:
+    script = QA_SMOKE.read_text()
+
+    assert 'trap cleanup EXIT' in script
+    assert 'target.hostname in {"localhost", "127.0.0.1"}' in script
+    assert '"$REPO_ROOT/$UVICORN_BIN" main:app' in script
+    assert 'exec "$PYTEST_BIN"' not in script


### PR DESCRIPTION
Context & Intent
- What problem does this solve? `scripts/qa-smoke.sh` failed all local checks when no app server was already running, despite presenting itself as a single-command runner.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? MVP stabilization and workflow-friction cleanup.

Implementation Details
- Brief overview of technical changes (files touched, key logic). The smoke runner now starts and cleans up loopback Uvicorn when needed, reuses a healthy caller-owned server, leaves remote targets untouched, and documents the behavior. A focused contract test protects the lifecycle path.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Test orchestration only; no product runtime, graph, learner evidence, persistence, or backend route behavior changed.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No. The new behavior runs only from the local shell script.
- [x] Are there SSRF or error-leakage risks in new external calls? No new remote calls are introduced; automatic startup is restricted to loopback HTTP targets.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Not applicable; no UI or drill behavior changed.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; graph behavior is untouched.
- [x] Is the active cognitive target explicitly clear to the user? Not applicable; this is test tooling.

Branch: feat/qa-smoke-self-start
Base: main
Diff summary: 3 files changed; local smoke server lifecycle, documentation, and one contract test.
