### PR TITLE
[codex] Avoid routing prefix copies

### DIFF
--- a/lib/seda/routing-proofs.mjs
+++ b/lib/seda/routing-proofs.mjs
@@ -18,7 +18,7 @@ export function isTelemetryOnlyEvent(event) {
 }
 
 /**
- * Walk event prefixes and collect nextPhase after each append.
+ * Collect nextPhase after each event append.
  * Skips telemetry-only events that never drive nextPhase mid-handler.
  * @param {Array<{ type: string, [key: string]: unknown }>} events
  * @returns {{ ok: boolean, phases: Array<{ afterEventIndex: number, eventType: string, nextPhase: string | null }>, terminalPhase: string | null, error?: string }}
@@ -30,11 +30,10 @@ export function simulatePhaseChain(events) {
       const event = events[i];
       if (isTelemetryOnlyEvent(event)) continue;
 
-      const prefix = events.slice(0, i + 1);
       phases.push({
         afterEventIndex: i,
         eventType: event.type,
-        nextPhase: nextPhase(prefix),
+        nextPhase: nextPhase([event]),
       });
     }
     const terminalPhase = nextPhase(events);

--- a/tests/test_seda_routing_proofs.py
+++ b/tests/test_seda_routing_proofs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from tests._helpers.node_runner import run_node_module
+
+
+def test_simulate_phase_chain_preserves_routing_contract() -> None:
+    result = run_node_module(
+        r"""
+        import assert from "node:assert/strict";
+        import { simulatePhaseChain } from "./lib/seda/routing-proofs.mjs";
+
+        const events = [
+          { type: "launch_attempt" },
+          { type: "repair_state_bucketed" },
+          { type: "repair_cap_selected" },
+          { type: "repair_recovery_started" },
+          { type: "repair_recovery_turn" },
+          { type: "repair_hint_requested" },
+          { type: "route_retry" },
+          { type: "route_generated" },
+          { type: "cold_attempt", evaluation: { classification: "solid" } },
+          {
+            type: "repair_dialogue_turn",
+            bridge_ready: false,
+            next_dialogue_action: "abandon",
+            turn_index: 2,
+          },
+          { type: "repair_abandoned", next_step: "recovery_prompt" },
+          { type: "repair_recovery_closed", next_phase: "repair" },
+          { type: "idle_exit" },
+        ];
+        const original = structuredClone(events);
+
+        assert.deepEqual(simulatePhaseChain(events), {
+          ok: true,
+          phases: [
+            { afterEventIndex: 0, eventType: "launch_attempt", nextPhase: "substrate_gate" },
+            { afterEventIndex: 7, eventType: "route_generated", nextPhase: "cold_attempt" },
+            { afterEventIndex: 8, eventType: "cold_attempt", nextPhase: "strong_cold_path" },
+            { afterEventIndex: 9, eventType: "repair_dialogue_turn", nextPhase: "repair_abandoned" },
+            { afterEventIndex: 10, eventType: "repair_abandoned", nextPhase: "repair_recovery" },
+            { afterEventIndex: 11, eventType: "repair_recovery_closed", nextPhase: "repair" },
+            { afterEventIndex: 12, eventType: "idle_exit", nextPhase: null },
+          ],
+          terminalPhase: null,
+        });
+        assert.deepEqual(events, original);
+
+        assert.deepEqual(
+          simulatePhaseChain([{ type: "launch_attempt" }, { type: "future_event" }]),
+          {
+            ok: false,
+            phases: [
+              { afterEventIndex: 0, eventType: "launch_attempt", nextPhase: "substrate_gate" },
+            ],
+            terminalPhase: null,
+            error: "unknown event type: future_event",
+          },
+        );
+        assert.deepEqual(
+          simulatePhaseChain([
+            { type: "launch_attempt" },
+            { type: "repair_state_bucketed" },
+          ]),
+          {
+            ok: false,
+            phases: [
+              { afterEventIndex: 0, eventType: "launch_attempt", nextPhase: "substrate_gate" },
+            ],
+            terminalPhase: null,
+            error: "unknown event type: repair_state_bucketed",
+          },
+        );
+        """
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Context & Intent
- What problem does this solve? `simulatePhaseChain()` copied every growing event prefix even though `nextPhase()` reads only the final event. The setup-excluded 20,000-event protocol `routing-phase-chain-20000-v1` classified the singleton-array change as `PROVEN`: 44.170 ms to 2.088 ms median, 95.27% faster and 21.154x, with fixture construction outside the timed region.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Speedup Proof, scoped to the exported routing-proof helper only.

Implementation Details
- Brief overview of technical changes (files touched, key logic). `lib/seda/routing-proofs.mjs` now passes `[event]` for each non-telemetry step. `tests/test_seda_routing_proofs.py` protects phase results, telemetry handling, indices, terminal routing, unknown-event errors, and input immutability.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). No production routing boundary changed. `nextPhase()` and its runtime callers are untouched; this changes only routing-proof simulation.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; the helper uses standard in-process arrays.
- [x] Are there SSRF or error-leakage risks in new external calls? No external calls were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is unchanged.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Not applicable; learner flow is unchanged.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; routing and evidence logic are unchanged.
- [x] Is the active cognitive target explicitly clear to the user? Not applicable; no UI or drill surface changed.

Branch: feat/routing-phase-chain-speedup
Base: main
Diff summary: 2 files changed, 78 insertions(+), 3 deletions(-)
