### PR TITLE
[codex] Verify canonical agent doc routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file is the lightweight local operating guide for this repository.
 
 ## Read this before edits
 - Current architecture/truth lives in `README.md`, `docs/project/doc-map.md`, and `docs/project/state.md`.
+- Agent workflow and verification doctrine lives in `agents/QUALITY.md`.
 - Runtime and deployment notes are in `.github/workflows/` and related scripts.
 - Product doctrine lives in `PRODUCT.md`, `DESIGN.md`, and `UBIQUITOUS_LANGUAGE.md`.
 

--- a/scripts/check_agent_docs.py
+++ b/scripts/check_agent_docs.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fail when canonical agent docs route to stale local references."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANONICAL_DOCS = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "agents/README.md",
+    "agents/QUALITY.md",
+    "docs/project/doc-map.md",
+    "docs/project/state.md",
+)
+REQUIRED_REFERENCES = {
+    "AGENTS.md": ("agents/QUALITY.md", "$socratink-agent-flow"),
+    "CLAUDE.md": ("AGENTS.md", "docs/project/doc-map.md"),
+}
+RETIRED_TERMS = (
+    ".socratink-brain",
+    "Context7",
+    "agents/founder/WORKFLOWS",
+    "scripts/install-hooks.sh",
+)
+MARKDOWN_LINK_RE = re.compile(r"\[[^]]*]\(([^)]+)\)")
+REFERENCE_DEFINITION_RE = re.compile(r"(?m)^\s{0,3}\[([^]]+)]\s*:\s*(\S+)")
+REFERENCE_USE_RE = re.compile(r"\[([^]]+)]\[([^]]*)]")
+INLINE_CODE_RE = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+LOCAL_PATH_RE = re.compile(
+    r"(?<![\w.-])(?:"
+    r"(?:agents|docs|scripts|tests|public|\.github)/[A-Za-z0-9_./-]+"
+    r"|(?:AGENTS|CLAUDE|README|PRODUCT|DESIGN|UBIQUITOUS_LANGUAGE)\.md"
+    r"|requirements(?:-dev)?\.txt|vercel\.json|package(?:-lock)?\.json"
+    r"|pyrefly\.toml|mypy\.ini"
+    r")"
+)
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _local_link_target(doc_path: Path, target: str, root: Path) -> Path | None:
+    target = target.strip().split(maxsplit=1)[0].strip("<>")
+    target = target.split("#", 1)[0].split("?", 1)[0]
+    if not target or target.startswith(("http://", "https://", "mailto:")):
+        return None
+    return root / target.lstrip("/") if target.startswith("/") else doc_path.parent / target
+
+
+def validate_document(doc_path: Path, root: Path) -> list[str]:
+    text = doc_path.read_text()
+    relative_doc = doc_path.relative_to(root).as_posix()
+    failures: list[str] = []
+
+    for term in RETIRED_TERMS:
+        for match in re.finditer(re.escape(term), text):
+            failures.append(
+                f"{relative_doc}:{_line_number(text, match.start())}: retired reference `{term}`"
+            )
+
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        target = _local_link_target(doc_path, match.group(1), root)
+        if target is not None and not target.exists():
+            failures.append(
+                f"{relative_doc}:{_line_number(text, match.start())}: missing link `{match.group(1)}`"
+            )
+
+    definitions = {
+        match.group(1).casefold(): match for match in REFERENCE_DEFINITION_RE.finditer(text)
+    }
+    for match in definitions.values():
+        target = _local_link_target(doc_path, match.group(2), root)
+        if target is not None and not target.exists():
+            failures.append(
+                f"{relative_doc}:{_line_number(text, match.start())}: missing link `{match.group(2)}`"
+            )
+    for match in REFERENCE_USE_RE.finditer(text):
+        label = (match.group(2) or match.group(1)).casefold()
+        if label not in definitions:
+            failures.append(
+                f"{relative_doc}:{_line_number(text, match.start())}: undefined link reference `{label}`"
+            )
+
+    for code_match in INLINE_CODE_RE.finditer(text):
+        for path_match in LOCAL_PATH_RE.finditer(code_match.group(1)):
+            reference = path_match.group(0).rstrip("./")
+            if reference and not (root / reference).exists():
+                failures.append(
+                    f"{relative_doc}:{_line_number(text, code_match.start())}: missing path `{reference}`"
+                )
+
+    for required in REQUIRED_REFERENCES.get(relative_doc, ()):
+        if required not in text:
+            failures.append(f"{relative_doc}: missing required route `{required}`")
+
+    return sorted(set(failures))
+
+
+def validate(root: Path = REPO_ROOT) -> list[str]:
+    failures: list[str] = []
+    for relative_doc in CANONICAL_DOCS:
+        doc_path = root / relative_doc
+        if not doc_path.is_file():
+            failures.append(f"{relative_doc}: canonical doc is missing")
+            continue
+        failures.extend(validate_document(doc_path, root))
+    return sorted(failures)
+
+
+def main() -> int:
+    failures = validate()
+    if failures:
+        print("[agent-docs] FAIL: stale agent documentation:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("[agent-docs] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -35,6 +35,9 @@ if [ ! -x ".venv/bin/python" ]; then
   exit 1
 fi
 
+echo "[doctor] agent-doc integrity..."
+.venv/bin/python scripts/check_agent_docs.py
+
 echo "[doctor] context-hub wrapper..."
 if [ ! -x "scripts/chub-docs.sh" ]; then
   echo "[doctor] FAIL: scripts/chub-docs.sh missing or not executable" >&2

--- a/tests/test_agent_doc_integrity.py
+++ b/tests/test_agent_doc_integrity.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHECKER_PATH = REPO_ROOT / "scripts" / "check_agent_docs.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_agent_docs", CHECKER_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_agent_docs_match_live_repo_routes() -> None:
+    checker = _load_checker()
+
+    assert checker.validate(REPO_ROOT) == []
+
+
+def test_agent_doc_checker_reports_stale_references(tmp_path: Path) -> None:
+    checker = _load_checker()
+    doc = tmp_path / "AGENTS.md"
+    doc.write_text("Use `scripts/gone.sh` and Context7.\n")
+
+    assert set(checker.validate_document(doc, tmp_path)) == {
+        "AGENTS.md:1: missing path `scripts/gone.sh`",
+        "AGENTS.md:1: retired reference `Context7`",
+        "AGENTS.md: missing required route `$socratink-agent-flow`",
+        "AGENTS.md: missing required route `agents/QUALITY.md`",
+    }
+
+
+def test_agent_doc_checker_validates_reference_style_links(tmp_path: Path) -> None:
+    checker = _load_checker()
+    doc = tmp_path / "notes.md"
+    doc.write_text(
+        "Read [quality][quality] and [missing][unknown].\n"
+        "[quality]: agents/missing.md \"Agent quality\"\n"
+    )
+
+    assert checker.validate_document(doc, tmp_path) == [
+        "notes.md:1: undefined link reference `unknown`",
+        "notes.md:2: missing link `agents/missing.md`",
+    ]


### PR DESCRIPTION
Context & Intent
- Prevent canonical agent documentation from silently routing future work to missing or retired repository surfaces.
- This stems from the repo-agent-readiness and workflow-hardening track.

Implementation Details
- Add `scripts/check_agent_docs.py` to validate canonical files, required routes, retired terms, Markdown links, and inline local paths.
- Run the checker from `scripts/doctor.sh`, route `AGENTS.md` to `agents/QUALITY.md`, and add focused regression tests.
- This changes only agent documentation and local verification tooling; it does not cross into frontend or backend product behavior.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; it runs only in local and CI verification.
- [x] Are there SSRF or error-leakage risks in new external calls? No external calls were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is unchanged.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Not applicable; learner UI is unchanged.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; graph behavior is unchanged.
- [x] Is the active cognitive target explicitly clear to the user? Not applicable; learner UI is unchanged.

Branch: feat/agent-doc-integrity
Base: main
Diff summary: 4 files changed; add a deterministic agent-doc checker, doctor integration, one AGENTS route, and focused tests.
