### PR TITLE
[codex] Make repair handoff truthful and alive

### DIFF
--- a/docs/product/spec.md
+++ b/docs/product/spec.md
@@ -146,13 +146,17 @@ the concept page renders a post-reveal comparison on the same surface before
 expanding the full route margin. This comparison may show the learner's draft,
 the same-entry study note, and named gaps when recorded. It must not show
 score/tier/band, diagnose the learner, reveal future entries, or count as graph
-truth. The normal comparison-exit action is `Keep working`, which writes
+truth. The normal comparison-exit action is `Return to route`, which writes
 UI-only acknowledgement state so return/reload can restore the expanded
 workspace; it does not append training evidence or imply progress. The repair
-branch is the exception: it suppresses `Keep working`, shows the repair panel,
-and only after a repair is saved offers `Pressure-check this link`. Saving the
-repair may also expand the workspace, but neither the repair nor the gap drill
-mutates graph state or records training evidence.
+branch is the exception: it suppresses that exit, shows the repair panel, and
+after a repair is saved renders an interleaving bridge. If a later room is
+genuinely ready under the existing training derivation, that room is the
+primary suggestion; otherwise a short break is primary. A break remains visible
+when a room is suggested, while `Pressure-check this link` stays behind
+progressive disclosure as graph-neutral fresh practice. Saving the repair,
+following the suggestion, taking a break, and pressure-checking do not mutate
+graph truth or record new reconstruction evidence.
 
 ---
 

--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -145,7 +145,7 @@ body.antigravity-theme .library-kicker {
   background: rgba(144, 103, 198, 0.10);
   border: 1px solid rgba(144, 103, 198, 0.22);
   color: var(--ag-violet);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -314,7 +314,7 @@ body.antigravity-theme .library-card-pill {
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.02em;
   border-radius: 999px;
@@ -616,7 +616,7 @@ body.antigravity-theme .settings-page-kicker {
   background: rgba(144, 103, 198, 0.10);
   border: 1px solid rgba(144, 103, 198, 0.22);
   color: var(--ag-violet);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1072,7 +1072,7 @@ body.antigravity-theme .desk-ready-filter__count {
   border-radius: 999px;
   background: color-mix(in srgb, var(--text-muted) 12%, transparent);
   color: inherit;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -1186,7 +1186,7 @@ body.antigravity-theme .desk-due-selection__copy {
 
 body.antigravity-theme .desk-due-selection__kicker {
   margin: 0 0 4px;
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -22,6 +22,32 @@
 /* ── 3. Base elements (typography, buttons, controls) ─────── */
 *, *::before, *::after { box-sizing:border-box; margin:0; padding:0; }
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-synthesis: none;
+}
+
+::selection {
+  background: var(--accent-soft-strong);
+  color: var(--text-strong);
+}
+
+a {
+  text-underline-position: from-font;
+  text-decoration-thickness: from-font;
+  text-decoration-skip-ink: auto;
+}
+
+:is(h1, h2, h3, h4) {
+  overflow-wrap: break-word;
+  text-wrap: balance;
+}
+
+:is(p, li, blockquote) {
+  overflow-wrap: break-word;
+}
+
 [hidden] {
   display: none !important;
 }
@@ -37,6 +63,7 @@ body {
   align-items: center;
   justify-content: center;
   min-height: 100vh;
+  font-optical-sizing: auto;
   transition: background-color var(--theme-transition-ms) var(--theme-transition-ease);
 }
 
@@ -112,14 +139,22 @@ p.desc {
 .row      { display:flex; gap:10px; }
 
 button {
-  flex:1; padding:12px 16px; border:none; border-radius:var(--radius-btn);
+  flex:1; min-height:40px; padding:12px 16px; border:none; border-radius:var(--radius-btn);
   font-family:var(--font-body); font-size:var(--text-sm); font-weight:600; cursor:pointer;
   background-color:var(--primary-fill); color:var(--text-on-primary); letter-spacing:0.2px;
-  transition: all 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+  user-select:none;
+  transition:
+    background-color 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    scale 0.15s ease-out,
+    transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
   box-shadow: var(--accent-shadow-sm);
 }
 button:hover:not(:disabled) { opacity: 0.95; transform: translateY(-1px); box-shadow: var(--accent-shadow-md); }
-button:active:not(:disabled) { transform: scale(0.97); opacity: 0.9; box-shadow: var(--accent-shadow-sm); }
+button:active:not(:disabled) { scale: 0.96; opacity: 0.9; box-shadow: var(--accent-shadow-sm); }
 button:disabled { background-color:var(--locked); cursor:not-allowed; transform:none; opacity:1; }
 .btn-fail { background-color:var(--danger); }
 .btn-pass { background-color:var(--success); }
@@ -155,6 +190,9 @@ button:disabled { background-color:var(--locked); cursor:not-allowed; transform:
 /* Touch target minimum — mobile only */
 @media (max-width: 899px) {
   button { min-height: 48px; }
+  input,
+  select,
+  textarea { font-size: max(1rem, var(--text-base)); }
 }
 
 /* Screen-reader-only utility (visually hidden, kept in the a11y tree). */
@@ -172,6 +210,14 @@ button:disabled { background-color:var(--locked); cursor:not-allowed; transform:
   font-size:22px; font-family:'SF Mono','Fira Code',monospace;
   font-weight:700; letter-spacing:2px; color:var(--primary);
   margin:8px 0 0; display:none; transition:color var(--theme-transition-ms) var(--theme-transition-ease);
+}
+
+#timer-display,
+.desk-index-count,
+.drill-chamber__history-count,
+.concept-page-b2__route-index,
+.concept-constellation__index {
+  font-variant-numeric: tabular-nums;
 }
 
 .drawer-toggle {

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -46,6 +46,7 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   gap: 8px;
   flex: none;
   width: auto;
+  min-height: 44px;
   padding: 7px 10px;
   border: 1px solid var(--accent-soft-strong);
   border-radius: 999px;
@@ -55,11 +56,12 @@ body[data-drawer-open="true"] #backdrop { opacity:1; pointer-events:all; }
   cursor: pointer;
   line-height: 1;
   opacity: 0.72;
-  transform: scale(0.72);
+  transform: scale(0.92);
   transform-origin: bottom right;
   transition:
     transform var(--duration-standard, 220ms) var(--ease-standard),
     opacity var(--duration-standard, 220ms) var(--ease-standard),
+    scale var(--duration-micro, 140ms) ease-out,
     box-shadow var(--duration-standard, 220ms) var(--ease-standard),
     border-color var(--duration-standard, 220ms) var(--ease-standard);
 }
@@ -151,7 +153,7 @@ html[data-motion="reduced"] .theme-toggle {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-height: 38px;
+  min-height: 40px;
   padding: 0 14px;
   border-radius: 999px;
   border: 1px solid var(--border-subtle);
@@ -163,7 +165,7 @@ html[data-motion="reduced"] .theme-toggle {
   text-decoration: none;
   cursor: pointer;
   line-height: 1;
-  transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+  transition: transform 140ms ease, scale 140ms ease-out, border-color 140ms ease, box-shadow 140ms ease;
 }
 
 #auth-login-link::before {
@@ -193,7 +195,7 @@ html[data-motion="reduced"] .theme-toggle {
   border: 1px solid var(--border);
   background: var(--surface-nested);
   color: var(--text-sub);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -267,7 +269,8 @@ html[data-motion="reduced"] .theme-toggle {
     box-shadow var(--duration-standard, 220ms) var(--ease-standard),
     background var(--duration-standard, 220ms) var(--ease-standard),
     border-color var(--duration-standard, 220ms) var(--ease-standard),
-    opacity var(--duration-standard, 220ms) var(--ease-standard);
+    opacity var(--duration-standard, 220ms) var(--ease-standard),
+    scale var(--duration-micro, 140ms) ease-out;
 }
 .hero-primary-action::before {
   content: "";
@@ -317,7 +320,7 @@ html[data-motion="reduced"] .theme-toggle {
 
 .hero-eyebrow {
   font-family: var(--font-display, inherit);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -400,7 +403,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
 
   /* #9 — Library card touch feedback */
   .library-card-vault:active {
-    transform: scale(0.97);
+    transform: scale(0.96);
     transition-duration: 0.08s;
   }
 }
@@ -495,7 +498,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
 
 .sidebar-section-label {
   font-family:var(--font-display);
-  font-size:10px; font-weight:700; letter-spacing:0.04em;
+  font-size:var(--text-xs); font-weight:700; letter-spacing:0.04em;
   text-transform:none; color:var(--text-sub);
   padding:8px 20px 4px; flex-shrink:0; display:block;
 }
@@ -516,7 +519,11 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   padding:0; border-radius:8px;
   width:40px; height:40px; min-height:40px;
   display:inline-flex; align-items:center; justify-content:center;
-  flex:none; transition:all 0.15s;
+  flex:none;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    scale 0.15s ease-out;
 }
 .drawer-close svg {
   width: 18px;
@@ -585,7 +592,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   opacity:0;
   pointer-events:none;
   font-size:16px; line-height:1; padding:0; border-radius:10px;
-  flex:none; width:36px; height:36px; min-height:36px;
+  flex:none; width:40px; height:40px; min-height:40px;
   display:inline-flex; align-items:center; justify-content:center;
   transform:scale(0.94);
   transition:
@@ -593,6 +600,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
     color 0.15s,
     background-color 0.15s,
     border-color 0.15s,
+    scale 0.15s ease-out,
     transform 0.15s;
 }
 .concept-actions .material-symbols-outlined {
@@ -802,7 +810,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   margin-bottom: 28px;
 }
 .library-kicker {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -854,7 +862,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   line-height: 1.3;
 }
 .library-card-state {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -899,7 +907,7 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   box-shadow: var(--shadow-raised);
 }
 .library-card-kicker {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.02em;
   color: var(--primary);
@@ -995,8 +1003,8 @@ body[data-theme="dark"] .hero-primary-action:disabled {
   margin-top:8px;
 }
 .paste-clipboard-btn {
-  background:none; border:none; cursor:pointer; padding:0;
-  font-size:11px; font-weight:600; color:var(--text-sub);
+  background:none; border:none; cursor:pointer; padding:0 8px;
+  min-height:40px; font-size:var(--text-xs); font-weight:600; color:var(--text-sub);
   text-align:left; width:auto; flex:none; letter-spacing:0;
   transition:color 0.15s, opacity 0.15s;
 }
@@ -1294,9 +1302,15 @@ html[data-motion="reduced"] .creation-source-panel-attach {
   cursor: pointer;
   width: max-content;
   max-width: max-content;
+  min-height: 40px;
   white-space: nowrap;
   box-shadow: var(--accent-shadow-sm);
-  transition: all 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition:
+    background-color 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    scale 0.15s ease-out,
+    transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1308,7 +1322,7 @@ html[data-motion="reduced"] .creation-source-panel-attach {
   box-shadow: var(--accent-shadow-md);
 }
 .btn-start-drill:active:not(:disabled) {
-  transform: scale(0.97);
+  scale: 0.96;
   box-shadow: var(--accent-shadow-sm);
 }
 
@@ -1320,14 +1334,20 @@ html[data-motion="reduced"] .creation-source-panel-attach {
   color: var(--text-on-primary);
   border: 1px solid var(--accent-border-strong);
   border-radius: 50%;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   box-shadow: var(--accent-shadow-sm);
-  transition: all 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition:
+    background-color 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.2, 0.8, 0.2, 1),
+    scale 0.15s ease-out,
+    transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
   z-index: 100;
   transform: translate(-50%, -100%);
 }
@@ -1338,7 +1358,8 @@ html[data-motion="reduced"] .creation-source-panel-attach {
   transform: translate(-50%, -100%) translateY(-2px) scale(1.05);
 }
 .btn-consolidate-float:active {
-  transform: translate(-50%, -100%) translateY(1px) scale(0.95);
+  scale: 0.96;
+  transform: translate(-50%, -100%) translateY(1px);
 }
 .btn-consolidate-float.show {
   animation: popInBtn 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
@@ -2219,15 +2240,18 @@ body[data-theme="dark"] .hero-single-input__file-note[data-tone="error"] {
   padding: 0;
   line-height: 1;
   border-radius: 50%;
-  flex: 0 0 32px;
-  width: 32px;
-  height: 32px;
-  min-height: 32px;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
   box-shadow: none;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 140ms ease;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    scale 140ms ease-out;
 }
 
 .modal-close svg {

--- a/public/css/concept-page.css
+++ b/public/css/concept-page.css
@@ -13,7 +13,7 @@
 .concept-page-b2 .eyebrow,
 .concept-strip .eyebrow {
   font-family: ui-monospace, monospace;
-  font-size: 10px;
+  font-size: var(--text-xs);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent-secondary);
@@ -88,7 +88,14 @@
 .concept-strip__edge.is-active { stroke: rgba(144, 103, 198, 0.55); stroke-width: 1.6; }
 [data-theme="dark"] .concept-strip__edge { stroke: rgba(215, 190, 255, 0.22); }
 [data-theme="dark"] .concept-strip__edge.is-active { stroke: rgba(215, 190, 255, 0.55); }
-.concept-strip__node circle { transition: all 240ms cubic-bezier(0.16, 1, 0.3, 1); }
+.concept-strip__node circle {
+  transition:
+    fill 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    filter 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    r 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    stroke 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    stroke-width 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
 .concept-strip__node--ready circle { fill: rgba(144, 103, 198, 0.10); stroke: rgba(144, 103, 198, 0.46); }
 .concept-strip__node--locked circle { fill: rgba(36, 32, 56, 0.18); stroke: rgba(36, 32, 56, 0.10); stroke-dasharray: 3 2; }
 .concept-strip__node--primed circle { fill: var(--accent-primary, #9067C6); stroke: var(--accent-primary, #9067C6); }
@@ -105,7 +112,7 @@
 [data-theme="dark"] .concept-strip__node--solidified circle { fill: rgba(77, 186, 138, 0.86); stroke: rgba(77, 186, 138, 0.96); }
 .concept-strip__node text {
   font-family: 'Inter', sans-serif;
-  font-size: 9px;
+  font-size: var(--text-xs);
   text-anchor: middle;
   letter-spacing: 0.04em;
   fill: var(--text-muted);
@@ -274,7 +281,7 @@
 .concept-constellation__index {
   fill: rgba(215, 190, 255, 0.78);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 820;
   letter-spacing: 0.14em;
 }
@@ -311,6 +318,10 @@
 .concept-constellation__node[data-state="locked"] {
   cursor: default;
 }
+.concept-constellation__node.is-active,
+.concept-constellation__node.is-active .concept-constellation__dot {
+  cursor: default;
+}
 .concept-constellation__node[data-state="locked"] .concept-constellation__dot {
   fill: rgba(var(--cream-50-rgb), 0.035);
   stroke: rgba(var(--mauve-200-rgb), 0.42);
@@ -334,7 +345,7 @@
   stroke: rgba(195, 239, 221, 0.70);
 }
 .concept-constellation__node:focus-visible .concept-constellation__halo,
-.concept-constellation__node:hover:not([data-state="locked"]) .concept-constellation__halo {
+.concept-constellation__node:hover:not([data-state="locked"]):not(.is-active) .concept-constellation__halo {
   opacity: 0.92;
   transform: scale(1.18);
 }
@@ -397,7 +408,7 @@
   margin-top: 14px;
 }
 .concept-constellation__return {
-  min-height: 38px;
+  min-height: 40px;
   appearance: none;
   border: 1px solid rgba(var(--violet-600-rgb), 0.16);
   border-radius: 999px;
@@ -407,6 +418,479 @@
   padding: 0 14px;
   cursor: pointer;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.20);
+}
+
+/* Post-repair bridge: the constellation becomes a light drafting surface.
+   Motion indicates a navigation suggestion only; it never upgrades evidence. */
+.concept-page-b2__doc.concept-page-b2__doc--post-repair {
+  width: 100%;
+  max-width: none;
+  margin-top: 4px;
+  padding-inline: 0;
+}
+.concept-page-b2__doc--post-repair > .concept-page-b2__gestalt {
+  display: block;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.concept-page-b2__doc--post-repair .concept-page-b2__route,
+.concept-page-b2__doc--post-repair .concept-page-b2__active-entry,
+.concept-page-b2__doc--post-repair .concept-page-b2__nearby {
+  display: none;
+}
+.concept-page-b2__doc--post-repair .concept-page-b2__work {
+  width: 100%;
+  max-width: none;
+}
+.concept-page-b2__doc--post-repair .concept-page-b2__context-dock {
+  max-width: none;
+  margin: 0 0 18px;
+}
+.concept-page-b2__doc--post-repair .concept-page-b2__threshold {
+  margin-bottom: 0;
+}
+.concept-post-repair-host {
+  width: calc(100% + 80px);
+  margin: 18px -40px 0;
+}
+.concept-constellation__shell.concept-constellation__shell--bridge {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(380px, 0.98fr);
+  min-height: 642px;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: var(--cream-50);
+  color: var(--ink-900);
+  box-shadow: none;
+}
+.concept-constellation__shell.concept-constellation__shell--bridge::before {
+  display: none;
+}
+.concept-post-repair__canvas {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  padding: 32px 24px 18px;
+  border-right: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--cream-50) 94%, var(--lavender-500) 6%);
+}
+.concept-post-repair__canvas > .eyebrow {
+  position: absolute;
+  z-index: 3;
+  top: 30px;
+  left: 30px;
+  color: var(--text-muted);
+}
+.concept-constellation__shell--bridge .concept-constellation__svg {
+  width: 100%;
+  min-height: 575px;
+  margin: 10px auto 0;
+  color: var(--violet-600);
+  overflow: visible;
+}
+.concept-constellation__shell--bridge .concept-constellation__star {
+  fill: rgba(var(--mauve-200-rgb), 0.32);
+}
+.concept-constellation__shell--bridge .concept-constellation__edge {
+  stroke: rgba(var(--mauve-200-rgb), 0.62);
+  stroke-width: 1.05;
+  stroke-dasharray: 2 11;
+  filter: none;
+}
+.concept-constellation__shell--bridge .concept-constellation__edge.is-lit {
+  stroke: rgba(var(--ink-900-rgb), 0.34);
+  stroke-width: 1.35;
+  stroke-dasharray: none;
+  filter: none;
+}
+.concept-constellation__shell--bridge .concept-constellation__edge.is-suggested {
+  stroke: rgba(var(--violet-600-rgb), 0.58);
+  stroke-width: 1.7;
+  stroke-dasharray: 7 12;
+  filter: drop-shadow(0 0 4px rgba(var(--violet-600-rgb), 0.16));
+  animation: concept-bridge-path 2.2s linear infinite;
+}
+.concept-constellation__shell--bridge .concept-constellation__label {
+  fill: rgba(var(--ink-900-rgb), 0.84);
+  stroke: rgba(var(--cream-50-rgb), 0.94);
+  stroke-width: 6px;
+  font-size: 14px;
+  font-weight: 720;
+}
+.concept-constellation__shell--bridge .concept-constellation__node.is-active .concept-constellation__label {
+  fill: rgba(var(--ink-900-rgb), 0.84);
+}
+.concept-constellation__shell--bridge .concept-constellation__index {
+  fill: rgba(var(--ink-900-rgb), 0.54);
+}
+.concept-constellation__shell--bridge .concept-constellation__bridge-role {
+  fill: var(--violet-600);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 780;
+  letter-spacing: 0.02em;
+  paint-order: stroke;
+  stroke: rgba(var(--cream-50-rgb), 0.96);
+  stroke-width: 4px;
+}
+.concept-constellation__shell--bridge .concept-constellation__halo {
+  fill: rgba(var(--violet-600-rgb), 0.08);
+}
+.concept-constellation__shell--bridge .concept-constellation__dot {
+  fill: var(--cream-50);
+  stroke: rgba(var(--mauve-200-rgb), 0.86);
+  filter: none;
+}
+.concept-constellation__shell--bridge .concept-constellation__facet {
+  stroke: rgba(var(--ink-900-rgb), 0.26);
+}
+.concept-constellation__shell--bridge .concept-constellation__node[data-state="locked"] .concept-constellation__dot {
+  fill: rgba(var(--cream-50-rgb), 0.72);
+  stroke: rgba(var(--mauve-200-rgb), 0.68);
+}
+.concept-constellation__shell--bridge .concept-constellation__node[data-state="locked"] .concept-constellation__label {
+  fill: rgba(var(--ink-900-rgb), 0.42);
+}
+.concept-constellation__shell--bridge .concept-constellation__node.is-active .concept-constellation__dot {
+  fill: var(--violet-600);
+  stroke: var(--cream-50);
+  filter: drop-shadow(0 0 9px rgba(var(--violet-600-rgb), 0.26));
+}
+.concept-constellation__shell--bridge .concept-constellation__node.is-suggested .concept-constellation__dot {
+  fill: var(--cream-50);
+  stroke: var(--violet-600);
+  stroke-width: 2.3;
+  filter: drop-shadow(0 0 8px rgba(var(--violet-600-rgb), 0.20));
+}
+.concept-constellation__shell--bridge .concept-constellation__node.is-suggested .concept-constellation__halo {
+  opacity: 0.78;
+  transform: scale(1.2);
+}
+.concept-constellation__shell--bridge .concept-constellation__node.is-active .concept-constellation__halo {
+  animation: concept-bridge-breathe 3.2s ease-in-out infinite;
+}
+.concept-constellation__shell--bridge .concept-constellation__node.is-suggested .concept-constellation__halo {
+  animation: concept-bridge-beacon 2.4s ease-in-out infinite;
+}
+.concept-constellation__shell--bridge .concept-constellation__node:focus-visible .concept-constellation__dot,
+.concept-constellation__shell--bridge .concept-constellation__node:hover:not([data-state="locked"]):not(.is-active) .concept-constellation__dot {
+  stroke: var(--violet-600);
+  stroke-width: 2.6;
+}
+.concept-post-repair__rail {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 34px 36px 30px;
+  background: color-mix(in srgb, var(--cream-50) 97%, var(--lavender-500) 3%);
+  color: var(--ink-900);
+  outline: none;
+}
+.concept-post-repair__rail:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--violet-600);
+}
+.concept-post-repair__truth {
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.concept-post-repair__truth .eyebrow,
+.concept-post-repair__next .eyebrow {
+  color: var(--primary-fill-hover);
+}
+.concept-post-repair__truth h3 {
+  max-width: 12ch;
+  margin: 14px 0 12px;
+  color: var(--ink-900);
+  font-family: var(--font-display);
+  font-size: clamp(31px, 3vw, 43px);
+  font-weight: 720;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+}
+.concept-post-repair__truth p,
+.concept-post-repair__next p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.concept-post-repair__next {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 32px 0 24px;
+}
+.concept-post-repair__next h4 {
+  margin: 14px 0 16px;
+  color: var(--ink-900);
+  font-family: var(--font-display);
+  font-size: clamp(27px, 2.4vw, 36px);
+  font-weight: 720;
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+}
+.concept-post-repair__primary {
+  display: inline-flex;
+  width: auto;
+  max-width: 100%;
+  min-height: 44px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 11px;
+  margin-top: 20px;
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 10px;
+  background: rgba(var(--white-rgb), 0.58);
+  color: var(--primary-readable);
+  box-shadow: var(--ui-shadow-border, 0 0 0 1px rgba(var(--ink-900-rgb), 0.08));
+  font: 720 13px/1.2 var(--font-body);
+  text-align: left;
+  white-space: normal;
+  cursor: pointer;
+  transition:
+    background-color 170ms ease-out,
+    box-shadow 170ms ease-out,
+    color 170ms ease-out,
+    scale 150ms ease-out,
+    transform 170ms ease-out;
+}
+.concept-post-repair__primary::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
+  border: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition:
+    background-color 170ms ease-out,
+    transform 170ms ease-out;
+}
+.concept-post-repair__primary:hover,
+.concept-post-repair__primary:focus-visible {
+  background: rgba(var(--violet-600-rgb), 0.10);
+  color: var(--primary-fill-hover);
+  box-shadow:
+    var(--ui-shadow-border, 0 0 0 1px rgba(var(--ink-900-rgb), 0.08)),
+    0 8px 20px rgba(var(--violet-600-rgb), 0.10);
+  transform: translateY(-1px);
+  outline: none;
+}
+.concept-post-repair__primary:hover::before,
+.concept-post-repair__primary:focus-visible::before {
+  background: currentColor;
+  transform: rotate(45deg) scale(0.78);
+}
+.concept-post-repair__break {
+  display: inline-flex;
+  width: auto;
+  min-height: 44px;
+  align-items: center;
+  margin-top: 4px;
+  padding: 8px 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-muted);
+  font: 600 13px/1.3 var(--font-body);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 150ms ease-out, scale 150ms ease-out;
+}
+.concept-post-repair__break:hover,
+.concept-post-repair__break:focus-visible,
+.concept-post-repair__break:active {
+  color: var(--violet-600);
+  box-shadow: none;
+  transform: none;
+  outline: none;
+}
+.concept-post-repair__break:hover,
+.concept-post-repair__break:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+.concept-post-repair__break:active {
+  scale: 0.96;
+}
+.concept-post-repair__break--standalone {
+  margin-top: 18px;
+  padding-inline: 12px;
+  border-radius: 8px;
+  background: rgba(var(--violet-600-rgb), 0.08);
+  color: var(--primary-readable);
+}
+.concept-post-repair__options {
+  border-top: 1px solid var(--border-subtle);
+}
+.concept-post-repair__options summary {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-muted);
+  font: 700 14px/1.2 var(--font-body);
+  cursor: pointer;
+  list-style: none;
+}
+.concept-post-repair__options summary::-webkit-details-marker {
+  display: none;
+}
+.concept-post-repair__options summary::after {
+  content: "+";
+  color: var(--violet-600);
+  font-size: 20px;
+  font-weight: 500;
+}
+.concept-post-repair__options[open] summary::after {
+  content: "−";
+}
+.concept-post-repair__options > button {
+  width: 100%;
+  min-height: 54px;
+  margin: 0 0 10px;
+  padding: 11px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(var(--cream-50-rgb), 0.72);
+  color: rgba(var(--ink-900-rgb), 0.84);
+  text-align: left;
+  cursor: pointer;
+}
+.concept-post-repair__options > button strong,
+.concept-post-repair__options > button span {
+  display: block;
+}
+.concept-post-repair__options > button strong {
+  font: 720 13px/1.3 var(--font-body);
+}
+.concept-post-repair__options > button span {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.concept-post-repair__options > button:hover,
+.concept-post-repair__options > button:focus-visible {
+  border-color: rgba(var(--violet-600-rgb), 0.46);
+  outline: none;
+}
+.concept-post-repair__rail footer {
+  margin-top: auto;
+  padding-top: 24px;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+}
+
+@keyframes concept-bridge-path {
+  to { stroke-dashoffset: -38; }
+}
+@keyframes concept-bridge-breathe {
+  0%, 100% { opacity: 0.66; transform: scale(1.08); }
+  50% { opacity: 1; transform: scale(1.27); }
+}
+@keyframes concept-bridge-beacon {
+  0%, 100% { opacity: 0.5; transform: scale(1.05); }
+  50% { opacity: 0.92; transform: scale(1.3); }
+}
+
+@media (max-width: 980px) {
+  .concept-page-b2__doc.concept-page-b2__doc--post-repair {
+    padding-inline: 20px;
+  }
+  .concept-post-repair-host {
+    width: auto;
+    margin-inline: 0;
+  }
+  .concept-constellation__shell.concept-constellation__shell--bridge {
+    grid-template-columns: 1fr;
+  }
+  .concept-post-repair__canvas {
+    min-height: 390px;
+    padding: 22px 14px 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .concept-post-repair__canvas > .eyebrow {
+    top: 20px;
+    left: 22px;
+  }
+  .concept-constellation__shell--bridge .concept-constellation__svg {
+    min-height: 390px;
+    margin: 0;
+    transform: none;
+  }
+  .concept-post-repair__rail {
+    min-height: 520px;
+    padding: 28px 28px 24px;
+  }
+}
+
+@media (max-width: 520px) {
+  .concept-page-b2__doc.concept-page-b2__doc--post-repair {
+    margin-top: 0;
+    padding-inline: 16px;
+  }
+  .concept-page-b2__doc--post-repair .concept-page-b2__context-dock {
+    margin-bottom: 6px;
+  }
+  .concept-post-repair-host {
+    width: calc(100% + 32px);
+    margin: 0 -16px;
+  }
+  .concept-constellation__shell.concept-constellation__shell--bridge {
+    min-height: 0;
+  }
+  .concept-post-repair__canvas {
+    min-height: 0;
+    padding-inline: 4px;
+  }
+  .concept-constellation__shell--bridge .concept-constellation__svg {
+    height: 210px;
+    min-height: 210px;
+    transform: scale(1.55);
+    transform-origin: 50% 52%;
+  }
+  .concept-constellation__shell--bridge .concept-constellation__label {
+    font-size: 16px;
+    stroke-width: 7px;
+  }
+  .concept-post-repair__rail {
+    min-height: 0;
+    padding: 24px 20px calc(28px + env(safe-area-inset-bottom));
+  }
+  .concept-post-repair__truth {
+    padding-bottom: 16px;
+  }
+  .concept-post-repair__truth h3 {
+    max-width: 13ch;
+    margin: 10px 0 8px;
+    font-size: 34px;
+  }
+  .concept-post-repair__next {
+    padding: 12px 0;
+  }
+  .concept-post-repair__next h4 {
+    margin: 8px 0;
+    font-size: 25px;
+    line-height: 1;
+  }
+  .concept-post-repair__next p {
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .concept-post-repair__primary {
+    margin-top: 12px;
+  }
+  .concept-post-repair__rail footer {
+    margin-top: 18px;
+  }
 }
 [data-theme="dark"] .concept-view-switch {
   background: rgba(255, 255, 255, 0.055);
@@ -511,7 +995,7 @@
 .concept-page-b2__route-index {
   padding-top: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--text-xs);
   letter-spacing: 0.12em;
   color: var(--accent-secondary);
 }
@@ -699,6 +1183,33 @@
   font-size: 16px;
   line-height: 1.48;
 }
+.concept-page-b2__repair--saved {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 8px 24px;
+  max-width: 620px;
+  margin: 8px 0 28px;
+  padding: 22px 24px;
+  border-left: 0;
+  border: 1px solid rgba(var(--violet-600-rgb), 0.16);
+  border-radius: 8px;
+  background: rgba(var(--paper-0-rgb), 0.42);
+}
+.concept-page-b2__repair--saved h3 {
+  grid-column: 1;
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.25;
+}
+.concept-page-b2__repair-context {
+  grid-column: 1;
+  max-width: 60ch;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.48;
+}
 .concept-page-b2__saved-repair {
   margin: 0 0 14px;
   padding-left: 14px;
@@ -716,6 +1227,29 @@
   color: var(--text-strong);
   font-size: 15px;
   line-height: 1.5;
+}
+.concept-page-b2__repair--saved .concept-page-b2__repair-attempt {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  width: auto;
+  min-height: 44px;
+  margin: 0;
+  border-radius: 999px;
+  box-shadow: none;
+}
+
+@media (max-width: 620px) {
+  .concept-page-b2__repair--saved {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+
+  .concept-page-b2__repair--saved .concept-page-b2__repair-attempt {
+    grid-column: 1;
+    grid-row: auto;
+    width: 100%;
+  }
 }
 .concept-page-b2__field {
   display: block;
@@ -964,7 +1498,12 @@
   font-family: inherit; font-size: 14px; font-weight: 600;
   letter-spacing: 0;
   cursor: pointer;
-  transition: all 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition:
+    background-color 220ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 220ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 220ms cubic-bezier(0.16, 1, 0.3, 1),
+    scale 150ms ease-out,
+    transform 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .concept-page-b2__entry-cta:hover {
   background: color-mix(in srgb, var(--accent-primary) 88%, var(--ink-900) 12%);
@@ -972,14 +1511,6 @@
   box-shadow: 0 12px 26px rgba(var(--violet-600-rgb), 0.20);
   transform: translateY(-1px);
 }
-.concept-page-b2__entry-cta::after {
-  content: "\2192";
-  font-size: 16px;
-  transform: translateX(0);
-  transition: transform 220ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-.concept-page-b2__entry-cta:hover::after { transform: translateX(4px); }
-
 .concept-page-b2__nearby {
   margin-top: 80px;
   padding-top: 28px;
@@ -1068,7 +1599,7 @@
 .concept-page-b2__nearby-item:last-child { border-bottom: 0; }
 .concept-page-b2__nearby-num {
   font-family: ui-monospace, monospace;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--accent-secondary);
   letter-spacing: 0.06em;
 }
@@ -1174,14 +1705,18 @@
 
 /* Re-edit sketch affordance */
 .concept-page-b2__threshold-edit {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
   margin-left: 12px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   letter-spacing: 0.04em;
   color: var(--accent-primary);
   text-decoration: none;
   border-bottom: 1px dashed currentColor;
-  padding-bottom: 1px;
+  padding: 0 8px 1px;
   cursor: pointer;
 }
 .concept-page-b2__threshold-edit:hover { color: var(--text-strong); }
@@ -1230,7 +1765,13 @@
   border-radius: 999px;
   padding: 7px 18px;
   cursor: pointer;
-  transition: all 240ms cubic-bezier(0.16, 1, 0.3, 1);
+  min-height: 40px;
+  transition:
+    background-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    scale 150ms ease-out,
+    transform 240ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .concept-page-b2__threshold-cancel {
   background: transparent;
@@ -1276,7 +1817,7 @@
     left: 12px; bottom: 8px; top: auto;
     gap: 8px;
   }
-  .concept-strip__active-name { font-size: 11px; padding: 3px 8px; }
+  .concept-strip__active-name { font-size: var(--text-xs); padding: 3px 8px; }
   .concept-page-b2 .concept-strip__overlay .eyebrow,
   .concept-strip__overlay .eyebrow { padding: 3px 6px; }
 
@@ -1436,6 +1977,14 @@
   .concept-constellation__edge.is-lit {
     animation: none;
   }
+  .concept-constellation__shell--bridge .concept-constellation__edge.is-suggested,
+  .concept-constellation__shell--bridge .concept-constellation__node.is-active .concept-constellation__halo,
+  .concept-constellation__shell--bridge .concept-constellation__node.is-suggested .concept-constellation__halo {
+    animation: none;
+  }
+  .concept-post-repair__primary {
+    transition: none;
+  }
   .concept-constellation__halo,
   .concept-constellation__dot {
     transition: none;
@@ -1560,7 +2109,7 @@
 
 .node-strip-num {
   padding-top: 0;
-  font-size: 9px;
+  font-size: var(--text-xs);
   letter-spacing: 0.08em;
   color: rgba(var(--lavender-500-rgb), 0.82);
 }
@@ -1686,7 +2235,7 @@
   appearance: none;
   flex: 0 1 auto;
   width: 100%;
-  min-height: 0;
+  min-height: 44px;
   border: 0;
   border-radius: 6px;
   background: transparent;
@@ -1699,6 +2248,7 @@
   color: var(--text-muted);
   text-align: left;
   cursor: pointer;
+  transition: scale 150ms ease-out;
 }
 
 .vd-sketch-head .concept-page-b2__threshold-edit {
@@ -1725,7 +2275,15 @@
 }
 
 .vd-sketch-toggle:active {
-  transform: scale(0.98);
+  scale: 0.96;
+}
+
+@media (max-width: 720px) {
+  .concept-constellation__return,
+  .concept-page-b2__threshold-cancel,
+  .concept-page-b2__threshold-save {
+    min-height: 44px;
+  }
 }
 
 .vd-sketch-toggle:focus-visible {

--- a/public/css/drill-chamber.css
+++ b/public/css/drill-chamber.css
@@ -41,11 +41,14 @@
   gap: 12px;
   padding: 0 0 36px;
   font-size: 12px;
-  opacity: 0.78;
+  opacity: 1;
   transition: opacity 240ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .drill-chamber-view:has(.drill-chamber__composer textarea:focus-visible) .drill-chamber__crumb {
-  opacity: 0.30;
+  opacity: 1;
+}
+.drill-chamber-view:has(.drill-chamber__composer textarea:focus-visible) .drill-chamber__crumb > :not(a) {
+  opacity: 0.36;
 }
 .drill-chamber__crumb a {
   text-decoration: none;
@@ -63,7 +66,10 @@
   padding: 12px 16px;
   border-radius: 10px;
   margin-bottom: 64px;
-  transition: all 240ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition:
+    background-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 240ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .drill-chamber__history-summary {
   font-size: 12px;
@@ -78,11 +84,16 @@
   border-radius: 999px;
   padding: 4px 12px;
   font-family: ui-monospace, monospace;
-  font-size: 10px;
+  min-height: 40px;
+  font-size: var(--text-xs, 12px);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 240ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition:
+    background-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    scale 150ms ease-out;
 }
 .drill-chamber__history-expanded {
   display: none;
@@ -103,7 +114,7 @@
 }
 .drill-chamber__history-turn-meta {
   font-family: ui-monospace, monospace;
-  font-size: 10px;
+  font-size: var(--text-xs, 12px);
   letter-spacing: 0;
   text-transform: none;
   margin-bottom: 4px;
@@ -120,6 +131,65 @@
   position: relative;
   padding-left: 24px;
   transition: opacity 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.drill-chamber__beat {
+  display: grid;
+  gap: 6px;
+  margin: 0 0 28px;
+}
+
+.drill-chamber__beat-label,
+.drill-chamber__anchor > span,
+.drill-chamber__bridge > span {
+  color: var(--primary-readable, #70529b);
+  font-family: ui-monospace, monospace;
+  font-size: var(--text-xs, 12px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.drill-chamber__beat-note {
+  color: var(--text-muted, rgba(36, 32, 56, 0.68));
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.drill-chamber__anchor,
+.drill-chamber__bridge {
+  border: 0;
+  border-left: 1px solid var(--accent-border-strong, rgba(144, 103, 198, 0.30));
+  margin: 0 0 26px;
+  padding: 2px 0 2px 16px;
+}
+
+.drill-chamber__anchor p,
+.drill-chamber__bridge p {
+  color: var(--text-muted, rgba(36, 32, 56, 0.68));
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 7px 0 0;
+}
+
+.drill-chamber__bridge p {
+  color: var(--text-strong, #242038);
+  font-size: 17px;
+}
+
+.drill-chamber-view[data-loop-surface="repair"] .drill-chamber__active,
+.drill-chamber-view[data-loop-surface="gap"] .drill-chamber__active,
+.drill-chamber-view[data-loop-surface="repair-ready"] .drill-chamber__active {
+  max-width: 520px;
+}
+
+.drill-chamber-view[data-loop-surface="bridge"] .drill-chamber__question {
+  font-size: 17px;
+  color: var(--text-muted, rgba(36, 32, 56, 0.68));
+}
+
+.drill-chamber-view[data-loop-surface="transfer"] .drill-chamber__active {
+  max-width: 620px;
 }
 .drill-chamber__active::before {
   content: "";
@@ -159,7 +229,7 @@
   display: flex; justify-content: space-between; align-items: center;
   gap: 14px;
   margin-top: 14px;
-  font-size: 11px;
+  font-size: var(--text-xs, 12px);
   letter-spacing: 0;
 }
 .drill-chamber__composer-actions {
@@ -173,6 +243,7 @@
      the send pill stretches to fill the composer-foot flex row. */
   flex: 0 0 auto;
   width: auto;
+  min-height: 40px;
   background: transparent;
   border: 1px solid;
   border-radius: 999px;
@@ -187,7 +258,9 @@
   box-shadow: none;
   transition: color 240ms cubic-bezier(0.16, 1, 0.3, 1),
               border-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
-              background-color 240ms cubic-bezier(0.16, 1, 0.3, 1);
+              background-color 240ms cubic-bezier(0.16, 1, 0.3, 1),
+              scale 150ms ease-out,
+              transform 120ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .drill-chamber__send:hover:not(:disabled) {
   transform: none;
@@ -196,9 +269,9 @@
 .drill-chamber__send[disabled] { opacity: 0.40; cursor: not-allowed; }
 .drill-chamber__voice-button {
   flex: 0 0 auto;
-  width: 34px;
-  height: 34px;
-  min-height: 0;
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
   padding: 0;
   border: 1px solid;
   border-radius: 999px;
@@ -206,7 +279,7 @@
   color: inherit;
   cursor: pointer;
   font-family: ui-monospace, monospace;
-  font-size: 9px;
+  font-size: var(--text-xs, 12px);
   letter-spacing: 0;
   box-shadow: none;
 }
@@ -326,7 +399,7 @@
   color: var(--text-muted, rgba(36, 32, 56, 0.68));
 }
 .drill-chamber__crumb a {
-  color: var(--accent-primary, #9067C6);
+  color: var(--primary-readable, #70529b);
 }
 .drill-chamber__crumb a:hover {
   color: var(--text-strong, #242038);
@@ -420,10 +493,13 @@
 }
 
 [data-theme="dark"] .drill-chamber__crumb { color: rgba(247, 236, 225, 0.48); }
-[data-theme="dark"] .drill-chamber__crumb a { color: rgba(176, 156, 224, 0.78); }
+[data-theme="dark"] .drill-chamber__crumb a { color: var(--primary-readable, #b09ce0); }
 [data-theme="dark"] .drill-chamber__crumb a:hover { color: rgba(247, 236, 225, 0.96); }
 [data-theme="dark"] .drill-chamber__sep { color: rgba(247, 236, 225, 0.18); }
 [data-theme="dark"] .drill-chamber__here { color: rgba(247, 236, 225, 0.92); }
+[data-theme="dark"] .drill-chamber__beat-note,
+[data-theme="dark"] .drill-chamber__anchor p { color: rgba(247, 236, 225, 0.56); }
+[data-theme="dark"] .drill-chamber__bridge p { color: rgba(247, 236, 225, 0.94); }
 
 [data-theme="dark"] .drill-chamber__history {
   background: transparent;
@@ -592,14 +668,17 @@
   justify-content: flex-start;
   max-width: none;
   margin: 0;
-  padding-left: 0;
+  padding-inline-start: 32px;
   border-left: 0;
 }
 
 .concept-page-b2__active-entry .drill-chamber__question {
-  font-size: clamp(22px, 3vw, 28px);
-  line-height: 1.36;
-  margin-bottom: 16px;
+  max-width: 34ch;
+  font-size: 28px;
+  letter-spacing: 0;
+  line-height: 1.2;
+  margin-bottom: 18px;
+  text-wrap: balance;
 }
 
 .concept-page-b2__active-entry .drill-chamber__composer textarea {
@@ -612,7 +691,20 @@
 }
 
 .concept-page-b2__active-entry .drill-chamber__send:active {
-  transform: scale(0.98);
+  transform: scale(0.96);
+}
+
+body.chamber-open #concept-header,
+body.chamber-open .concept-page-b2__context-dock,
+body.chamber-open .concept-page-b2__active-entry > .concept-page-b2__entry-eyebrow,
+body.chamber-open .concept-page-b2__active-entry > .concept-page-b2__entry-title,
+body.chamber-open .concept-page-b2__active-entry > .concept-page-b2__entry-purpose {
+  display: none;
+}
+
+.drill-chamber__voice-button svg {
+  width: 17px;
+  height: 17px;
 }
 
 [data-theme="dark"] .concept-page-b2__active-entry .drill-chamber__history-turn {
@@ -626,6 +718,14 @@
 }
 
 @media (max-width: 720px) {
+  body.chamber-open .concept-page-b2__active-entry {
+    padding-top: 8px;
+  }
+
+  body.chamber-open .concept-page-b2__active-entry .drill-chamber__inner {
+    padding-bottom: calc(108px + env(safe-area-inset-bottom));
+  }
+
   .drill-chamber__inner {
     padding: 24px 20px 78px;
   }
@@ -641,8 +741,21 @@
     align-items: center;
   }
 
+  .concept-page-b2__active-entry .drill-chamber__crumb .drill-chamber__sep,
+  .concept-page-b2__active-entry .drill-chamber__crumb #chamber-concept-name,
+  .concept-page-b2__active-entry .drill-chamber__crumb #chamber-entry-name {
+    display: none;
+  }
+
   .concept-page-b2__active-entry .drill-chamber__active {
     min-height: 220px;
+    padding-inline-start: 22px;
+  }
+
+  .concept-page-b2__active-entry .drill-chamber__question {
+    max-width: none;
+    font-size: 22px;
+    line-height: 1.24;
   }
 
   .drill-chamber__composer-foot {
@@ -664,6 +777,10 @@
   .drill-chamber__voice-button {
     width: 44px;
     height: 44px;
+    min-height: 44px;
+  }
+
+  .drill-chamber__history-toggle {
     min-height: 44px;
   }
 }

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=173'     layer(components);
-@import '../antigravity.css?v=40' layer(legacy);
-@import 'paper.css?v=20'          layer(paper);
+@import '../styles.css?v=177'     layer(components);
+@import '../antigravity.css?v=41' layer(legacy);
+@import 'paper.css?v=22'          layer(paper);

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -131,7 +131,7 @@ body:not([data-map-open="true"]) .map-back-link {
 }
 .main-header-title {
   font-family: var(--font-display);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.02em;
   color: var(--text-sub);
@@ -482,7 +482,7 @@ body:not([data-map-open="true"]) .map-back-link {
   }
 
   .bottom-nav-label {
-    font-size: 10px;
+    font-size: var(--text-xs);
     font-weight: 600;
   }
 
@@ -685,7 +685,7 @@ body:not([data-map-open="true"]) .map-back-link {
   text-align: center; height: 18px;
 }
 .eo-meta-text {
-  font-size: 10px; font-weight: 700;
+  font-size: var(--text-xs); font-weight: 700;
   letter-spacing: 0.16em; text-transform: uppercase;
   color: rgba(var(--cream-50-rgb), 0.36);
   transition: opacity 0.25s ease;
@@ -701,7 +701,7 @@ body:not([data-map-open="true"]) .map-back-link {
   display: flex; justify-content: space-between; align-items: center; padding: 0 2px;
 }
 .eo-progress-label {
-  font-size: 9px; font-weight: 700;
+  font-size: var(--text-xs); font-weight: 700;
   letter-spacing: 0.16em; text-transform: uppercase;
   color: rgba(var(--cream-50-rgb), 0.38);
 }
@@ -793,8 +793,9 @@ body:not([data-map-open="true"]) .map-back-link {
 
 .map-close-btn {
   flex: none;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
   padding: 0;
   background: var(--accent-soft);
   border: none;
@@ -805,7 +806,10 @@ body:not([data-map-open="true"]) .map-back-link {
   align-items: center;
   justify-content: center;
   box-shadow: none;
-  transition: all 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    scale 0.15s ease-out;
 }
 
 .map-close-btn svg {
@@ -833,7 +837,7 @@ body:not([data-map-open="true"]) .map-back-link {
 .map-core-thesis { font-size: 20px; font-weight: 600; color: var(--text); line-height: 1.4; margin-bottom: 16px; font-family: var(--font-display); letter-spacing: -0.3px; }
 
 .map-badges { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
-.map-badge { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700; padding: 4px 10px; border-radius: 12px; text-transform: none; letter-spacing: 0.01em; }
+.map-badge { display: inline-flex; align-items: center; gap: 6px; font-size: var(--text-xs); font-weight: 700; padding: 4px 10px; border-radius: 12px; text-transform: none; letter-spacing: 0.01em; }
 .map-badge.arch { background: var(--accent-soft-strong); color: var(--primary); }
 .map-badge.diff { background: var(--surface-nested); color: var(--text); border: 1px solid var(--border); }
 .map-badge.state { background: var(--surface-nested); color: var(--text); border: 1px solid var(--border); }
@@ -890,7 +894,7 @@ body:not([data-map-open="true"]) .map-back-link {
   background: var(--surface-nested);
   border: 1px solid var(--border);
   color: var(--text-sub);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.02em;
 }
@@ -1115,7 +1119,7 @@ body:not([data-map-open="true"]) .map-back-link {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -1195,7 +1199,7 @@ body:not([data-map-open="true"]) .map-back-link {
 
 .settings-identity-meta {
   display: block;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   letter-spacing: 0.02em;
   margin-top: 2px;

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -23,6 +23,13 @@ body {
   min-height: 100%;
 }
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-synthesis: none;
+  overflow: clip;
+}
+
 body {
   position: relative;
   overflow: hidden;
@@ -33,11 +40,15 @@ body {
     linear-gradient(180deg, #f7ece1, #f2e3d2);
   color: var(--text);
   font-family: var(--font-body);
+  font-optical-sizing: auto;
 }
 
 a {
   color: inherit;
   text-decoration: none;
+  text-underline-position: from-font;
+  text-decoration-thickness: from-font;
+  text-decoration-skip-ink: auto;
 }
 
 button,
@@ -148,6 +159,8 @@ input {
   border-radius: 16px;
   object-fit: cover;
   box-shadow: 0 14px 28px rgba(var(--violet-600-rgb), 0.16);
+  outline: 1px solid oklch(0 0 0 / 0.10);
+  outline-offset: -1px;
 }
 
 .brand-title {
@@ -266,7 +279,12 @@ input {
   box-shadow: inset 0 0 0 1px rgba(var(--violet-600-rgb), 0.32);
   color: var(--text);
   font-weight: 700;
-  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+  user-select: none;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease,
+    scale 150ms ease-out,
+    transform 160ms ease;
 }
 
 .google-button:hover {
@@ -317,7 +335,13 @@ input {
   box-shadow: inset 0 0 0 1px var(--outline-soft);
   color: var(--text);
   font-weight: 700;
-  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
+  user-select: none;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease,
+    scale 150ms ease-out,
+    transform 160ms ease;
 }
 
 .guest-button:hover {
@@ -347,7 +371,13 @@ input {
   color: var(--text-muted);
   font-size: 0.84rem;
   font-weight: 600;
-  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
+  user-select: none;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease,
+    scale 150ms ease-out,
+    transform 160ms ease;
 }
 
 .coffee-button:hover {
@@ -379,9 +409,9 @@ input {
 
 .icon-chip-row .coffee-button,
 .icon-chip-row .discord-link {
-  width: 36px;
-  height: 36px;
-  min-height: 36px;
+  width: 44px;
+  height: 44px;
+  min-height: 44px;
   padding: 0;
   border-radius: var(--radius-pill);
   background: transparent;
@@ -389,8 +419,19 @@ input {
   color: rgba(var(--ink-900-rgb), 0.68);
   flex: 0 0 auto;
   justify-self: auto;
-  transition: transform 120ms ease, box-shadow 120ms ease,
-              background 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease,
+    scale 150ms ease-out,
+    transform 120ms ease;
+}
+
+.google-button:active,
+.guest-button:active,
+.coffee-button:active,
+.discord-link:active {
+  scale: 0.96;
 }
 
 .icon-chip-row .coffee-button:hover,

--- a/public/css/paper.css
+++ b/public/css/paper.css
@@ -342,6 +342,22 @@
   background: rgba(var(--paper-0-rgb), 0.42);
 }
 
+.ignition-view--linear .composer-card__label {
+  display: block;
+  padding: 10px 16px 0;
+  color: var(--primary-readable);
+  font-family: ui-monospace, monospace;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.ignition-view--linear .composer-card__label + .composer-card__field {
+  padding-top: 8px;
+}
+
 .ignition-view--linear #hero-cold-guess-field {
   padding: 10px 16px 0;
   min-height: calc(var(--rule-step) * 4.35);
@@ -431,7 +447,7 @@
   margin: 0;
   max-width: none;
   padding: 0;
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: var(--leading-snug);
 }
 
@@ -567,6 +583,7 @@
   cursor: pointer;
   transition:
     background var(--duration-quick) var(--ease-standard),
+    scale      var(--duration-micro) ease-out,
     transform  var(--duration-micro) var(--ease-standard),
     box-shadow var(--duration-quick) var(--ease-standard);
 }
@@ -778,7 +795,7 @@ body.antigravity-theme #library-view {
 .library-page-title {
   margin: 0 0 var(--space-6);
   color: var(--text-strong);
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-size: var(--text-2xl);
   font-weight: 700;
   line-height: var(--leading-tight);
@@ -1066,6 +1083,171 @@ body.antigravity-theme #library-view {
   }
 }
 
+/* ── Cross-view UI + typography refinement ──────────────────
+   Shared polish from the Better UI / Better Typography pass. Keep this
+   structural: no learner state, graph truth, or route behavior changes. */
+
+body.antigravity-theme {
+  --ui-shadow-border:
+    0 0 0 1px oklch(0 0 0 / 0.06),
+    0 1px 2px -1px oklch(0 0 0 / 0.06),
+    0 2px 4px oklch(0 0 0 / 0.04);
+}
+
+html[data-theme="dark"] body.antigravity-theme {
+  --ui-shadow-border: 0 0 0 1px oklch(1 0 0 / 0.08);
+}
+
+.sidebar-brand-mark {
+  outline: 1px solid oklch(0 0 0 / 0.10);
+  outline-offset: -1px;
+}
+
+html[data-theme="dark"] .sidebar-brand-mark {
+  outline-color: oklch(1 0 0 / 0.10);
+}
+
+.sidebar-section-label,
+.ignition-view--linear .composer-card__label,
+.ignition-view--linear .composer-card__footer .ig-footnote,
+body.antigravity-theme .library-kicker,
+body.antigravity-theme .settings-page-kicker {
+  font-size: var(--text-xs);
+}
+
+.ignition-view--linear .ig-property__action,
+.ignition-view--linear .composer-card__footer .ig-button--linear {
+  min-height: 40px;
+}
+
+.library-section-copy,
+.settings-page-copy,
+.ig-first-use,
+.ig-helper,
+.modal-desc,
+.feedback-rating-copy {
+  text-wrap: pretty;
+}
+
+body.antigravity-theme .settings-page-title {
+  font-family: var(--font-display);
+  font-weight: 650;
+  text-wrap: balance;
+}
+
+body.antigravity-theme .settings-section-heading {
+  font-family: var(--font-body);
+}
+
+body.antigravity-theme .settings-identity-row,
+body.antigravity-theme .settings-display,
+.feedback-modal {
+  border-color: transparent;
+  box-shadow: var(--ui-shadow-border);
+}
+
+body.antigravity-theme .settings-identity-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 8px 14px;
+  transition:
+    background-color 150ms ease-out,
+    border-color 150ms ease-out,
+    color 150ms ease-out,
+    scale 150ms ease-out;
+}
+
+body.antigravity-theme .settings-pill {
+  min-height: 40px;
+  padding: 7px 16px;
+  transition:
+    background-color 150ms ease-out,
+    color 150ms ease-out,
+    scale 150ms ease-out;
+}
+
+body.antigravity-theme .settings-identity-action:active,
+body.antigravity-theme .settings-pill:active:not(:disabled) {
+  scale: 0.96;
+}
+
+body.antigravity-theme .settings-toggle {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  min-height: 44px;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  transition: scale 150ms ease-out;
+}
+
+body.antigravity-theme .settings-toggle::before {
+  content: "";
+  position: absolute;
+  inset: 9px 0 auto;
+  width: 44px;
+  height: 26px;
+  border-radius: 999px;
+  background: rgba(36, 32, 56, 0.14);
+  transition: background-color 250ms ease-out;
+}
+
+html[data-theme="dark"] body.antigravity-theme .settings-toggle::before {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+body.antigravity-theme .settings-toggle::after {
+  top: 12px;
+  left: 3px;
+}
+
+body.antigravity-theme .settings-toggle[aria-checked="true"] {
+  background: transparent;
+  box-shadow: none;
+}
+
+body.antigravity-theme .settings-toggle[aria-checked="true"]::before {
+  background: var(--ag-violet);
+}
+
+body.antigravity-theme .settings-toggle:hover:not(:disabled),
+body.antigravity-theme .settings-toggle:active:not(:disabled) {
+  opacity: 1;
+  scale: 1;
+  transform: none;
+}
+
+@media (max-width: 899px) {
+  .ignition-view--linear .ig-property__action,
+  .ignition-view--linear .composer-card__footer .ig-button--linear {
+    min-height: 44px;
+  }
+
+  .ig-button,
+  .concept-constellation__return,
+  .modal-close,
+  body.antigravity-theme .settings-identity-action,
+  body.antigravity-theme .settings-pill {
+    min-height: 44px;
+  }
+
+  .modal-close {
+    flex-basis: 44px;
+    width: 44px;
+  }
+
+  input,
+  select,
+  textarea,
+  .feedback-rating-input,
+  .modal-textarea {
+    font-size: 1rem;
+  }
+}
+
 /* ── Reduced motion ────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -1088,6 +1270,14 @@ body.antigravity-theme #library-view {
   }
   .composer-card[data-state="locked"],
   .composer-card[data-state="busy"] {
+    transition: none;
+  }
+
+  body.antigravity-theme .settings-identity-action,
+  body.antigravity-theme .settings-pill,
+  body.antigravity-theme .settings-toggle,
+  body.antigravity-theme .settings-toggle::before,
+  body.antigravity-theme .settings-toggle::after {
     transition: none;
   }
 }

--- a/public/css/tokens.css
+++ b/public/css/tokens.css
@@ -48,6 +48,8 @@
 }
 
 :root {
+  font-synthesis: none;
+
   --ink-900:        #242038;
   --violet-600:     #9067c6;
   --lavender-500:   #8d86c9;
@@ -108,9 +110,9 @@
   --font-display: "Geom", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-body:    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 
-  --text-xs:   clamp(0.7rem,  0.65rem + 0.25vw, 0.80rem);
+  --text-xs:   clamp(0.75rem, 0.65rem + 0.25vw, 0.80rem);
   --text-sm:   clamp(0.8rem,  0.75rem + 0.35vw, 0.95rem);
-  --text-base: clamp(0.95rem, 0.85rem + 0.50vw, 1.10rem);
+  --text-base: clamp(1rem,    0.85rem + 0.50vw, 1.10rem);
   --text-lg:   clamp(1.10rem, 1.00rem + 0.60vw, 1.25rem);
   --text-xl:   clamp(1.25rem, 1.10rem + 0.75vw, 1.40rem);
   --text-2xl:  clamp(1.50rem, 1.30rem + 1.00vw, 1.75rem);

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -273,12 +273,13 @@
   --surface-card:     var(--surface-card-theme);
   --surface-nested:   var(--surface-nested-theme);
   /* Typography */
+  font-synthesis: none;
   --font-display:     'Manrope', -apple-system, sans-serif;
   --font-body:        'Inter', -apple-system, sans-serif;
   
-  --text-xs:          clamp(0.7rem, 0.65rem + 0.25vw, 0.8rem);
+  --text-xs:          clamp(0.75rem, 0.65rem + 0.25vw, 0.8rem);
   --text-sm:          clamp(0.8rem, 0.75rem + 0.35vw, 0.95rem);
-  --text-base:        clamp(0.95rem, 0.85rem + 0.5vw, 1.1rem);
+  --text-base:        clamp(1rem, 0.85rem + 0.5vw, 1.1rem);
   --text-lg:          clamp(1.1rem, 1rem + 0.6vw, 1.25rem);
   --text-xl:          clamp(1.25rem, 1.1rem + 0.75vw, 1.4rem);
   --text-2xl:         clamp(1.5rem, 1.3rem + 1vw, 1.75rem);

--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,8 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=191">
-  <link rel="stylesheet" href="/css/drill-chamber.css?v=17">
+  <link rel="stylesheet" href="/css/index.css?v=196">
+  <link rel="stylesheet" href="/css/drill-chamber.css?v=21">
 </head>
 
 <body data-primary-view="desk" data-desk-first-use="true">
@@ -283,9 +283,9 @@
       <div class="ignition-view__inner">
         <header class="ig-header">
           <p class="ig-eyebrow">New session</p>
-          <h1 class="ig-title" id="ignition-title" tabindex="-1">
+          <h2 class="ig-title" id="ignition-title" tabindex="-1">
             What are you trying to explain?
-          </h1>
+          </h2>
           <p class="ig-first-use" id="ignition-first-use">
             Write what you remember first. We'll show what to study — not a summary.
           </p>
@@ -301,12 +301,14 @@
 
         <form class="composer-card composer-card--tall" id="hero-single-input"
               onsubmit="return App.runHeroAction(event)" autocomplete="off">
+          <label class="composer-card__label" for="hero-single-input-field">Topic or question</label>
           <textarea class="composer-card__field composer-card__field--linear"
                     id="hero-single-input-field"
                     rows="2" maxlength="200"
                     placeholder="why vaccines create immune memory"
                     aria-label="Learning goal"
                     aria-describedby="ignition-boundary hero-door-error"></textarea>
+          <label class="composer-card__label" for="hero-cold-guess-field">Your first model</label>
           <textarea class="composer-card__field" id="hero-cold-guess-field"
                     rows="5" maxlength="1200"
                     placeholder="I think…
@@ -332,7 +334,7 @@ I'm fuzzy on…
 
           <footer class="composer-card__footer">
             <p class="ig-footnote" id="ignition-boundary">
-              You'll write first. Answers come after.
+              Add your first model to start.
             </p>
             <button type="submit" class="ig-button ig-button--linear" id="hero-door-submit"
                     disabled aria-label="Start session">Start session</button>
@@ -357,9 +359,9 @@ I'm fuzzy on…
         </p>
         <p class="ig-concept-goal" id="launch-pad-concept-goal" hidden></p>
 
-        <h1 class="ig-title" id="launch-pad-title" tabindex="-1">
+        <h2 class="ig-title" id="launch-pad-title" tabindex="-1">
           What do you already think?
-        </h1>
+        </h2>
 
         <p class="ig-helper">
           Name the parts, guesses, examples, or confusions you have.
@@ -434,8 +436,8 @@ I'm fuzzy on…
   <!-- PDF.js for robust client-side extraction -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 
-  <script src="/js/drill-chamber.js?v=18"></script>
-  <script type="module" src="/js/app.js?v=208"></script>
+  <script src="/js/drill-chamber.js?v=20"></script>
+  <script type="module" src="/js/app.js?v=213"></script>
   <script type="module" src="/js/floating-room-label.js?v=10"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=10"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4964,9 +4964,16 @@ const App = (() => {
     chamber.setComposerEnabled(surface.composerEnabled);
     if (surface.verdict) chamber.appendVerdict?.(surface.verdict);
     if (surface.completionAction) {
-      chamber.setCompletionAction?.(surface.completionAction.label, () => {
+      const actionLabel = surface.completionAction.kind === 'study'
+        ? sedaCompleteCompletionLabel()
+        : surface.completionAction.label;
+      chamber.setCompletionAction?.(actionLabel, () => {
         if (surface.completionAction.kind === 'return') {
           cancelDrill();
+          return;
+        }
+        if (surface.completionAction.kind === 'study') {
+          openStudyAfterVerdict(getActiveConcept()?.id, drillState.node?.id);
           return;
         }
         void requestSedaTurn(surface.completionAction.value, { internal: true });
@@ -5044,7 +5051,7 @@ const App = (() => {
             window.DrillChamber.appendVerdict?.(verdictCopy({ userText, recordable: false }));
           }
         }
-        if (studyReady) {
+        if (studyReady && surface.mode !== 'complete') {
           window.DrillChamber.setCompletionAction?.(
             sedaCompleteCompletionLabel(),
             () => openStudyAfterVerdict(concept.id, drillState.node?.id),

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -160,6 +160,8 @@ const App = (() => {
   const _appendAttempt = trainingStore.appendAttempt.bind(trainingStore);
   const _setStudyRevealed = trainingStore.setStudyRevealed.bind(trainingStore);
   const _appendRepair = trainingStore.appendRepair.bind(trainingStore);
+  const _saveTraining = trainingStore.saveTraining.bind(trainingStore);
+  const _markRepairChecked = trainingStore.markRepairChecked.bind(trainingStore);
   const _setProvenance = trainingStore.setProvenance.bind(trainingStore);
   const _setSketch = trainingStore.setSketch.bind(trainingStore);
   trainingStore.appendAttempt = async (...args) => {
@@ -176,6 +178,17 @@ const App = (() => {
   };
   trainingStore.appendRepair = async (...args) => {
     const result = await _appendRepair(...args);
+    scheduleLearnerStatePush();
+    return result;
+  };
+  trainingStore.saveTraining = async (...args) => {
+    const result = await _saveTraining(...args);
+    scheduleLearnerStatePush();
+    renderDeskDueSurfaces();
+    return result;
+  };
+  trainingStore.markRepairChecked = async (...args) => {
+    const result = await _markRepairChecked(...args);
     scheduleLearnerStatePush();
     return result;
   };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -74,11 +74,14 @@ import {
   runRepairReps,
   runDrillTurn,
 } from './api-client.js?v=2';
-import { visibleSedaPromptFromResponse } from './seda-visible-prompt.js?v=3';
+import {
+  sedaSurfaceFromResponse,
+  visibleSedaPromptFromResponse,
+} from './seda-visible-prompt.js?v=5';
 import {
   projectCompletedSedaRecord,
   projectLatestSedaAttemptEvent,
-} from './seda-evidence-projection.js?v=1';
+} from './seda-evidence-projection.js?v=2';
 import {
   bindSourceLessSedaRoute,
   boundSourceLessSedaNodeId,
@@ -4813,7 +4816,30 @@ const App = (() => {
     handleSystemAction(action);
   }
 
-  async function requestSedaTurn(userText) {
+  function presentSedaSurface(data, { challengePrompt = null } = {}) {
+    const surface = sedaSurfaceFromResponse(data);
+    const chamber = window.DrillChamber;
+    if (!chamber) return surface;
+
+    chamber.setSurface?.(surface.mode, surface);
+    chamber.setQuestion?.(surface.mode === 'challenge' && challengePrompt
+      ? challengePrompt
+      : surface.question);
+    chamber.setComposerEnabled(surface.composerEnabled);
+    if (surface.verdict) chamber.appendVerdict?.(surface.verdict);
+    if (surface.completionAction) {
+      chamber.setCompletionAction?.(surface.completionAction.label, () => {
+        if (surface.completionAction.kind === 'return') {
+          cancelDrill();
+          return;
+        }
+        void requestSedaTurn(surface.completionAction.value, { internal: true });
+      });
+    }
+    return surface;
+  }
+
+  async function requestSedaTurn(userText, { internal = false } = {}) {
     const concept = getActiveConcept();
     if (!concept || !drillState.node || !drillState.sedaSessionId) return;
     const sessionToken = drillState.sessionToken;
@@ -4821,7 +4847,9 @@ const App = (() => {
     drillState.pending = true;
     if (chatInput) chatInput.disabled = true;
     showTypingIndicator();
-    window.DrillChamber?.setLoading?.(true, { checkingAnswer: Boolean(String(userText || '').trim()) });
+    window.DrillChamber?.setLoading?.(true, {
+      checkingAnswer: !internal && Boolean(String(userText || '').trim()),
+    });
 
     const normalizedText = String(userText ?? '');
     const pendingSubmission = drillState.sedaPendingSubmission;
@@ -4837,7 +4865,7 @@ const App = (() => {
       const responseSaved = await saveSedaResponse(concept, drillState.node, data);
       /* c8 ignore start -- session-state storage failure shares the proven idempotent persistence-retry UI. */
       if (!responseSaved) {
-        showSedaPersistenceRetry(normalizedText);
+        showSedaPersistenceRetry(normalizedText, { internal });
         return;
       }
       /* c8 ignore stop */
@@ -4846,49 +4874,45 @@ const App = (() => {
         ? { ok: true, classification: null }
         : await projectSedaAttemptEvent(concept, drillState.node, data);
       if (!projectedAttempt.ok) {
-        showSedaPersistenceRetry(normalizedText);
+        showSedaPersistenceRetry(normalizedText, { internal });
         return;
       }
       drillState.sedaPendingSubmission = null;
       drillState.sedaSessionId = data.sessionId;
       drillState.sedaSessionVersion = sessionVersionFromResponse(data);
       const projectedAttemptClassification = projectedAttempt.classification;
-      const studyReady = data.caseComplete || Boolean(projectedAttemptClassification);
       if (sessionToken !== drillState.sessionToken || !drillState.node) return;
-      const previousPrompt = chamberLastShownQuestion;
-      const promptText = sedaPromptFromResponse(data);
-      const nextPrompt = nextSedaPromptAfterVerdict(promptText, previousPrompt, userText);
-      window.DrillChamber?.appendHistoryTurn('ai', previousPrompt || '');
-      window.DrillChamber?.appendHistoryTurn('learner', normalizedText);
-      drillState.messages.push({ role: 'user', content: userText });
-      drillState.messages.push({ role: 'assistant', content: studyReady ? promptText : nextPrompt });
-      chamberLastShownQuestion = studyReady ? promptText : nextPrompt;
+      const surface = sedaSurfaceFromResponse(data);
+      const studyReady = data.caseComplete || (
+        Boolean(projectedAttemptClassification) && surface.mode === 'unsupported'
+      );
+      if (!internal) drillState.messages.push({ role: 'user', content: normalizedText });
+      drillState.messages.push({ role: 'assistant', content: surface.prompt });
+      chamberLastShownQuestion = surface.prompt;
       drillState.pending = false;
-      drillState.sessionCompletePending = Boolean(studyReady);
+      drillState.sessionCompletePending = Boolean(studyReady || surface.mode === 'settle');
       persistSessionState();
 
       if (window.DrillChamber) {
         window.DrillChamber.setLoading?.(false);
-        if (studyReady) {
+        presentSedaSurface(data);
+        if (!internal && (studyReady || surface.mode === 'gap')) {
           window.DrillChamber.appendVerdict?.(verdictCopy({
             userText,
             sedaComplete: data.caseComplete,
             classification: projectedAttemptClassification || undefined,
           }));
-        } else {
-          window.DrillChamber.swapQuestion(nextPrompt);
-          setTimeout(() => {
-            window.DrillChamber?.appendVerdict?.(verdictCopy({ userText, recordable: false }));
-            window.DrillChamber?.setCompletionAction?.('Keep going', () => {
-              window.DrillChamber?.setComposerEnabled(true);
-            });
-          }, 260);
+        } else if (!internal && surface.mode === 'challenge') {
+          const lastEvent = Array.isArray(data?.events) ? data.events.at(-1) : null;
+          if (lastEvent?.graph_neutral === true && lastEvent?.score_eligible === false) {
+            window.DrillChamber.appendVerdict?.(verdictCopy({ userText, recordable: false }));
+          }
         }
         if (studyReady) {
-          /* c8 ignore next -- completed-loop button behavior is covered by API evidence proof; browser smoke covers active turn routing. */
-          window.DrillChamber.setCompletionAction?.(sedaCompleteCompletionLabel(), () => openStudyAfterVerdict(concept.id, drillState.node?.id));
-        } else {
-          window.DrillChamber.setComposerEnabled(false);
+          window.DrillChamber.setCompletionAction?.(
+            sedaCompleteCompletionLabel(),
+            () => openStudyAfterVerdict(concept.id, drillState.node?.id),
+          );
         }
       }
     } catch (err) {
@@ -4898,17 +4922,17 @@ const App = (() => {
       drillState.pending = false;
       window.DrillChamber?.setLoading?.(false);
       if (err?.status === 409 && err?.body?.error === 'session_conflict') {
-        await reconcileSedaSessionConflict(concept, normalizedText, sessionToken);
+        await reconcileSedaSessionConflict(concept, normalizedText, sessionToken, { internal });
         return;
       }
       console.error(err);
-      showSedaTransportRetry(normalizedText);
+      showSedaTransportRetry(normalizedText, { internal });
       return;
       /* c8 ignore stop */
     }
   }
 
-  function showSedaPersistenceRetry(userText) {
+  function showSedaPersistenceRetry(userText, { internal = false } = {}) {
     drillState.pending = false;
     window.DrillChamber?.setLoading?.(false);
     window.DrillChamber?.appendVerdict?.(
@@ -4916,12 +4940,12 @@ const App = (() => {
     );
     window.DrillChamber?.setCompletionAction?.('Try saving again', () => {
       window.DrillChamber?.setComposerEnabled(false);
-      void requestSedaTurn(userText);
+      void requestSedaTurn(userText, { internal });
     });
-    restoreUnrecordedDraft(userText, { chamber: true });
+    if (!internal) restoreUnrecordedDraft(userText, { chamber: true });
   }
 
-  function showSedaTransportRetry(userText) {
+  function showSedaTransportRetry(userText, { internal = false } = {}) {
     drillState.pending = false;
     window.DrillChamber?.setLoading?.(false);
     window.DrillChamber?.appendVerdict?.(
@@ -4929,22 +4953,22 @@ const App = (() => {
     );
     window.DrillChamber?.setCompletionAction?.('Try sending again', () => {
       window.DrillChamber?.setComposerEnabled(false);
-      void requestSedaTurn(userText);
+      void requestSedaTurn(userText, { internal });
     });
     // Completion actions normally clear the composer. Put the learner's exact
     // draft back after installing the retry action so a network failure never
     // turns visible effort into a blank form.
-    restoreUnrecordedDraft(userText, { chamber: true });
+    if (!internal) restoreUnrecordedDraft(userText, { chamber: true });
   }
 
-  async function reconcileSedaSessionConflict(concept, draft, sessionToken) {
+  async function reconcileSedaSessionConflict(concept, draft, sessionToken, { internal = false } = {}) {
     try {
       const latest = await getSedaSession(drillState.sedaSessionId);
       if (sessionToken !== drillState.sessionToken || !drillState.node) return;
       const responseSaved = await saveSedaResponse(concept, drillState.node, latest);
       /* c8 ignore start -- conflict refresh storage failure reuses the persistence-retry contract. */
       if (!responseSaved) {
-        showSedaPersistenceRetry(draft);
+        showSedaPersistenceRetry(draft, { internal });
         return;
       }
       /* c8 ignore stop */
@@ -4968,19 +4992,17 @@ const App = (() => {
       }
       /* c8 ignore stop */
       const currentPrompt = sedaPromptFromResponse(latest);
-      const question = document.getElementById('chamber-question');
-      if (question) question.textContent = currentPrompt;
       chamberLastShownQuestion = currentPrompt;
-      restoreUnrecordedDraft(draft, { chamber: true });
+      presentSedaSurface(latest);
+      if (!internal) restoreUnrecordedDraft(draft, { chamber: true });
       window.DrillChamber?.appendVerdict?.(
         'Session changed in another tab • Review the current question, then check your draft again.',
       );
-      window.DrillChamber?.setComposerEnabled(true);
     } catch (refreshError) {
       /* c8 ignore start -- refresh transport failure preserves the draft and is covered by the general transport-retry proof. */
       console.error(refreshError);
       if (sessionToken !== drillState.sessionToken) return;
-      restoreUnrecordedDraft(draft, { chamber: true });
+      if (!internal) restoreUnrecordedDraft(draft, { chamber: true });
       window.DrillChamber?.appendVerdict?.(
         'Session changed in another tab • Your draft was not recorded.',
       );
@@ -5411,15 +5433,10 @@ const App = (() => {
               window.DrillChamber.swapQuestion(promptText);
             }
             window.DrillChamber.setLoading?.(false);
-            /* c8 ignore start -- opening an already-complete stored session is covered by API proof, not browser smoke. */
-            if (data.caseComplete) {
-              drillState.sessionCompletePending = true;
-              window.DrillChamber.setCompletionAction?.(sedaCompleteCompletionLabel(), () => openStudyAfterVerdict(activeConcept.id, nodeContext?.id));
-            } else if (initialSedaTurnText) {
+            if (initialSedaTurnText) {
               await requestSedaTurn(initialSedaTurnText);
             } else {
-            /* c8 ignore stop */
-              window.DrillChamber.setComposerEnabled(true);
+              presentSedaSurface(data, { challengePrompt: promptText });
               if (restoredSedaDraftText) {
                 restoreUnrecordedDraft(restoredSedaDraftText, { chamber: true });
                 window.DrillChamber.appendVerdict?.(

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -56,7 +56,7 @@ import { createTrainingStore, TRAINING_SCHEMA_VERSION, TRAINING_STORE_KEY_PREFIX
 import {
   hydrateAndSyncLearnerState,
   pushLocalLearnerState,
-} from './learner-state-sync.js?v=3';
+} from './learner-state-sync.js?v=4';
 import {
   listDueForSpaced,
   dueConceptIdSet,
@@ -851,10 +851,19 @@ const App = (() => {
   }
   function _doorUpdateSubmitState() {
     const submitBtn = document.getElementById('hero-door-submit');
+    const hint = document.getElementById('ignition-boundary');
     if (!submitBtn) return;
     // Mirror the at-cap gate: if at cap, stay disabled regardless of input.
     const atCap = loadConcepts().length >= BOARD_SLOT_COUNT;
-    submitBtn.disabled = atCap || !_doorReady();
+    const ready = _doorReady();
+    submitBtn.disabled = atCap || !ready;
+    if (hint) {
+      hint.textContent = atCap
+        ? 'The board holds nine sessions. Retire one to start another.'
+        : ready
+          ? "You'll write first. Answers come after."
+          : 'Add your first model to start.';
+    }
   }
 
   let _sourcePanelGen = 0;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -27,17 +27,21 @@ import {
 import { createCountdownTimer } from './app-timer.js';
 import {
   deriveConceptEntries,
+  deriveConceptEntryViewState,
   findConceptEntryById,
   getConceptEntryId,
   renderActiveEntryHtml,
   selectInitialConceptEntry,
-} from './concept-page-view.js?v=34';
+} from './concept-page-view.js?v=39';
 import {
   clearComparisonAcknowledgementsForConcept,
   hasComparisonAcknowledgement,
   markComparisonAcknowledged,
 } from './comparison-acknowledgement.js';
-import { renderConceptConstellationHtml } from './concept-constellation-view.js?v=5';
+import {
+  derivePostRepairBridge,
+  renderConceptConstellationHtml,
+} from './concept-constellation-view.js?v=7';
 import { deriveConceptBadge } from './concept-status.js';
 import {
   getDefaultPhaseBSessionState,
@@ -139,6 +143,7 @@ const App = (() => {
   const LOCAL_QA_NODE_ID = 'qa-node';
   const LOCAL_REPAIR_QA_CONCEPT_ID = 'qa-repair-concept';
   const LOCAL_REPAIR_QA_NODE_ID = 'repair-node';
+  const LOCAL_REPAIR_QA_NEXT_NODE_ID = 'depolarization-node';
   const DRILL_NODE_MECHANISM_MAX_CHARS = 10000;
   const trainingStore = createTrainingStore();
   let learnerStatePushTimer = null;
@@ -355,28 +360,48 @@ const App = (() => {
   function buildLocalRepairQaConcept(nowMs) {
     const studyNote = 'Voltage-gated sodium channels open when membrane voltage reaches threshold; the concentration gradient drives flow after the gate opens.';
     const purpose = 'Name what opens the channel before reading the study note.';
+    const nextStudyNote = 'Sodium entry makes the membrane voltage less negative and begins depolarization.';
+    const nextPurpose = 'Explain what changes the membrane voltage from memory.';
     const graphData = {
       metadata: {
         source_title: 'Repair QA source',
         starting_map_context: 'I think sodium just rushes in.',
         map_maturity: 'provisional',
       },
-      backbone: [{
-        id: LOCAL_REPAIR_QA_NODE_ID,
-        label: 'Sodium channel gate',
-        purpose,
-        study_note: studyNote,
-        drill_status: null,
-      }],
-      clusters: [{
-        id: 'cluster-1',
-        subnodes: [{
+      backbone: [
+        {
           id: LOCAL_REPAIR_QA_NODE_ID,
           label: 'Sodium channel gate',
           purpose,
           study_note: studyNote,
           drill_status: null,
-        }],
+        },
+        {
+          id: LOCAL_REPAIR_QA_NEXT_NODE_ID,
+          label: 'Membrane depolarization',
+          purpose: nextPurpose,
+          study_note: nextStudyNote,
+          drill_status: null,
+        },
+      ],
+      clusters: [{
+        id: 'cluster-1',
+        subnodes: [
+          {
+            id: LOCAL_REPAIR_QA_NODE_ID,
+            label: 'Sodium channel gate',
+            purpose,
+            study_note: studyNote,
+            drill_status: null,
+          },
+          {
+            id: LOCAL_REPAIR_QA_NEXT_NODE_ID,
+            label: 'Membrane depolarization',
+            purpose: nextPurpose,
+            study_note: nextStudyNote,
+            drill_status: null,
+          },
+        ],
       }],
     };
 
@@ -637,6 +662,10 @@ const App = (() => {
   }
 
   function refreshConstellationAvailability(training = null) {
+    if (document.querySelector('.concept-page-b2__doc--post-repair')) {
+      setConstellationAvailable(false);
+      return;
+    }
     if (document.body.dataset.conceptSourceMode === 'source_less') {
       setConstellationAvailable(false);
       return;
@@ -2149,6 +2178,20 @@ const App = (() => {
           }
           return;
         }
+        if (ctaBtn.dataset.activeEntryAction === 'write-repair') {
+          const repairPanel = docEl.querySelector('.concept-page-b2__repair');
+          const studyNote = docEl.querySelector('.concept-page-b2__study-note');
+          const studyNoteToggle = docEl.querySelector('[data-study-note-toggle]');
+          repairPanel?.removeAttribute('hidden');
+          studyNote?.classList.add('is-collapsed');
+          if (studyNoteToggle) {
+            studyNoteToggle.textContent = 'Show study note';
+            studyNoteToggle.setAttribute('aria-expanded', 'false');
+          }
+          ctaBtn.hidden = true;
+          repairPanel?.querySelector('.concept-page-b2__repair-input')?.focus?.();
+          return;
+        }
         if (ctaBtn.dataset.activeEntryAction === 'drill-gap') {
           const entryId = ctaBtn.dataset.activeEntryId;
           startDrill(buildRepairGapDrillContext(entryId, concept, data, training));
@@ -2261,6 +2304,31 @@ const App = (() => {
     });
   }
 
+  function renderActiveEntryDocumentHtml(activeEntry, activeIdx, backbone, concept, data, training, renderOptions = {}) {
+    const activeHtml = renderActiveEntryHtml(
+      activeEntry,
+      activeIdx,
+      backbone,
+      concept,
+      data,
+      training,
+      renderOptions,
+    );
+    const postRepairBridge = derivePostRepairBridge(data, training, getConceptEntryId(activeEntry, activeIdx), renderOptions);
+    if (!postRepairBridge) return { html: activeHtml, hasPostRepair: false };
+    const constellationHtml = renderConceptConstellationHtml(data, {
+      ...renderOptions,
+      concept,
+      training,
+      activeEntryId: postRepairBridge.repairedEntryId,
+      postRepairBridge,
+    });
+    return {
+      html: `${activeHtml}<section class="concept-post-repair-host">${constellationHtml}</section>`,
+      hasPostRepair: true,
+    };
+  }
+
   function renderActiveEntryWorkColumn(entryId, concept, data, training = null, options = {}) {
     const docEl = document.querySelector('.concept-page-b2__doc');
     const backbone = deriveConceptEntries(data);
@@ -2271,7 +2339,7 @@ const App = (() => {
     if (!docEl || !match) return;
     const renderBackbone = backbone.length ? backbone : [match.entry];
     const renderOptions = conceptPageRenderOptionsForEntry(concept, entryId, training, options);
-    docEl.innerHTML = renderActiveEntryHtml(
+    const rendered = renderActiveEntryDocumentHtml(
       match.entry,
       match.index,
       renderBackbone,
@@ -2280,6 +2348,8 @@ const App = (() => {
       training,
       renderOptions,
     );
+    docEl.innerHTML = rendered.html;
+    docEl.classList.toggle('concept-page-b2__doc--post-repair', rendered.hasPostRepair);
     rebindActiveEntryHandlers(docEl, concept, data, training);
   }
 
@@ -2375,8 +2445,8 @@ const App = (() => {
     const label = entry.label || entry.principle || entry.task_label || concept?.name || 'Entry';
     const gapTitle = titleFromRepairGap(gap, label);
     const visiblePrompt = gap
-      ? `Close the note. Rebuild the repaired link for ${gapTitle}: name the condition, the action, and what changes next.`
-      : `Close the note. Reconstruct this entry from memory.`;
+      ? `Rebuild the repaired link for ${gapTitle}: name the condition, the action, and what changes next.`
+      : `Reconstruct this entry from memory.`;
     const repairContext = [
       entry.mechanism || entry.principle || entry.study_note || entry.detail || entry.purpose || '',
       latestAttempt.user_text ? `Learner cold draft: ${latestAttempt.user_text}` : '',
@@ -2653,7 +2723,11 @@ const App = (() => {
       if (mountEl) {
         window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
         renderConceptPageB2(mountEl, data, concept, training, { activeEntryId: entryId });
-        focusRenderedMoment('.concept-page-b2__repair--saved');
+        focusRenderedMoment(
+          mountEl.querySelector('.concept-post-repair__rail')
+            ? '.concept-post-repair__rail'
+            : '.concept-page-b2__repair--saved',
+        );
       }
     } catch (err) {
       /* c8 ignore next -- defensive storage/invariant failure branch */
@@ -2786,7 +2860,9 @@ const App = (() => {
       );
       const activeEntry = backbone[activeIdx] || backbone[0] || { id: 'core-thesis', label: 'Core thesis' };
       const renderOptions = conceptPageRenderOptionsForEntry(liveConcept, _activeEntryId, training, {});
-      docEl.innerHTML = renderActiveEntryHtml(activeEntry, activeIdx, backbone, liveConcept, freshData, training, renderOptions);
+      const rendered = renderActiveEntryDocumentHtml(activeEntry, activeIdx, backbone, liveConcept, freshData, training, renderOptions);
+      docEl.innerHTML = rendered.html;
+      docEl.classList.toggle('concept-page-b2__doc--post-repair', rendered.hasPostRepair);
       rebindActiveEntryHandlers(docEl, liveConcept, freshData, training);
       bindConceptRouteMarginHandlers(document.getElementById('map-content'), freshData, liveConcept, training);
     });
@@ -2828,7 +2904,9 @@ const App = (() => {
       comparisonAcknowledged: true,
     } : {});
     setTimeout(() => {
-      doc.innerHTML = renderActiveEntryHtml(newEntry, newIdx, backbone, concept, data, training, renderOptions);
+      const rendered = renderActiveEntryDocumentHtml(newEntry, newIdx, backbone, concept, data, training, renderOptions);
+      doc.innerHTML = rendered.html;
+      doc.classList.toggle('concept-page-b2__doc--post-repair', rendered.hasPostRepair);
       rebindActiveEntryHandlers(doc, concept, data, training);
       bindConceptRouteMarginHandlers(mountEl, data, concept, training);
       restoreActiveEntryDraft(entryId);
@@ -2971,13 +3049,21 @@ const App = (() => {
     const renderBackbone = backbone.length ? backbone : [activeEntry];
 
     const renderOptions = conceptPageRenderOptionsForEntry(concept, activeEntryId, training, options);
-    const docHtml = renderActiveEntryHtml(activeEntry, activeIdx, renderBackbone, concept, data, training, renderOptions);
+    const rendered = renderActiveEntryDocumentHtml(
+      activeEntry,
+      activeIdx,
+      renderBackbone,
+      concept,
+      data,
+      training,
+      renderOptions,
+    );
 
     // Mount the whole thing
     mountEl.classList.add('concept-page-b2');
     mountEl.innerHTML = `
-      <div class="concept-page-b2__doc">
-        ${docHtml}
+      <div class="concept-page-b2__doc${rendered.hasPostRepair ? ' concept-page-b2__doc--post-repair' : ''}">
+        ${rendered.html}
       </div>
     `;
 
@@ -3145,29 +3231,67 @@ const App = (() => {
     }
   }
 
+  async function openConceptEntry(entryId, { focusAttempt = false } = {}) {
+    const concept = getActiveConcept();
+    const data = parseConceptGraphData(concept);
+    const entries = deriveConceptEntries(data || {});
+    const match = findConceptEntryById(entries, entryId);
+    if (!entryId || !concept || !data || !match || entryId === _activeEntryId) return false;
+
+    try {
+      const training = await trainingStore.loadTraining(concept.id);
+      const state = deriveConceptEntryViewState(entries, match.index, training);
+      if (state.state === 'locked') return false;
+      setActiveEntry(entryId, data, concept, training, { focusAttempt });
+      return true;
+    } catch (err) {
+      console.warn('Concept entry unavailable.', err);
+      return false;
+    }
+  }
+
   function bindMapModeControls() {
     document.addEventListener('click', (event) => {
       const target = event.target instanceof Element ? event.target : null;
+      const postRepairAction = target?.closest('[data-post-repair-action]') || null;
+      if (postRepairAction) {
+        event.preventDefault();
+        const action = postRepairAction.getAttribute('data-post-repair-action');
+        if (action === 'break') {
+          showDashboard();
+          return;
+        }
+        if (action === 'next-entry') {
+          const entryId = postRepairAction.getAttribute('data-entry-id');
+          void openConceptEntry(entryId, { focusAttempt: true });
+          return;
+        }
+        if (action === 'pressure-check') {
+          const entryId = postRepairAction.getAttribute('data-repair-entry-id');
+          const concept = getActiveConcept();
+          const data = parseConceptGraphData(concept);
+          if (!entryId || !concept || !data) return;
+          void trainingStore.loadTraining(concept.id)
+            .then((training) => startDrill(buildRepairGapDrillContext(entryId, concept, data, training)))
+            .catch((err) => console.warn('Repair record unavailable for pressure-check.', err));
+          return;
+        }
+      }
       const constellationNode = target?.closest('.concept-constellation__node[data-entry-id]') || null;
       if (constellationNode) {
         const entryId = constellationNode.getAttribute('data-entry-id');
         const state = constellationNode.getAttribute('data-state');
+        const opensSuggestedRoom = constellationNode.getAttribute('data-bridge-target') === 'true';
         if (state === 'locked') return;
-        const concept = getActiveConcept();
-        /* v8 ignore start -- route-margin async handoff is covered by browser smoke through the same active-entry renderer. */
-        const data = parseConceptGraphData(concept);
-        if (entryId && data && concept) {
+        if (entryId) {
           event.preventDefault();
-          void trainingStore.loadTraining(concept.id)
-            .then((training) => setActiveEntry(entryId, data, concept, training))
-            .catch(() => setActiveEntry(entryId, data, concept, null));
+          void openConceptEntry(entryId, { focusAttempt: opensSuggestedRoom });
         }
         return;
-        /* v8 ignore stop */
       }
 
       const button = target
-        ? target.closest('[data-map-mode]')
+        ? target.closest('button[data-map-mode]')
         : null;
       if (!button) return;
       const mode = button.getAttribute('data-map-mode');
@@ -3184,7 +3308,10 @@ const App = (() => {
       const constellationNode = target?.closest('.concept-constellation__node[data-entry-id]') || null;
       if (!constellationNode) return;
       event.preventDefault();
-      constellationNode.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      void openConceptEntry(
+        constellationNode.getAttribute('data-entry-id'),
+        { focusAttempt: constellationNode.getAttribute('data-bridge-target') === 'true' },
+      );
     });
 
   }

--- a/public/js/concept-constellation-view.js
+++ b/public/js/concept-constellation-view.js
@@ -2,7 +2,9 @@ import { escHtml } from './html.js';
 import {
   deriveConceptEntries,
   deriveConceptEntryViewState,
+  deriveRepairPhase,
   getConceptEntryId,
+  nextReadyEntry,
 } from './concept-page-view.js';
 
 const SVG_WIDTH = 800;
@@ -107,6 +109,25 @@ function resolveNodePosition(entries, entry, index, angles) {
   };
 }
 
+function resolveBridgeNodePosition(entries, entry, index, bridge) {
+  const id = getConceptEntryId(entry, index);
+  if (id === bridge?.repairedEntryId) return { x: 292, y: 286 };
+  if (id === bridge?.targetEntryId) return { x: 528, y: 306 };
+
+  const peripheral = entries.filter((candidate, candidateIndex) => {
+    const candidateId = getConceptEntryId(candidate, candidateIndex);
+    return candidateId !== bridge?.repairedEntryId && candidateId !== bridge?.targetEntryId;
+  });
+  const peripheralIndex = peripheral.findIndex((candidate) => candidate === entry);
+  const spread = peripheral.length <= 1 ? 0 : 250 / (peripheral.length - 1);
+  const angle = -145 + (peripheralIndex * spread);
+  const position = polar(CENTER, 238, angle);
+  return {
+    x: clamp(position.x, 86, SVG_WIDTH - 86),
+    y: clamp(position.y, 84, SVG_HEIGHT - 84),
+  };
+}
+
 function entryFallbackLabel(index) {
   return `Entry ${String(index + 1).padStart(2, '0')}`;
 }
@@ -192,17 +213,42 @@ function displayStateLabel(viewState) {
   return 'future room';
 }
 
+export function derivePostRepairBridge(data = {}, training = null, activeEntryId = null, options = {}) {
+  if (options?.isDrilling) return null;
+  const entries = deriveConceptEntries(data);
+  const resolvedEntryId = activeEntryId || getConceptEntryId(entries[0], 0);
+  const activeIndex = entries.findIndex((entry, index) => getConceptEntryId(entry, index) === resolvedEntryId);
+  if (activeIndex < 0) return null;
+
+  const record = training?.node_records?.[resolvedEntryId] || null;
+  const viewState = deriveConceptEntryViewState(entries, activeIndex, training, options);
+  if (
+    viewState.nextAction !== 'repair'
+    || deriveRepairPhase(record, options) !== 'saved'
+  ) return null;
+
+  const target = nextReadyEntry(entries, activeIndex, training, options);
+  return {
+    repairedEntryId: resolvedEntryId,
+    targetEntryId: target?.id || null,
+  };
+}
+
 function buildConstellationModel(entries, training, activeEntryId, options = {}) {
+  const bridge = options.postRepairBridge || null;
   const angles = resolveBackboneAngles(entries.length);
   const nodes = entries.map((entry, index) => {
     const id = getConceptEntryId(entry, index);
     const viewState = deriveConceptEntryViewState(entries, index, training, options);
     const isActive = id === activeEntryId;
-    const position = resolveNodePosition(entries, entry, index, angles);
-    const label = canShowEntryLabel(viewState, index, isActive)
+    const isSuggested = bridge?.targetEntryId === id;
+    const position = bridge
+      ? resolveBridgeNodePosition(entries, entry, index, bridge)
+      : resolveNodePosition(entries, entry, index, angles);
+    const label = canShowEntryLabel(viewState, index, isActive || isSuggested)
       ? entrySafeLabel(entry, index)
       : entryFallbackLabel(index);
-    const purpose = entrySafePurpose(entry, viewState, index, isActive);
+    const purpose = entrySafePurpose(entry, viewState, index, isActive || isSuggested);
     return {
       id,
       index,
@@ -211,7 +257,12 @@ function buildConstellationModel(entries, training, activeEntryId, options = {})
       position,
       viewState,
       isActive,
-      className: stateClass(viewState, isActive),
+      isSuggested,
+      bridgeRole: isActive ? 'repair' : isSuggested ? 'suggested' : null,
+      className: [
+        stateClass(viewState, isActive),
+        isSuggested ? 'is-suggested' : '',
+      ].filter(Boolean).join(' '),
     };
   });
 
@@ -219,6 +270,7 @@ function buildConstellationModel(entries, training, activeEntryId, options = {})
     nodes,
     selectedNode: nodes.find((node) => node.isActive) || nodes[0] || null,
     stars: buildStars(entries),
+    bridge,
   };
 }
 
@@ -256,14 +308,39 @@ function renderConnectors(nodes) {
   }).join('');
 }
 
+function renderSuggestedConnector(nodes, bridge) {
+  if (!bridge?.repairedEntryId || !bridge?.targetEntryId) return '';
+  const from = nodes.find((node) => node.id === bridge.repairedEntryId);
+  const to = nodes.find((node) => node.id === bridge.targetEntryId);
+  if (!from || !to) return '';
+  return `
+    <path
+      class="concept-constellation__edge is-suggested"
+      data-edge-recommendation="true"
+      d="${buildCurvePath(from.position, to.position)}"
+      aria-hidden="true"
+    />
+  `;
+}
+
 function renderNode(node) {
   const label = escHtml(node.label);
   const purpose = escHtml(node.purpose);
   const state = escHtml(displayState(node.viewState));
   const stateLabel = escHtml(displayStateLabel(node.viewState));
   const entryId = escHtml(node.id);
-  const selectable = state !== 'locked';
-  const ariaLabel = escHtml(`${node.label}, ${stateLabel}${node.isActive ? ', current room' : ''}`);
+  const selectable = state !== 'locked' && !node.isActive;
+  const indexLabel = String(node.index + 1).padStart(2, '0');
+  const bridgeLabel = node.bridgeRole === 'repair'
+    ? 'Correction kept'
+    : node.bridgeRole === 'suggested' ? 'Suggested next' : null;
+  const ariaLabel = escHtml([
+    indexLabel,
+    node.label,
+    bridgeLabel,
+    stateLabel,
+    node.isActive ? 'current room' : null,
+  ].filter(Boolean).join(', '));
   const className = ['concept-constellation__node', node.className].filter(Boolean).join(' ');
   return `
     <g
@@ -274,6 +351,7 @@ function renderNode(node) {
       data-state-label="${stateLabel}"
       data-selected-name="${label}"
       data-selected-purpose="${purpose}"
+      data-bridge-target="${node.isSuggested ? 'true' : 'false'}"
       role="${selectable ? 'button' : 'listitem'}"
       tabindex="${selectable ? '0' : '-1'}"
       focusable="${selectable ? 'true' : 'false'}"
@@ -281,11 +359,68 @@ function renderNode(node) {
       transform="translate(${node.position.x.toFixed(1)} ${node.position.y.toFixed(1)})"
     >
       <circle class="concept-constellation__halo" r="42" aria-hidden="true" />
-      <path class="concept-constellation__dot" d="${diamondPath(node.isActive ? 26 : 22)}" aria-hidden="true" />
+      <path class="concept-constellation__dot" d="${diamondPath(node.isActive || node.isSuggested ? 26 : 22)}" aria-hidden="true" />
       <path class="concept-constellation__facet" d="M 0 -22 L 0 22 M -18 0 L 18 0" aria-hidden="true" />
       <text class="concept-constellation__index" x="-44" y="-34">${String(node.index + 1).padStart(2, '0')}</text>
       <text class="concept-constellation__label" y="52" text-anchor="middle">${label}</text>
+      ${node.bridgeRole ? `<text class="concept-constellation__bridge-role" y="72" text-anchor="middle">${node.bridgeRole === 'repair' ? 'Correction kept' : 'Suggested next'}</text>` : ''}
     </g>
+  `;
+}
+
+function renderPostRepairRail(model) {
+  const bridge = model.bridge;
+  const target = model.nodes.find((node) => node.id === bridge?.targetEntryId) || null;
+  const targetLabel = target ? escHtml(target.label) : '';
+  const nextHtml = target
+    ? `
+      <section class="concept-post-repair__next">
+        <span class="eyebrow">Suggested next</span>
+        <h4>${targetLabel}</h4>
+        <p>Another ready room lets this link settle.</p>
+        <button
+          class="concept-post-repair__primary"
+          type="button"
+          data-post-repair-action="next-entry"
+          data-entry-id="${escHtml(target.id)}"
+          aria-label="Enter this room: ${targetLabel}"
+        >Enter this room</button>
+        <button class="concept-post-repair__break" type="button" data-post-repair-action="break">Take a short break</button>
+      </section>
+    `
+    : `
+      <section class="concept-post-repair__next concept-post-repair__next--break">
+        <span class="eyebrow">Let this settle</span>
+        <h4>Take a short break.</h4>
+        <p>No nearby room is ready. The repaired link stays on your route.</p>
+        <button class="concept-post-repair__break concept-post-repair__break--standalone" type="button" data-post-repair-action="break">Take a short break</button>
+      </section>
+    `;
+  const pressureCheckHtml = `
+      <details class="concept-post-repair__options">
+        <summary>More options</summary>
+        <button
+          type="button"
+          data-post-repair-action="pressure-check"
+          data-repair-entry-id="${escHtml(bridge?.repairedEntryId || '')}"
+        >
+          <strong>Pressure-check this link</strong>
+          <span>Fresh practice. Your map stays unchanged.</span>
+        </button>
+      </details>
+    `;
+
+  return `
+    <article class="concept-post-repair__rail" aria-label="Post-repair handoff" tabindex="-1">
+      <section class="concept-post-repair__truth">
+        <span class="eyebrow">Correction kept</span>
+        <h3>Your map is unchanged.</h3>
+        <p>Reconstruct this link later to test it.</p>
+      </section>
+      ${nextHtml}
+      ${pressureCheckHtml}
+      <footer>Correction kept. No new reconstruction evidence.</footer>
+    </article>
   `;
 }
 
@@ -306,7 +441,54 @@ function renderSelectedDetail(node) {
   `;
 }
 
+function renderConstellationSvg(model) {
+  const titleId = model.bridge ? 'concept-post-repair-title' : 'concept-constellation-title';
+  const descriptionId = model.bridge ? 'concept-post-repair-desc' : 'concept-constellation-desc';
+  const hasSuggestedTarget = Boolean(
+    model.bridge?.targetEntryId
+    && model.nodes.some((node) => node.id === model.bridge.targetEntryId),
+  );
+  const description = model.bridge
+    ? hasSuggestedTarget
+      ? 'The repaired room remains unchanged. One eligible room is suggested for interleaving.'
+      : 'The repaired room remains unchanged. No nearby room is ready, so the repaired link stays on the route.'
+    : 'A draft map of concept rooms. Future rooms hide study content until reconstruction evidence exists.';
+  return `
+    <svg
+      class="concept-constellation__svg"
+      viewBox="0 0 ${SVG_WIDTH} ${SVG_HEIGHT}"
+      aria-labelledby="${titleId} ${descriptionId}"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title id="${titleId}">${model.bridge ? 'Post-repair route' : 'Concept constellation'}</title>
+      <desc id="${descriptionId}">${description}</desc>
+      <g class="concept-constellation__stars" aria-hidden="true">
+        ${renderStars(model.stars)}
+      </g>
+      <g class="concept-constellation__links" aria-hidden="true">
+        ${renderConnectors(model.nodes)}
+        ${renderSuggestedConnector(model.nodes, model.bridge)}
+      </g>
+      <g class="concept-constellation__entries" role="group" aria-label="Concept rooms">
+        ${model.nodes.map(renderNode).join('')}
+      </g>
+    </svg>
+  `;
+}
+
 function renderConstellation(model) {
+  const constellationSvg = renderConstellationSvg(model);
+  if (model.bridge) {
+    return `
+      <div class="concept-constellation__shell concept-constellation__shell--bridge" aria-label="Post-repair concept route">
+        <div class="concept-post-repair__canvas">
+          <span class="eyebrow">draft route</span>
+          ${constellationSvg}
+        </div>
+        ${renderPostRepairRail(model)}
+      </div>
+    `;
+  }
   return `
     <div class="concept-constellation__shell" aria-label="Concept constellation">
       <div class="concept-constellation__copy">
@@ -318,24 +500,7 @@ function renderConstellation(model) {
         <strong>Overview first.</strong>
         <span>Select a room to orient, then return to the route to write.</span>
       </div>
-      <svg
-          class="concept-constellation__svg"
-          viewBox="0 0 ${SVG_WIDTH} ${SVG_HEIGHT}"
-          aria-labelledby="concept-constellation-title concept-constellation-desc"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title id="concept-constellation-title">Concept constellation</title>
-          <desc id="concept-constellation-desc">A draft map of concept rooms. Future rooms hide study content until reconstruction evidence exists.</desc>
-          <g class="concept-constellation__stars" aria-hidden="true">
-            ${renderStars(model.stars)}
-          </g>
-          <g class="concept-constellation__links" aria-hidden="true">
-            ${renderConnectors(model.nodes)}
-          </g>
-          <g class="concept-constellation__entries" role="list">
-            ${model.nodes.map(renderNode).join('')}
-          </g>
-        </svg>
+      ${constellationSvg}
       ${renderSelectedDetail(model.selectedNode)}
     </div>
   `;
@@ -345,6 +510,9 @@ export function renderConceptConstellationHtml(data = {}, options = {}) {
   const entries = deriveConceptEntries(data);
   const training = options.training || null;
   const activeEntryId = options.activeEntryId || getConceptEntryId(entries[0], 0);
-  const model = buildConstellationModel(entries, training, activeEntryId, options);
+  const model = buildConstellationModel(entries, training, activeEntryId, {
+    ...options,
+    postRepairBridge: options.postRepairBridge || null,
+  });
   return renderConstellation(model);
 }

--- a/public/js/concept-constellation-view.js
+++ b/public/js/concept-constellation-view.js
@@ -352,7 +352,7 @@ function renderNode(node) {
       data-selected-name="${label}"
       data-selected-purpose="${purpose}"
       data-bridge-target="${node.isSuggested ? 'true' : 'false'}"
-      role="${selectable ? 'button' : 'listitem'}"
+      role="${selectable ? 'button' : 'img'}"
       tabindex="${selectable ? '0' : '-1'}"
       focusable="${selectable ? 'true' : 'false'}"
       aria-label="${ariaLabel}"

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -59,6 +59,25 @@ function trainingRecordsFor(training) {
     : {};
 }
 
+export function deriveRepairPhase(record = null, options = {}) {
+  const repairs = Array.isArray(record?.repairs) ? record.repairs : [];
+  if (!repairs.length) return 'write';
+
+  const latestAt = (items) => items.reduce((latest, item) => {
+    const at = Date.parse(item?.at || '');
+    return Number.isFinite(at) ? Math.max(latest, at) : latest;
+  }, Number.NEGATIVE_INFINITY);
+  const latestRepairAt = latestAt(repairs);
+  const attempts = Array.isArray(record?.attempts) ? record.attempts : [];
+  const latestAttemptAt = latestAt(attempts);
+  if (latestAttemptAt > latestRepairAt) return 'write';
+
+  if (options?.repairCheckedThisSession === true) return 'checked';
+  const checkedAt = Date.parse(record?.repair_checked_at || '');
+  if (Number.isFinite(checkedAt) && checkedAt >= latestRepairAt) return 'checked';
+  return 'saved';
+}
+
 function recordWithLegacyStudyReveal(entry, record, legacyEntry) {
   const status = String(entry?.drill_status || '').toLowerCase();
   const phase = String(entry?.drill_phase || '').toLowerCase();
@@ -113,8 +132,11 @@ function entryLearnerState(backbone, index, training, options = {}) {
   const checkedEntryIds = Array.isArray(options?.repairCheckedEntryIds)
     ? options.repairCheckedEntryIds
     : [];
+  const repairPhase = deriveRepairPhase(derived.record, {
+    repairCheckedThisSession: checkedEntryIds.includes(entryId),
+  });
   if (derived.attempted) {
-    if (derived.state === 'needs repair' && checkedEntryIds.includes(entryId)) {
+    if (derived.state === 'needs repair' && repairPhase === 'checked') {
       /* c8 ignore next -- secondary route-state label is covered by Node render tests; source-less browser route chrome is hidden */
       return 'repair checked';
     }
@@ -360,9 +382,9 @@ export function renderConceptStripHtml(backbone, activeEntry, activeIdx, trainin
 
 function activeEntryEyebrow({ isBlocked, attempted, state, nextAction, justRevealedStudy }) {
   if (isBlocked) return 'locked';
-  if (!attempted) return 'Start from memory';
+  if (!attempted) return '';
   if (justRevealedStudy) return 'Compare notes';
-  if (nextAction === 'study') return 'Draft saved';
+  if (nextAction === 'study') return 'Your draft';
   if (nextAction === 'repair') return 'Needs repair';
   if (state === 'needs repair' && nextAction === 'spaced_attempt') return 'Ready to reconstruct again';
   if (state === 'solidified') return 'Solid spaced reconstruction';
@@ -493,19 +515,20 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId, options = {}
   const entryId = activeEntryId || activeEntry.id || 'core-thesis';
   const repairs = Array.isArray(derived.record?.repairs) ? derived.record.repairs : [];
   const latestRepairText = String(repairs.at(-1)?.text || '').trim();
-  const repairCheckedThisSession = repairs.length && options?.repairCheckedThisSession === true;
-  const nextAttemptButton = repairs.length && !repairCheckedThisSession
+  const repairPhase = deriveRepairPhase(derived.record, options);
+  const waitsForRepairAction = repairPhase === 'write';
+  const nextAttemptButton = repairPhase === 'saved'
     ? `<button class="concept-page-b2__entry-cta concept-page-b2__repair-attempt" type="button" data-active-entry-id="${escHtml(entryId)}" data-active-entry-action="drill-gap">Pressure-check this link</button>`
     : '';
   const repairTarget = repairGapCorrection(gaps[0]) || 'Write the part that was missing from your first attempt.';
 
-  const helperHtml = repairCheckedThisSession
-    ? '<p class="concept-page-b2__repair-helper">Return later for spaced reconstruction. A strong later answer can update the record. <button class="concept-page-b2__feedback-link" type="button" data-feedback-rating data-feedback-moment="repair checked">Rate this moment</button></p>'
-    : repairs.length
+  const helperHtml = repairPhase === 'checked'
+    ? '<p class="concept-page-b2__repair-helper">Return later for spaced reconstruction. A strong later answer can update the record.</p>'
+    : repairPhase === 'saved'
     ? ''
     : `<p class="concept-page-b2__repair-helper">Use your words. One or two sentences is enough.</p>`;
 
-  const inputFormHtml = repairs.length
+  const inputFormHtml = repairPhase !== 'write'
     ? ''
     : `
       <label class="concept-page-b2__field">
@@ -523,10 +546,20 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId, options = {}
       <button class="concept-page-b2__repair-save" type="button" data-repair-entry-id="${escHtml(entryId)}">Save repair</button>
     `;
 
+  if (repairPhase === 'saved') {
+    return `
+      <section class="concept-page-b2__repair concept-page-b2__repair--saved" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link" tabindex="-1">
+        <h3>Explain the link again from memory.</h3>
+        <p class="concept-page-b2__repair-context">${escHtml(repairTarget)}</p>
+        ${nextAttemptButton}
+      </section>
+    `;
+  }
+
   return `
-    <section class="concept-page-b2__repair${repairs.length ? ' concept-page-b2__repair--saved' : ''}" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link" tabindex="-1">
-      <span class="eyebrow concept-page-b2__repair-eyebrow">${repairCheckedThisSession ? 'Repair checked' : repairs.length ? 'Repair saved' : 'Repair'}</span>
-      <h3>${repairCheckedThisSession ? 'Repair checked for now.' : repairs.length ? 'Pressure-check the repaired link.' : 'Write the missing link.'}</h3>
+    <section class="concept-page-b2__repair${repairPhase !== 'write' ? ' concept-page-b2__repair--saved' : ''}" data-repair-entry-id="${escHtml(entryId)}" aria-label="Repair missing link" tabindex="-1"${waitsForRepairAction ? ' hidden' : ''}>
+      <span class="eyebrow concept-page-b2__repair-eyebrow">${repairPhase === 'checked' ? 'Repair checked' : 'Repair'}</span>
+      <h3>${repairPhase === 'checked' ? 'Repair checked for now.' : 'Write the missing link.'}</h3>
       <div class="concept-page-b2__repair-target">
         <span>Missing link</span>
         <p>${escHtml(repairTarget)}</p>
@@ -544,13 +577,15 @@ function renderRepairPanelHtml(activeEntry, derived, activeEntryId, options = {}
   `;
 }
 
-function nextReadyEntry(backbone, activeIdx, training, options = {}) {
+export function nextReadyEntry(backbone, activeIdx, training, options = {}) {
   for (let index = activeIdx + 1; index < backbone.length; index += 1) {
     const derived = entryTraining(backbone, index, training, options);
     if (!derived.attempted && predecessorsAttempted(backbone, index, training, options)) {
       const entry = backbone[index];
       return {
         id: getConceptEntryId(entry, index),
+        entry,
+        index,
       };
     }
   }
@@ -785,6 +820,10 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
   const activeEntryId = getConceptEntryId(activeEntry, activeIdx);
 
   const derived = entryTraining(backbone, activeIdx, training, options);
+  const repairs = Array.isArray(derived.record?.repairs) ? derived.record.repairs : [];
+  const repairPhase = deriveRepairPhase(derived.record, options);
+  const isSavedRepairAwaitingCheck = derived.next_action === 'repair'
+    && repairPhase === 'saved';
   const sourceMode = sourceModeForConcept(concept, data, training);
   const isSourceLess = sourceMode === 'source_less';
   const viewMode = isSourceLess ? deriveSourceLessViewMode(derived, options) : (options?.viewMode || 'expanded-workspace');
@@ -817,21 +856,21 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
   });
   const visibleEntryEyebrow = options?.isDrilling
     ? 'Reconstruction'
-    : options?.repairCheckedThisSession && derived.next_action === 'repair'
+    : repairPhase === 'checked' && derived.next_action === 'repair'
     ? 'Repair checked'
+    : isSavedRepairAwaitingCheck
+    ? 'Repair saved'
     : entryEyebrow;
-  const studyGatePurpose = derived.attempted && derived.next_action === 'study'
-    ? 'You wrote first. Now socratink can compare your model against the missing relationship.'
-    : '';
   const scaffold = entryScaffold(activeEntry);
   const activeEntryTitle = isSourceLess && scaffold
     ? (scaffold.task_label || scaffold.learner_move || activeEntry.label || 'Core thesis')
     : (activeEntry.label || 'Core thesis');
-  const suppressPurposeForScaffoldAttempt = isAttempting && isColdReadyEntry && Boolean(scaffold?.entry_prompt);
-  const entryPurpose = suppressPurposeForScaffoldAttempt
+  const suppressPurpose = options?.isDrilling
+    || Boolean(derived.record?.study_revealed_at)
+    || (isAttempting && isColdReadyEntry);
+  const entryPurpose = suppressPurpose
     ? ''
-    : studyGatePurpose
-      || scaffold?.task_cue
+    : scaffold?.task_cue
       || activeEntry.purpose
       || (isBlocked
         ? 'Locked until you write from memory on the entry above. The mechanism stays hidden until you have put your current model into words.'
@@ -842,11 +881,12 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     nextAction: derived.next_action,
   });
   const ctaAction = derived.next_action === 'study' ? 'study' : 'drill';
-  const collapseStudyNote = derived.next_action === 'repair' && !isPostRevealComparison;
-  const hiddenStudyNoteText = options?.repairCheckedThisSession && derived.next_action === 'repair'
+  const collapseStudyNote = derived.next_action === 'repair' && repairPhase !== 'write';
+  const suppressStudyNoteForSavedRepair = collapseStudyNote && repairPhase === 'saved';
+  const hiddenStudyNoteText = repairPhase === 'checked' && derived.next_action === 'repair'
     ? 'Study note stays hidden for later reconstruction.'
     : 'Study note stays hidden while you repair.';
-  const studyNoteHtml = derived.record?.study_revealed_at && !isAttempting
+  const studyNoteHtml = derived.record?.study_revealed_at && !isAttempting && !suppressStudyNoteForSavedRepair
     ? `
       <section class="concept-page-b2__study-note${collapseStudyNote ? ' is-collapsed' : ''}" aria-label="Study note" tabindex="-1">
         <div class="concept-page-b2__study-note-header">
@@ -858,7 +898,9 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
       </section>
     `
     : '';
-  const evidenceArtifactHtml = !isAttempting ? renderEvidenceArtifactHtml(derived) : '';
+  const evidenceArtifactHtml = !isAttempting && !isSavedRepairAwaitingCheck
+    ? renderEvidenceArtifactHtml(derived)
+    : '';
   const repairPanelHtml = isAttempting ? '' : renderRepairPanelHtml(activeEntry, derived, activeEntryId, options);
   const attemptPanelHtml = isAttempting ? renderAttemptPanelHtml(activeEntryId, activeEntry, {
     useScaffold: isColdReadyEntry,
@@ -871,23 +913,23 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
     : renderSketchWrapperHtml('');
   const sourceLessProvenanceHtml = '';
   const contextDockLabel = 'Concept context';
-  const nextReady = (derived.next_action === 'review' || (derived.next_action === 'repair' && options?.repairCheckedThisSession))
+  const nextReady = (derived.next_action === 'review' || (derived.next_action === 'repair' && repairPhase === 'checked'))
     ? nextReadyEntry(backbone, activeIdx, training, options)
     : null;
   const nextReadyButton = nextReady
-    ? `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(nextReady.id)}" data-active-entry-action="next-entry">${isSourceLess ? 'Continue' : 'Continue route'}</button>`
+    ? `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(nextReady.id)}" data-active-entry-action="next-entry">Continue route</button>`
     : '';
-  const ctaButton = options?.isDrilling || isAttempting || derived.next_action === 'repair' || derived.next_action === 'review' || derived.next_action === null
+  const repairActionButton = derived.next_action === 'repair' && repairPhase === 'write'
+    ? `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="write-repair">Write the repair</button>`
+    : '';
+  const ctaButton = repairActionButton || (options?.isDrilling || isAttempting || derived.next_action === 'repair' || derived.next_action === 'review' || derived.next_action === null
     ? (isPostRevealComparison
       && derived.next_action !== 'repair'
-      ? (nextReadyButton || `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="keep-working">Keep working</button>`)
+      ? (nextReadyButton || `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="keep-working">Return to route</button>`)
       : nextReadyButton)
     : isBlocked
     ? `<button class="concept-page-b2__entry-cta concept-page-b2__entry-cta--disabled" type="button" disabled aria-disabled="true" title="Write from memory on the entry above first">Locked</button>`
-    : `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="${escHtml(ctaAction)}">${ctaLabel}</button>`;
-  const compareFeedbackHtml = isPostRevealComparison
-    ? ' <button class="concept-page-b2__feedback-link" type="button" data-feedback-rating data-feedback-moment="compare notes">Rate this moment</button>'
-    : '';
+    : `<button class="concept-page-b2__entry-cta" type="button" data-active-entry-id="${escHtml(activeEntryId)}" data-active-entry-action="${escHtml(ctaAction)}">${ctaLabel}</button>`);
   const truthNoteText = isAttempting
     ? 'Study stays hidden until you save a draft. This is not a grade.'
     : 'Your words shape the path. This is not a grade.';
@@ -895,11 +937,10 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
   const activeEntryClass = [
     'concept-page-b2__active-entry',
     options?.isDrilling ? 'concept-page-b2__active-entry--drilling' : '',
-    suppressPurposeForScaffoldAttempt ? 'concept-page-b2__active-entry--prompt-first' : '',
   ].filter(Boolean).join(' ');
   const activeHtml = `
     <section class="${activeEntryClass}" aria-label="Active concept entry">
-      <span class="eyebrow concept-page-b2__entry-eyebrow">${escHtml(visibleEntryEyebrow)}</span>
+      ${visibleEntryEyebrow ? `<span class="eyebrow concept-page-b2__entry-eyebrow">${escHtml(visibleEntryEyebrow)}</span>` : ''}
       <h2 class="concept-page-b2__entry-title">${escHtml(activeEntryTitle)}</h2>
       ${entryPurpose ? `<p class="concept-page-b2__entry-purpose">${escHtml(entryPurpose)}</p>` : ''}
       ${options?.isDrilling ? renderDrillChamberHtml() : `
@@ -908,12 +949,12 @@ export function renderActiveEntryHtml(activeEntry, activeIdx, backbone, concept,
         ${repairPanelHtml}
         ${attemptPanelHtml}
         ${ctaButton}
-        <p class="concept-page-b2__truth-note">${escHtml(truthNoteText)}${compareFeedbackHtml}</p>
+        ${isSavedRepairAwaitingCheck ? '' : `<p class="concept-page-b2__truth-note">${escHtml(truthNoteText)}</p>`}
       `}
     </section>
   `;
 
-  const suppressNearbyForPrimaryHandoff = Boolean(nextReadyButton) && options?.repairCheckedThisSession === true;
+  const suppressNearbyForPrimaryHandoff = Boolean(nextReadyButton) && repairPhase === 'checked';
   const nearby = !hidesRouteAndNearby && isExpandedWorkspace && !isAttempting && !suppressNearbyForPrimaryHandoff
     ? backbone.filter((n) => n !== activeEntry)
     : [];

--- a/public/js/concept-page-view.js
+++ b/public/js/concept-page-view.js
@@ -742,6 +742,18 @@ function renderDrillChamberHtml() {
         <div class="drill-chamber__chat-log" id="chamber-chat-log" hidden></div>
 
         <div class="drill-chamber__active" id="chamber-active">
+          <div class="drill-chamber__beat">
+            <span class="drill-chamber__beat-label" id="chamber-beat-label">Reconstruct</span>
+            <p class="drill-chamber__beat-note" id="chamber-beat-note">Build the connection before you see it.</p>
+          </div>
+          <blockquote class="drill-chamber__anchor" id="chamber-anchor" hidden>
+            <span id="chamber-anchor-label">Your first model</span>
+            <p id="chamber-anchor-text"></p>
+          </blockquote>
+          <aside class="drill-chamber__bridge" id="chamber-bridge" hidden>
+            <span>Mechanism</span>
+            <p id="chamber-bridge-text"></p>
+          </aside>
           <p class="drill-chamber__question" id="chamber-question">—</p>
           <div class="drill-chamber__verdict" id="chamber-verdict" role="status" aria-live="polite" hidden></div>
           <div class="drill-chamber__composer">
@@ -750,10 +762,10 @@ function renderDrillChamberHtml() {
               <span class="drill-chamber__hint" id="chamber-hint">A sentence is enough.</span>
               <div class="drill-chamber__composer-actions">
                 <button class="drill-chamber__voice-button" id="chamber-mic" type="button" aria-label="Dictate answer" aria-pressed="false" hidden>
-                  <span aria-hidden="true">mic</span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6"/></svg>
                 </button>
                 <button class="drill-chamber__voice-button" id="chamber-tutor-voice" type="button" aria-label="Tutor voice off" aria-pressed="false" hidden>
-                  <span aria-hidden="true">voice</span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 5 6.5 9H3v6h3.5l4.5 4zM15 9a4 4 0 0 1 0 6M18 6a8 8 0 0 1 0 12"/></svg>
                 </button>
                 <button class="drill-chamber__send" id="chamber-send" type="button">Check my answer</button>
               </div>

--- a/public/js/drill-chamber.js
+++ b/public/js/drill-chamber.js
@@ -23,6 +23,7 @@ let tutorVoiceEnabled = false;
 let lastSpokenQuestion = '';
 let pendingVerdictTimer = null;
 let pendingVerdictShown = false;
+let currentSurface = 'challenge';
 const DEFAULT_SEND_LABEL = 'Check my answer';
 const DEFAULT_HINT = 'A sentence is enough.';
 const EMPTY_REPLY_HINT = 'Write a sentence before checking.';
@@ -30,6 +31,78 @@ const CHECKING_REPLY_HINT = 'Checking your answer…';
 const PENDING_VERDICT = 'Answer received • Checking the link you wrote.';
 const PENDING_VERDICT_DELAY_MS = 1200;
 const _originalPlaceholder = 'Write your reconstruction here. Fragments are fine.';
+const SURFACES = {
+  challenge: {
+    label: 'Reconstruct',
+    note: 'Build the connection before you see it.',
+    send: 'Check the link',
+    hint: 'One clear connection is enough.',
+    placeholder: _originalPlaceholder,
+  },
+  gap: {
+    label: 'One missing link',
+    note: 'Your first model is held steady. Work only the edge that broke.',
+    send: 'Work this link',
+    hint: 'The rest of your model stays untouched.',
+    placeholder: 'Add only the missing connection.',
+  },
+  repair: {
+    label: 'Repair one link',
+    note: 'Use the question to revise your own explanation.',
+    send: 'Try this repair',
+    hint: 'Answer the question in your own words.',
+    placeholder: 'Complete the causal link.',
+  },
+  recovery: {
+    label: 'One smaller step',
+    note: 'Get unstuck without turning help into evidence.',
+    send: 'Try this step',
+    hint: 'One short connection is enough.',
+    placeholder: 'Name the first part of the link you can see.',
+  },
+  'repair-ready': {
+    label: 'Link formed',
+    note: 'Now compare your connection with the full mechanism.',
+    send: 'See the connection',
+    hint: 'Your repair is kept as written.',
+    placeholder: '',
+  },
+  bridge: {
+    label: 'Compare',
+    note: 'Compare this with your repair, then rebuild from memory.',
+    send: 'Close and rebuild',
+    hint: 'The next turn does not change your record.',
+    placeholder: '',
+  },
+  transfer: {
+    label: 'Rebuild',
+    note: 'The bridge is closed. Use the connection somewhere new.',
+    send: 'Check the transfer',
+    hint: 'This is practice, not mastery evidence.',
+    placeholder: 'Rebuild the connection from memory.',
+  },
+  settle: {
+    label: 'Loop complete',
+    note: 'You found a gap, repaired it, and rebuilt once.',
+    send: 'Return to concept',
+    hint: 'A later memory check can change the record.',
+    placeholder: '',
+  },
+  complete: {
+    label: 'Loop complete',
+    note: 'Your recorded work is preserved without an extra mastery claim.',
+    send: 'Return to concept',
+    hint: 'The next evidence comes from a later reconstruction.',
+    placeholder: '',
+  },
+  unsupported: {
+    label: 'Loop paused',
+    note: 'This step cannot be shown safely in this app.',
+    send: 'Return to concept',
+    hint: 'Your recorded work is unchanged.',
+    placeholder: '',
+  },
+};
 const MIC_INPUT_PREF_KEY = 'socratink.loop.micInput';
 const TUTOR_VOICE_PREF_KEY = 'socratink.loop.tutorVoice';
 
@@ -71,6 +144,13 @@ function bind() {
   els.exit = document.getElementById('chamber-exit');
   els.chatLog = document.getElementById('chamber-chat-log');
   els.verdict = document.getElementById('chamber-verdict');
+  els.beatLabel = document.getElementById('chamber-beat-label');
+  els.beatNote = document.getElementById('chamber-beat-note');
+  els.anchor = document.getElementById('chamber-anchor');
+  els.anchorLabel = document.getElementById('chamber-anchor-label');
+  els.anchorText = document.getElementById('chamber-anchor-text');
+  els.bridge = document.getElementById('chamber-bridge');
+  els.bridgeText = document.getElementById('chamber-bridge-text');
 
   if (!hasRequiredElements()) return false;
 
@@ -126,6 +206,7 @@ function show({ conceptName, entryName, question }) {
   els.conceptName.textContent = conceptName || '—';
   els.entryName.textContent = entryName || '—';
   els.question.textContent = question || '—';
+  setSurface('challenge');
   els.composer.value = '';
   setComposerEnabled(true);
   syncVoiceControls();
@@ -143,6 +224,38 @@ function show({ conceptName, entryName, question }) {
       || els.view.contains(active);
     if (canClaimFocus) els.composer.focus();
   });
+}
+
+function setSurface(mode = 'challenge', context = {}) {
+  if (!bind()) return;
+  const surface = SURFACES[mode] || SURFACES.challenge;
+  currentSurface = SURFACES[mode] ? mode : 'challenge';
+  els.view.setAttribute('data-loop-surface', currentSurface);
+  if (els.beatLabel) els.beatLabel.textContent = surface.label;
+  if (els.beatNote) els.beatNote.textContent = surface.note;
+  if (els.anchor && els.anchorText) {
+    const originalText = String(context.originalText || '').trim();
+    const repairText = String(context.repairText || '').trim();
+    const useRepair = ['repair-ready', 'bridge'].includes(mode) && repairText;
+    const anchorText = useRepair ? repairText : originalText;
+    if (els.anchorLabel) els.anchorLabel.textContent = useRepair ? 'Your repair' : 'Your first model';
+    els.anchorText.textContent = anchorText;
+    els.anchor.hidden = !anchorText || !['gap', 'repair', 'repair-ready', 'bridge'].includes(mode);
+  }
+  if (els.bridge && els.bridgeText) {
+    const bridgeText = String(context.bridgeText || '').trim();
+    els.bridgeText.textContent = bridgeText;
+    els.bridge.hidden = mode !== 'bridge' || !bridgeText;
+  }
+  els.send.textContent = surface.send;
+  els.composer.placeholder = surface.placeholder;
+  setComposerHint(surface.hint);
+}
+
+function restoreSurfaceComposer() {
+  const surface = SURFACES[currentSurface] || SURFACES.challenge;
+  els.composer.placeholder = surface.placeholder;
+  setComposerHint(surface.hint);
 }
 
 function hide() {
@@ -200,6 +313,15 @@ function swapQuestion(nextText) {
   }, 240);
 }
 
+function setQuestion(text) {
+  if (!bind()) return;
+  clearCompletionAction();
+  clearVerdict();
+  els.question.textContent = String(text || '').trim() || 'Your turn.';
+  els.composer.value = '';
+  speakTutorQuestion(els.question.textContent);
+}
+
 function setComposerEnabled(enabled) {
   if (!bind()) return;
   if (!enabled && listening) speechRecognition?.stop();
@@ -236,9 +358,8 @@ function setLoading(loading, { checkingAnswer = false } = {}) {
     if (pendingVerdictTimer != null) clearTimeout(pendingVerdictTimer);
     pendingVerdictTimer = null;
     if (pendingVerdictShown) clearVerdict();
-    els.composer.placeholder = _originalPlaceholder;
+    restoreSurfaceComposer();
     els.active?.removeAttribute('data-loading');
-    resetComposerHint();
   }
 }
 
@@ -268,9 +389,9 @@ function clearCompletionAction() {
   if (!hasRequiredElements()) return;
   completionHandler = null;
   els.active?.removeAttribute('data-complete');
-  els.send.textContent = DEFAULT_SEND_LABEL;
-  els.composer.placeholder = _originalPlaceholder;
-  resetComposerHint();
+  const surface = SURFACES[currentSurface] || SURFACES.challenge;
+  els.send.textContent = surface.send || DEFAULT_SEND_LABEL;
+  restoreSurfaceComposer();
 }
 
 function clearVerdict() {
@@ -476,8 +597,8 @@ function initVoiceControls() {
 }
 
 window.DrillChamber = {
-  show, hide, appendHistoryTurn, swapQuestion,
-  setComposerEnabled, setLoading, setCompletionAction,
+  show, hide, appendHistoryTurn, swapQuestion, setQuestion,
+  setComposerEnabled, setLoading, setCompletionAction, setSurface,
   getComposerValue, clearComposer,
   appendCreed, appendVerdict, clearVerdict,
   onSend, onExit,

--- a/public/js/learner-state-sync.js
+++ b/public/js/learner-state-sync.js
@@ -96,6 +96,14 @@ function earliestIso(a, b) {
   return aMs <= bMs ? a : b;
 }
 
+function latestIso(a, b) {
+  const aMs = Date.parse(a || '');
+  const bMs = Date.parse(b || '');
+  if (!Number.isFinite(aMs)) return b || null;
+  if (!Number.isFinite(bMs)) return a || null;
+  return aMs >= bMs ? a : b;
+}
+
 export function mergeTrainingRecords(localTraining, remoteTraining) {
   if (!localTraining) return remoteTraining || null;
   if (!remoteTraining) return localTraining;
@@ -116,6 +124,7 @@ export function mergeTrainingRecords(localTraining, remoteTraining) {
       attempts: mergeAttemptLists(localNode.attempts, remoteNode.attempts),
       repairs: mergeRepairLists(localNode.repairs, remoteNode.repairs),
       study_revealed_at: earliestIso(localNode.study_revealed_at, remoteNode.study_revealed_at),
+      repair_checked_at: latestIso(localNode.repair_checked_at, remoteNode.repair_checked_at),
     };
   });
 

--- a/public/js/seda-evidence-projection.js
+++ b/public/js/seda-evidence-projection.js
@@ -50,6 +50,14 @@ function latestColdAttemptEvent(data) {
   return null;
 }
 
+function latestIndexedEvent(data, type) {
+  const events = Array.isArray(data?.events) ? data.events : [];
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index]?.type === type) return { event: events[index], index };
+  }
+  return null;
+}
+
 // Select the single attempted backend node record. A SEDA session completes
 // exactly one node, so zero or several attempted records is unexpected; fail
 // closed rather than arbitrarily projecting whichever happens to be first.
@@ -104,9 +112,9 @@ function baseTraining(training, conceptId) {
 }
 
 /**
- * Projects the latest recordable SEDA cold_attempt event before the case is
- * complete. This lets first-session study reveal honor the cold-attempt gate
- * without waiting for the whole spaced SEDA case to finish.
+ * Projects recordable progress before the case is complete: the cold attempt,
+ * the honest study-reveal boundary, and the learner's accepted repair. The
+ * repair dialogue and immediate transfer remain graph-neutral and unprojected.
  */
 export function projectLatestSedaAttemptEvent({
   training = null,
@@ -126,10 +134,42 @@ export function projectLatestSedaAttemptEvent({
     : {};
   const existing = nodeRecords[nodeId] || { attempts: [], repairs: [] };
   const existingAttempts = Array.isArray(existing.attempts) ? existing.attempts : [];
+  const existingRepairs = Array.isArray(existing.repairs) ? existing.repairs : [];
+  const attempts = [...existingAttempts];
+  const repairs = [...existingRepairs];
+  let studyRevealedAt = existing.study_revealed_at;
+  let changed = false;
   const attemptId = sedaEventAttemptId(sessionId, coldAttempt.index);
-  if (existingAttempts.some((attempt) => attempt?.id === attemptId)) {
-    return null;
+  if (!attempts.some((attempt) => attempt?.id === attemptId)) {
+    attempts.push({
+      id: attemptId,
+      at: now,
+      user_text: coldAttempt.text,
+      classification: coldAttempt.classification,
+      gaps: gapsForEarlyAttempt(coldAttempt.event?.evaluation),
+      grader_version: coldAttempt.event?.evaluation?.prompt_version
+        || coldAttempt.event?.evaluation?.grader_version
+        || 'seda-loop',
+      kind: attempts.length === 0 ? 'cold' : 'spaced',
+    });
+    changed = true;
   }
+
+  if (!studyRevealedAt && latestIndexedEvent(data, 'gap_identified')) {
+    studyRevealedAt = now;
+    changed = true;
+  }
+
+  const repairEvent = latestIndexedEvent(data, 'repair');
+  if (repairEvent?.event?.text && studyRevealedAt) {
+    const repairId = `${sedaEventAttemptId(sessionId, repairEvent.index)}-repair`;
+    if (!repairs.some((repair) => repair?.id === repairId)) {
+      repairs.push({ id: repairId, at: now, text: repairEvent.event.text });
+      changed = true;
+    }
+  }
+
+  if (!changed) return null;
 
   return {
     ...next,
@@ -139,21 +179,9 @@ export function projectLatestSedaAttemptEvent({
       ...nodeRecords,
       [nodeId]: {
         ...existing,
-        attempts: [
-          ...existingAttempts,
-          {
-            id: attemptId,
-            at: now,
-            user_text: coldAttempt.text,
-            classification: coldAttempt.classification,
-            gaps: gapsForEarlyAttempt(coldAttempt.event?.evaluation),
-            grader_version: coldAttempt.event?.evaluation?.prompt_version
-              || coldAttempt.event?.evaluation?.grader_version
-              || 'seda-loop',
-            kind: existingAttempts.length === 0 ? 'cold' : 'spaced',
-          },
-        ],
-        repairs: Array.isArray(existing.repairs) ? existing.repairs : [],
+        attempts,
+        repairs,
+        ...(studyRevealedAt ? { study_revealed_at: studyRevealedAt } : {}),
       },
     },
   };
@@ -210,6 +238,13 @@ export function projectCompletedSedaRecord({
     completedStartIndex = 1;
   }
 
+  const existingRepairs = Array.isArray(existing.repairs) ? existing.repairs : [];
+  const eventRepairPrefix = `seda-${sessionId}-event-`;
+  const canonicalRepairs = restampedRepairs({ backendRecord, sessionId, now });
+  const reconciledRepairs = existingRepairs.filter(
+    (repair) => !String(repair?.id || '').startsWith(eventRepairPrefix),
+  );
+
   const projected = {
     ...existing,
     attempts: [
@@ -222,10 +257,7 @@ export function projectCompletedSedaRecord({
         startIndex: completedStartIndex,
       }),
     ],
-    repairs: [
-      ...(Array.isArray(existing.repairs) ? existing.repairs : []),
-      ...restampedRepairs({ backendRecord, sessionId, now }),
-    ],
+    repairs: [...reconciledRepairs, ...canonicalRepairs],
   };
   if (backendRecord.study_revealed_at && !projected.study_revealed_at) {
     projected.study_revealed_at = now;

--- a/public/js/seda-visible-prompt.js
+++ b/public/js/seda-visible-prompt.js
@@ -79,3 +79,116 @@ export function visibleSedaPromptFromResponse(data) {
     .join('\n');
   return [visible, cta].filter(Boolean).join('\n\n') || 'Your turn.';
 }
+
+function latestEvent(data, type) {
+  const events = Array.isArray(data?.events) ? data.events : [];
+  return events.findLast((event) => event?.type === type) || null;
+}
+
+const AWAITING_SURFACE_MODE = Object.freeze({
+  cmd: 'challenge',
+  concept: 'challenge',
+  learner_goal: 'challenge',
+  launch_attempt: 'challenge',
+  substrate_refinement: 'challenge',
+  cold_attempt: 'challenge',
+  repair: 'repair',
+  repair_dialogue_turns: 'repair',
+  repair_recovery: 'recovery',
+  run_gap_drill: 'bridge',
+  gap_attempt: 'transfer',
+  spaced_attempt: 'settle',
+});
+
+function surfaceMode(data, lastEvent) {
+  if (data?.caseComplete) return 'complete';
+  const awaitingKey = data?.awaiting?.key || null;
+  if (awaitingKey === 'continue') return lastEvent?.type === 'repair' ? 'repair-ready' : 'gap';
+  return AWAITING_SURFACE_MODE[awaitingKey] || 'unsupported';
+}
+
+function surfacePresentation(mode, { prompt, gapText }) {
+  if (mode === 'gap') return {
+    question: gapText || 'There is one missing connection in your model.',
+    composerEnabled: false,
+    completionAction: { label: 'Work this link', kind: 'submit', value: 'continue' },
+  };
+  if (mode === 'repair') return {
+    question: gapText || prompt,
+    composerEnabled: true,
+    completionAction: null,
+  };
+  if (mode === 'recovery') return {
+    question: prompt || 'Name only the first part of the link you can see.',
+    composerEnabled: true,
+    completionAction: null,
+  };
+  if (mode === 'repair-ready') return {
+    question: 'You formed the missing connection in your own words.',
+    composerEnabled: false,
+    completionAction: { label: 'See the connection', kind: 'submit', value: 'continue' },
+  };
+  if (mode === 'bridge') return {
+    question: 'Close it when you can rebuild the link.',
+    composerEnabled: false,
+    completionAction: { label: 'Close and rebuild', kind: 'submit', value: 'y' },
+  };
+  if (mode === 'transfer') return {
+    question: 'Without looking back, rebuild the connection in your own words. Then name one situation where it would matter.',
+    composerEnabled: true,
+    completionAction: null,
+  };
+  if (mode === 'settle') return {
+    question: 'Keep the repaired connection. The next useful test is later, from memory.',
+    composerEnabled: false,
+    completionAction: { label: 'Return to concept', kind: 'return' },
+    verdict: 'Repair practiced • This turn did not change your record.',
+  };
+  if (mode === 'complete') return {
+    question: 'This learning loop is complete.',
+    composerEnabled: false,
+    completionAction: { label: 'Return to concept', kind: 'return' },
+  };
+  if (mode === 'unsupported') return {
+    question: 'This learning step is not available here. Your recorded work is unchanged.',
+    composerEnabled: false,
+    completionAction: { label: 'Return to concept', kind: 'return' },
+  };
+  return {
+    question: prompt,
+    composerEnabled: true,
+    completionAction: null,
+  };
+}
+
+/**
+ * Maps the hosted SEDA transport state onto the learner-facing nested loop.
+ * This is presentation only: evidence eligibility stays owned by SEDA events.
+ */
+export function sedaSurfaceFromResponse(data) {
+  const lastEvent = Array.isArray(data?.events) ? data.events.at(-1) : null;
+  const mode = surfaceMode(data, lastEvent);
+
+  const coldAttempt = latestEvent(data, 'cold_attempt');
+  const gap = latestEvent(data, 'gap_identified');
+  const repair = latestEvent(data, 'repair');
+  const bridge = latestEvent(data, 'model_bridge');
+
+  const surface = {
+    mode,
+    prompt: visibleSedaPromptFromResponse(data),
+    originalText: learnerVisibleSedaText(coldAttempt?.text || ''),
+    gapText: learnerVisibleSedaText(
+      gap?.repair_scaffold?.socratic_question
+      || gap?.gap_log?.missing_operation
+      || data?.awaiting?.ctaText
+      || '',
+    ),
+    repairText: learnerVisibleSedaText(repair?.text || ''),
+    bridgeText: learnerVisibleSedaText(bridge?.text || ''),
+  };
+  return {
+    ...surface,
+    ...surfacePresentation(mode, surface),
+  };
+}

--- a/public/js/seda-visible-prompt.js
+++ b/public/js/seda-visible-prompt.js
@@ -147,7 +147,7 @@ function surfacePresentation(mode, { prompt, gapText }) {
   if (mode === 'complete') return {
     question: 'This learning loop is complete.',
     composerEnabled: false,
-    completionAction: { label: 'Return to concept', kind: 'return' },
+    completionAction: { kind: 'study' },
   };
   if (mode === 'unsupported') return {
     question: 'This learning step is not available here. Your recorded work is unchanged.',

--- a/public/login.html
+++ b/public/login.html
@@ -13,8 +13,8 @@
   <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png?v=6">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
-  <link rel="stylesheet" href="/css/tokens.css?v=2">
-  <link rel="stylesheet" href="/css/login.css?v=5">
+  <link rel="stylesheet" href="/css/tokens.css?v=3">
+  <link rel="stylesheet" href="/css/login.css?v=6">
 </head>
 <body data-mode="signin">
   <div id="stardust-container" aria-hidden="true"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,9 +1,9 @@
-@import './css/variables.css?v=82';
-@import './css/base.css?v=73';
+@import './css/variables.css?v=83';
+@import './css/base.css?v=74';
 @import './css/crystal.css?v=71';
-@import './css/components.css?v=102';
-@import './css/layout.css?v=111';
+@import './css/components.css?v=103';
+@import './css/layout.css?v=112';
 @import './css/board-first.css?v=9';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=8';
-@import './css/concept-page.css?v=57';
+@import './css/concept-page.css?v=61';

--- a/tests/e2e/test_app_helper_modules.py
+++ b/tests/e2e/test_app_helper_modules.py
@@ -1356,7 +1356,8 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               {},
               { metadata: {} },
             );
-            assert(legacyStudyHtml.includes('Draft saved'), 'legacy primed study stays in study phase');
+            assert(legacyStudyHtml.includes('Your draft'), 'legacy primed study keeps the learner draft visible');
+            assert(!legacyStudyHtml.includes('Draft saved'), 'legacy primed study removes phase jargon');
             assert(legacyStudyHtml.includes('data-active-entry-action="study"'), 'legacy primed study reveals study before redrill');
             assert(legacyStudyHtml.includes('Reveal notes and compare'), 'legacy primed study cta is learner-facing');
             const legacyStudyRevealedHtml = conceptPage.renderActiveEntryHtml(
@@ -1545,7 +1546,8 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
               }
             );
             assert(conceptPagePrimedHtml.includes('concept-page-b2__threshold--empty'), 'concept page empty threshold');
-            assert(conceptPagePrimedHtml.includes('Draft saved'), 'concept page primed study eyebrow');
+            assert(conceptPagePrimedHtml.includes('Your draft'), 'concept page primed study labels the learner artifact');
+            assert(!conceptPagePrimedHtml.includes('Draft saved'), 'concept page primed study removes ceremonial copy');
             assert(conceptPagePrimedHtml.includes('concept-page-b2__evidence'), 'concept page primed shows recorded draft before study');
             assert(conceptPagePrimedHtml.includes('Your memory draft'), 'concept page primed evidence uses learner language');
             assert(conceptPagePrimedHtml.includes('A strong first attempt.'), 'concept page primed preserves learner words before study');
@@ -1655,7 +1657,9 @@ def test_app_helper_modules_preserve_browser_contracts(clean_page: Page, base_ur
             assert(conceptPageRepairHtml.includes('Use your words. One or two sentences is enough.'), 'concept page repair gives brief scope');
             assert(!conceptPageRepairHtml.includes('1 missing link to repair'), 'concept page repair removes count chip noise');
             assert(!conceptPageRepairHtml.includes('Save this repair before you try from memory again.'), 'concept page repair removes order explanation');
-            assert(conceptPageRepairHtml.includes('Show study note'), 'concept page repair starts with study note tucked away');
+            assert(conceptPageRepairHtml.includes('Hide study note'), 'concept page repair starts with the study note visible');
+            assert(conceptPageRepairHtml.includes('data-active-entry-action="write-repair"'), 'concept page repair stages writing behind an explicit action');
+            assert(/concept-page-b2__repair[^>]+hidden/.test(conceptPageRepairHtml), 'concept page repair form stays out of the accessibility tree until requested');
             assert(conceptPageRepairHtml.includes('Save repair'), 'concept page repair save');
             const conceptPageFallbackRepairHtml = conceptPage.renderActiveEntryHtml(
               { label: 'Fallback repair', study_note: 'Study the unnamed entry.' },

--- a/tests/e2e/test_drill_chamber.py
+++ b/tests/e2e/test_drill_chamber.py
@@ -399,7 +399,7 @@ def test_drill_chamber_opens_inline_inside_concept_view(
       1. Seed a concept with a graph and navigate to its map view.
       2. Invoke App.startDrill() via the browser to simulate the user
          clicking a drill-ready graph node.
-      3. Assert the chamber is visible without hiding the concept context.
+      3. Assert the chamber is visible without replacing the concept view.
 
     Note: this test exercises the JS wiring (startDrill -> DrillChamber.show)
     without making a real network call to the drill API. The typing indicator
@@ -441,7 +441,7 @@ def test_drill_chamber_opens_inline_inside_concept_view(
     expect(clean_page.locator("#chamber-composer")).not_to_have_attribute(
         "placeholder", "Preparing your first question"
     )
-    expect(clean_page.locator("#chamber-send")).to_have_text("Check my answer")
+    expect(clean_page.locator("#chamber-send")).to_have_text("Check the link")
     expect(clean_page.locator(".concept-page-b2__entry-eyebrow")).to_have_text("Reconstruction")
     expect(clean_page.locator("#drill-chamber-view")).to_contain_text(
         "Reconstruct Entry A from memory"
@@ -464,8 +464,9 @@ def test_drill_chamber_opens_inline_inside_concept_view(
     )
     clean_page.evaluate("window.DrillChamber.setLoading(false)")
     expect(clean_page.locator(".node-strip")).to_be_visible()
-    expect(clean_page.locator(".vd-sketch-wrapper")).to_be_visible()
-    # The concept view remains visible as context during an active drill.
+    expect(clean_page.locator(".vd-sketch-wrapper")).to_have_count(1)
+    # The concept view remains mounted during an active drill, while its
+    # secondary context may stay collapsed to keep reconstruction focused.
     expect(clean_page.locator("#map-view")).to_be_visible()
     clean_page.locator('.concept-page-b2__route-item[data-entry-id="entry-a"]').focus()
     clean_page.keyboard.press("Enter")

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1462,7 +1462,7 @@ def _seda_route_result(**kwargs) -> dict:
 def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
     clean_page: Page, base_url: str
 ) -> None:
-    """The Door sketch bootstraps SEDA; the first room answer earns study."""
+    """The real chamber carries one SEDA case through the nested learner loop."""
     page = clean_page
     _enter_app_shell_as_guest(page, base_url)
 
@@ -1510,6 +1510,8 @@ def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
     room_answer = (
         "Memory cells remain after the first exposure and make the second response faster."
     )
+    repair_answer = "The retained cells recognize the antigen and activate sooner."
+    transfer_answer = "A saved pattern can make a later matching response start sooner."
     routed_prompt = "Route prompt B: why does the later response happen faster?"
     routed_mechanism = (
         "Route mechanism B: memory cells persist and activate sooner on re-exposure."
@@ -1550,32 +1552,63 @@ def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
                 }),
             )
             return
+        route_event = _seda_route_event(
+            node_id="c9_s1", label="Routed memory target",
+            prompt=routed_prompt, mechanism=routed_mechanism,
+        )
+        cold_event = {
+            "type": "cold_attempt", "kc_id": "c9_s1", "text": room_answer,
+            "evaluation": {
+                "classification": "deep",
+                "agent_response": (
+                    "You connected memory cells to the faster response, "
+                    "but not why they react sooner."
+                ),
+                "gap_description": "Name why memory cells respond faster.",
+                "grader_version": "qa",
+            },
+        }
+        gap_event = {
+            "type": "gap_identified", "graph_neutral": True,
+            "repair_scaffold": {
+                "socratic_question": "What lets the retained cells react sooner?",
+            },
+            "gap_log": {"missing_operation": "recognition triggers faster activation"},
+        }
+        repair_turn = {
+            "type": "repair_dialogue_turn", "text": repair_answer,
+            "bridge_ready": True, "graph_neutral": True, "score_eligible": False,
+        }
+        repair_event = {"type": "repair", "text": repair_answer, "graph_neutral": True}
+        bridge_event = {"type": "model_bridge", "text": routed_mechanism, "graph_neutral": True}
+        decision_event = {
+            "type": "post_bridge_transfer_decision", "run_gap": True,
+            "graph_neutral": True, "score_eligible": False,
+        }
+        transfer_event = {
+            "type": "post_bridge_transfer_check", "text": transfer_answer,
+            "graph_neutral": True, "score_eligible": False,
+            "evaluation": {"classification": "deep"},
+        }
+        turns = {
+            2: ({"key": "continue", "ctaText": cold_event["evaluation"]["agent_response"]}, [route_event, cold_event]),
+            3: ({"key": "repair", "ctaText": gap_event["repair_scaffold"]["socratic_question"]}, [route_event, cold_event, gap_event]),
+            4: ({"key": "continue", "ctaText": "Continue."}, [route_event, cold_event, gap_event, repair_turn, repair_event]),
+            5: ({"key": "run_gap_drill", "ctaText": "Try using it somewhere new?"}, [route_event, cold_event, gap_event, repair_turn, repair_event, bridge_event]),
+            6: ({"key": "gap_attempt", "ctaText": "Use it somewhere new."}, [route_event, cold_event, gap_event, repair_turn, repair_event, bridge_event, decision_event]),
+            7: ({"key": "spaced_attempt", "ctaText": "From memory, explain it again."}, [route_event, cold_event, gap_event, repair_turn, repair_event, bridge_event, decision_event, transfer_event]),
+        }
+        awaiting, events = turns[len(turn_texts)]
         route.fulfill(
             status=200,
             content_type="application/json",
             body=json.dumps({
                 "sessionId": "mid-loop-session",
-                "sessionVersion": 3,
+                "sessionVersion": len(turn_texts) + 1,
                 "status": "awaiting_input",
-                "awaiting": {
-                    "key": "compare",
-                    "ctaText": "Compare your answer with the note.",
-                },
+                "awaiting": awaiting,
                 "learnerTranscript": [],
-                "events": [{
-                    "type": "cold_attempt",
-                    "kc_id": "c9_s1",
-                    "text": room_answer,
-                    "evaluation": {
-                        "classification": "deep",
-                        "agent_response": (
-                            "You connected memory cells to the faster response, "
-                            "but not why they react sooner."
-                        ),
-                        "gap_description": "Name why memory cells respond faster.",
-                        "grader_version": "qa",
-                    },
-                }],
+                "events": events,
                 "caseComplete": False,
                 "record": None,
             }),
@@ -1650,9 +1683,9 @@ def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
     expect(page.locator("#chamber-verdict")).not_to_contain_text(
         "You connected memory cells to the faster response, but not why they react sooner."
     )
-    expect(page.locator("#chamber-send")).to_have_text("See what to study")
+    expect(page.locator("#chamber-send")).to_have_text("Work this link")
     expect(page.locator("#chamber-composer")).to_be_disabled()
-    expect(page.locator("#chamber-question")).to_have_text(routed_prompt)
+    expect(page.locator("#chamber-question")).to_contain_text("not why they react sooner")
     assert turn_texts == [door_sketch, room_answer]
     assert [payload["expectedVersion"] for payload in turn_payloads] == [1, 2]
     projected = page.wait_for_function(
@@ -1681,10 +1714,39 @@ def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
         }"""
     ) is False
     page.locator("#chamber-send").click()
-    expect(page.locator("#drill-chamber-view")).to_be_hidden()
-    expect(page.locator(".concept-page-b2__study-note")).to_contain_text(
-        routed_mechanism, timeout=20_000
+    expect(page.locator("#drill-chamber-view")).to_have_attribute("data-loop-surface", "repair")
+    expect(page.locator("#chamber-anchor-text")).to_have_text(room_answer)
+    expect(page.locator("#chamber-question")).to_have_text("What lets the retained cells react sooner?")
+    page.locator("#chamber-composer").fill(repair_answer)
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_attribute("data-loop-surface", "repair-ready")
+    expect(page.locator("#chamber-anchor-label")).to_have_text("Your repair")
+    expect(page.locator("#chamber-anchor-text")).to_have_text(repair_answer)
+    expect(page.locator("#chamber-send")).to_have_text("See the connection")
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_attribute("data-loop-surface", "bridge")
+    expect(page.locator("#chamber-anchor-label")).to_have_text("Your repair")
+    expect(page.locator("#chamber-anchor-text")).to_have_text(repair_answer)
+    expect(page.locator("#chamber-bridge-text")).to_have_text(routed_mechanism)
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_attribute("data-loop-surface", "transfer")
+    expect(page.locator("#chamber-bridge")).to_be_hidden()
+    page.locator("#chamber-composer").fill(transfer_answer)
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_attribute("data-loop-surface", "settle")
+    assert turn_texts == [
+        door_sketch, room_answer, "continue", repair_answer, "continue", "y", transfer_answer,
+    ]
+    evidence = page.evaluate(
+        """() => {
+          const conceptId = localStorage.getItem('learnops_active');
+          const training = JSON.parse(localStorage.getItem(`socratink:training:v1:${conceptId}`));
+          return training.node_records.c9_s1;
+        }"""
     )
+    assert len(evidence["attempts"]) == 1
+    assert [repair["text"] for repair in evidence["repairs"]] == [repair_answer]
+    assert evidence["study_revealed_at"]
 
 
 def test_late_source_less_route_cannot_overwrite_a_newly_selected_concept(
@@ -2024,8 +2086,9 @@ def test_seda_support_turn_is_neutral_and_records_no_evidence(
     expect(page.locator("#chamber-verdict")).to_contain_text("Response received")
     expect(page.locator("#chamber-verdict")).not_to_contain_text("Gap found")
     expect(page.locator("#chamber-verdict")).not_to_contain_text("Study")
-    expect(page.locator("#chamber-send")).to_have_text("Keep going")
-    expect(page.locator("#chamber-composer")).to_be_disabled()
+    expect(page.locator("#chamber-send")).to_have_text("Check the link")
+    expect(page.locator("#chamber-question")).to_have_text("Try one concrete cause.")
+    expect(page.locator("#chamber-composer")).to_be_enabled()
     assert turn_texts == [door_sketch, support_text]
     assert [payload["expectedVersion"] for payload in turn_payloads] == [1, 2]
     attempt_count = page.evaluate(
@@ -2038,8 +2101,6 @@ def test_seda_support_turn_is_neutral_and_records_no_evidence(
         }"""
     )
     assert attempt_count == 0
-    page.locator("#chamber-send").click()
-    expect(page.locator("#chamber-composer")).to_be_enabled()
 
 
 def test_seda_start_failure_offers_retry_from_product_flow(
@@ -3064,7 +3125,7 @@ def test_seda_transport_failure_keeps_draft_and_retries_same_turn(
             && document.getElementById('chamber-question')?.textContent
               === 'Why is the later response faster?'
             && document.getElementById('chamber-composer')?.disabled === false
-            && document.getElementById('chamber-send')?.textContent === 'Check my answer';
+            && document.getElementById('chamber-send')?.textContent === 'Check the link';
         }""",
         timeout=20_000,
     )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -690,7 +690,7 @@ def test_localhost_library_qa_seed_creates_training_truth_concept(
         "No source attached. Treat this route as provisional."
     )
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Draft saved"
+        "Your draft"
     )
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
         "Reveal notes and compare"
@@ -711,26 +711,9 @@ def test_localhost_library_qa_seed_creates_training_truth_concept(
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
         "Compare notes"
     )
-    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Keep working")
-    expect(page.locator("[data-feedback-rating]")).to_have_text("Rate this moment")
-    page.locator("[data-feedback-rating]").click()
-    expect(page.locator("#feedback-overlay")).to_be_visible()
-    expect(page.locator("#feedback-title")).to_have_text("Rate this moment")
-    expect(page.locator("#feedback-desc")).to_have_text(
-        "How did comparing your answer to the notes feel? A 9 or 10 means the UX feels ready for a new customer."
-    )
-    expect(page.locator("#feedback-submit")).to_have_text("Send Rating")
-    expect(page.locator("#feedback-ux-rating")).to_be_focused()
-    page.locator("#feedback-ux-rating").select_option("9")
-    page.locator("#feedback-submit").click()
-    expect(page.locator("#feedback-status")).to_have_text(
-        "Thank you! Feedback captured."
-    )
-    assert feedback_payloads == [
-        {"message": "UX feel: 9/10\nUX moment: compare notes"}
-    ]
-    page.locator(".modal-close").click()
-    expect(page.locator("#feedback-overlay")).not_to_be_visible()
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Return to route")
+    expect(page.locator("[data-feedback-rating]")).to_have_count(0)
+    assert feedback_payloads == []
     revealed_training = page.evaluate(
         """JSON.parse(localStorage.getItem('socratink:training:v1:local-qa-training-concept'))"""
     )
@@ -854,7 +837,7 @@ def test_legacy_primed_study_node_reveals_study_without_fabricating_evidence(
     page.locator("#nav-library").click()
     page.locator(".library-card-vault", has_text="Legacy Study QA").click()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Draft saved"
+        "Your draft"
     )
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
         "Reveal notes and compare"
@@ -951,7 +934,7 @@ def test_localhost_concept_repair_appends_learner_gap_work(
         "Learner thinks"
     )
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Draft saved"
+        "Your draft"
     )
     expect(page.locator(".concept-page-b2__evidence")).to_contain_text(
         "Your memory draft"
@@ -966,6 +949,18 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     )
     expect(page.locator(".concept-page-b2__evidence")).not_to_contain_text(
         "Missing piece"
+    )
+    expect(page.locator(".concept-page-b2__study-note")).not_to_have_class(
+        re.compile(r"is-collapsed")
+    )
+    expect(page.locator("[data-study-note-toggle]")).to_have_text("Hide study note")
+    expect(page.locator(".concept-page-b2__repair")).to_be_hidden()
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Write the repair")
+    page.locator(".concept-page-b2__entry-cta").click()
+    expect(page.locator(".concept-page-b2__repair")).to_be_visible()
+    expect(page.locator(".concept-page-b2__repair-input")).to_be_focused()
+    expect(page.locator(".concept-page-b2__study-note")).to_have_class(
+        re.compile(r"is-collapsed")
     )
     expect(page.locator(".concept-page-b2__repair")).to_contain_text(
         "Missing link"
@@ -996,7 +991,7 @@ def test_localhost_concept_repair_appends_learner_gap_work(
         "labelLetterSpacing": "normal",
         "saveMinHeight": "44px",
     }
-    expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
+    expect(page.locator(".concept-page-b2__entry-cta")).to_be_hidden()
 
     page.locator(".concept-page-b2__repair-save").click()
     expect(page.locator("[data-repair-error]")).to_be_visible()
@@ -1035,28 +1030,87 @@ def test_localhost_concept_repair_appends_learner_gap_work(
         "Threshold opens voltage-gated sodium channels; the gradient drives sodium flow only after that gate opens."
     )
     page.locator(".concept-page-b2__repair-save").click()
-    expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Needs repair"
+    expect(page.locator(".concept-post-repair__rail")).to_be_focused()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
+    expect(page.locator(".concept-post-repair__truth")).to_contain_text(
+        "Your map is unchanged."
     )
-    expect(page.locator(".concept-page-b2__repair--saved")).to_be_focused()
-    expect(page.locator(".concept-page-b2__repair--saved")).to_contain_text(
-        "Your saved repair"
+    expect(page.locator(".concept-post-repair__truth")).to_contain_text(
+        "Reconstruct this link later to test it."
     )
-    expect(page.locator(".concept-page-b2__repair--saved")).to_contain_text(
-        "Threshold opens voltage-gated sodium channels; the gradient drives sodium flow only after that gate opens."
+    expect(page.locator(".concept-post-repair__primary")).to_have_text(
+        "Enter this room"
     )
-    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
-        "Pressure-check this link"
+    expect(page.locator(".concept-post-repair__primary")).to_have_attribute(
+        "aria-label", "Enter this room: Membrane depolarization"
     )
-    expect(page.locator(".concept-page-b2__repair")).to_be_visible()
+    expect(page.locator(".concept-post-repair__break")).to_have_text(
+        "Take a short break"
+    )
+    suggested_node = page.locator(
+        '.concept-post-repair-host .concept-constellation__node[data-bridge-target="true"]'
+    )
+    expect(suggested_node).to_be_visible()
+    expect(suggested_node).to_have_attribute("role", "button")
+    expect(suggested_node).to_have_attribute("tabindex", "0")
+    expect(suggested_node).to_have_attribute(
+        "aria-label", re.compile(r"Membrane depolarization.*ready to reconstruct")
+    )
+    repaired_label_fill = page.locator(
+        ".concept-post-repair-host .concept-constellation__node.is-active "
+        ".concept-constellation__label"
+    ).evaluate("el => getComputedStyle(el).fill")
+    assert repaired_label_fill == "rgba(36, 32, 56, 0.84)"
+    suggested_eyebrow_color = page.locator(
+        ".concept-post-repair__next > .eyebrow"
+    ).evaluate("el => getComputedStyle(el).color")
+    assert suggested_eyebrow_color == "rgb(112, 82, 155)"
+    expect(
+        page.locator('.concept-post-repair-host [data-edge-recommendation="true"]')
+    ).to_be_visible()
+    expect(
+        page.locator('.concept-post-repair-host [data-edge-evidence="true"]')
+    ).to_have_count(0)
     assert page.evaluate("window.scrollY") == 0
-    page.locator(".concept-page-b2__entry-cta").click()
+
+    # The graph itself is keyboard-operable and routes to the genuinely ready room.
+    suggested_node.focus()
+    suggested_node.press("Enter")
+    expect(page.locator(".concept-page-b2__entry-title")).to_have_text(
+        "Membrane depolarization"
+    )
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_focused()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_have_count(0)
+
+    # Reload returns to the pending repair handoff; pressure-check remains
+    # available through progressive disclosure.
+    page.reload()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
+    # The primary action routes by entry identity, not by proxy-clicking the
+    # decorative graph node. Removing that rendering detail must not dead-end
+    # the learner's main path.
+    page.evaluate(
+        "document.querySelector('.concept-post-repair-host [data-bridge-target=\"true\"]')?.remove()"
+    )
+    page.locator(".concept-post-repair__primary").click()
+    expect(page.locator(".concept-page-b2__entry-title")).to_have_text(
+        "Membrane depolarization"
+    )
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_focused()
+
+    page.reload()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
+    page.locator(".concept-post-repair__options summary").click()
+    expect(
+        page.locator('[data-post-repair-action="pressure-check"]')
+    ).to_be_visible()
+    page.locator('[data-post-repair-action="pressure-check"]').click()
     expect(page.locator("#drill-chamber-view")).to_be_visible()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
         "Reconstruction"
     )
-    expect(page.locator("#chamber-send")).to_have_text("Check my answer")
-    expect(page.locator(".drill-chamber__hint")).to_have_text("A sentence is enough.")
+    expect(page.locator("#chamber-send")).to_have_text("Check the link")
+    expect(page.locator(".drill-chamber__hint")).to_have_text("One clear connection is enough.")
     expect(
         page.locator(".concept-page-b2__active-entry--drilling #drill-chamber-view")
     ).to_be_visible()
@@ -1083,16 +1137,8 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     expect(page.locator(".concept-page-b2__study-note")).not_to_contain_text(
         "while you repair"
     )
-    expect(page.locator("[data-feedback-rating]")).to_have_text("Rate this moment")
-    page.locator("[data-feedback-rating]").click()
-    expect(page.locator("#feedback-overlay")).to_be_visible()
-    expect(page.locator("#feedback-desc")).to_have_text(
-        "How did checking your repair feel? A 9 or 10 means the UX feels ready for a new customer."
-    )
-    expect(page.locator("#feedback-ux-rating")).to_be_focused()
-    page.keyboard.press("Escape")
-    expect(page.locator("#feedback-overlay")).not_to_be_visible()
-    expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
+    expect(page.locator("[data-feedback-rating]")).to_have_count(0)
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Continue route")
     assert "/session/qa-repair-concept" in page.url
     page.reload()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
@@ -1101,7 +1147,7 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     expect(page.locator(".concept-page-b2__repair")).to_contain_text(
         "Repair checked for now."
     )
-    expect(page.locator(".concept-page-b2__entry-cta")).to_have_count(0)
+    expect(page.locator(".concept-page-b2__entry-cta")).to_have_text("Continue route")
     assert drill_calls[0]["drill_mode"] == "re_drill"
     repaired_training = page.evaluate(
         """JSON.parse(localStorage.getItem('socratink:training:v1:qa-repair-concept'))"""

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -805,6 +805,17 @@ def test_legacy_primed_study_node_reveals_study_without_fabricating_evidence(
     page.route("**/api/drill", fulfill_drill)
     _enter_app_shell_as_guest(page, base_url)
     page.evaluate("localStorage.clear(); sessionStorage.clear();")
+    checked_at = page.evaluate(
+        """async () => {
+          const { mergeTrainingRecords } = await import('/js/learner-state-sync.js');
+          const merged = mergeTrainingRecords(
+            { concept_id: 'checked', node_records: { n1: { repair_checked_at: '2026-07-08T11:00:00.000Z' } } },
+            { concept_id: 'checked', node_records: { n1: {} } },
+          );
+          return merged.node_records.n1.repair_checked_at;
+        }"""
+    )
+    assert checked_at == "2026-07-08T11:00:00.000Z"
     page.evaluate(
         """(() => {
             const graphData = JSON.stringify({
@@ -1047,6 +1058,18 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     expect(page.locator(".concept-post-repair__break")).to_have_text(
         "Take a short break"
     )
+    page.evaluate(
+        """(() => {
+          const concepts = JSON.parse(localStorage.getItem('learnops_concepts') || '[]');
+          const concept = concepts.find((item) => item.id === 'qa-repair-concept');
+          const graph = JSON.parse(concept.graphData);
+          graph.backbone.push({ id: 'peripheral-node', label: 'Peripheral room' });
+          concept.graphData = JSON.stringify(graph);
+          localStorage.setItem('learnops_concepts', JSON.stringify(concepts));
+        })()"""
+    )
+    page.reload()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
     suggested_node = page.locator(
         '.concept-post-repair-host .concept-constellation__node[data-bridge-target="true"]'
     )
@@ -1073,7 +1096,49 @@ def test_localhost_concept_repair_appends_learner_gap_work(
     ).to_have_count(0)
     assert page.evaluate("window.scrollY") == 0
 
+    page.locator(".concept-post-repair__break").click()
+    expect(page.locator(".hero-card")).to_be_visible()
+    page.locator("#nav-library").click()
+    page.locator(".library-card-vault", has_text="Repair Truth QA").click()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
+
+    # A failed room load stays on the handoff instead of losing the route.
+    page.evaluate(
+        """(() => {
+          window.__qaOriginalGetItem = Storage.prototype.getItem;
+          Storage.prototype.getItem = function (key) {
+            if (String(key).startsWith('socratink:training:v1:')) {
+              throw new Error('forced room load failure');
+            }
+            return window.__qaOriginalGetItem.call(this, key);
+          };
+        })()"""
+    )
+    suggested_node = page.locator(
+        '.concept-post-repair-host .concept-constellation__node[data-bridge-target="true"]'
+    )
+    suggested_node.dispatch_event("click")
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
+    page.evaluate(
+        """(() => {
+          Storage.prototype.getItem = window.__qaOriginalGetItem;
+          delete window.__qaOriginalGetItem;
+        })()"""
+    )
+    suggested_node.dispatch_event("click")
+    expect(page.locator(".concept-page-b2__entry-title")).to_have_text(
+        "Membrane depolarization"
+    )
+    expect(page.locator(".concept-page-b2__attempt-input")).to_be_focused()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_have_count(0)
+
+    page.reload()
+    expect(page.locator(".concept-constellation__shell--bridge")).to_be_visible()
+
     # The graph itself is keyboard-operable and routes to the genuinely ready room.
+    suggested_node = page.locator(
+        '.concept-post-repair-host .concept-constellation__node[data-bridge-target="true"]'
+    )
     suggested_node.focus()
     suggested_node.press("Enter")
     expect(page.locator(".concept-page-b2__entry-title")).to_have_text(
@@ -1780,6 +1845,9 @@ def test_source_less_first_chamber_answer_shows_verdict_and_study_cta(
     page.locator("#chamber-composer").fill(transfer_answer)
     page.locator("#chamber-send").click()
     expect(page.locator("#drill-chamber-view")).to_have_attribute("data-loop-surface", "settle")
+    expect(page.locator("#chamber-send")).to_have_text("Return to concept")
+    page.locator("#chamber-send").click()
+    expect(page.locator("#drill-chamber-view")).to_have_count(0)
     assert turn_texts == [
         door_sketch, room_answer, "continue", repair_answer, "continue", "y", transfer_answer,
     ]

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -221,7 +221,7 @@ def test_first_run_guidance_is_inline_not_modal(clean_page: Page, base_url: str)
         "Write what you remember first. We'll show what to study — not a summary."
     )
     expect(clean_page.locator("#ignition-boundary")).to_have_text(
-        "You'll write first. Answers come after."
+        "Add your first model to start."
     )
 
 
@@ -2288,7 +2288,7 @@ def test_seda_start_failure_offers_retry_from_product_flow(
     expect(page.locator("#chamber-active")).not_to_have_attribute(
         "data-loading", "true"
     )
-    expect(page.locator("#chamber-hint")).to_have_text("A sentence is enough.")
+    expect(page.locator("#chamber-hint")).to_have_text("One clear connection is enough.")
     page.locator("#chamber-send").click()
     expect(page.locator("#chamber-verdict")).to_contain_text(
         "Use the next question to add one cause-and-effect link.", timeout=2_000
@@ -3719,7 +3719,7 @@ def test_concept_entry_mutation_preserves_active_later_entry(
     page.locator(".library-card-vault", has_text="Active Entry QA").click()
     page.locator('.concept-page-b2__route-item[data-entry-id="entry-two"]').click()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Draft saved"
+        "Your draft"
     )
     page.locator(".concept-page-b2__entry-cta").click()
     expect(page.locator(".concept-page-b2__route-item.is-active")).to_have_attribute(
@@ -3857,7 +3857,7 @@ def test_localhost_concept_page_cold_attempt_appends_training_evidence(
     )
     page.locator(".concept-page-b2__attempt-save").click()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Draft saved"
+        "Your draft"
     )
     expect(page.locator(".concept-page-b2__evidence")).to_be_focused()
     expect(page.locator(".concept-page-b2__entry-cta")).to_have_text(
@@ -4226,7 +4226,7 @@ def test_localhost_concept_page_corrupt_training_storage_recovers_and_records_at
     save_button = page.locator(".concept-page-b2__attempt-save")
     save_button.click()
     expect(page.locator(".concept-page-b2__entry-eyebrow")).to_have_text(
-        "Draft saved"
+        "Your draft"
     )
     assert len(drill_calls) == 1
     assert drill_calls[0]["node_id"] == "corrupt-node"

--- a/tests/test_app_local_seda_frontend_contract.py
+++ b/tests/test_app_local_seda_frontend_contract.py
@@ -143,6 +143,7 @@ def test_seda_surface_maps_outer_repair_bridge_and_transfer_beats() -> None:
           awaiting: null,
         });
         assert.equal(complete.mode, 'complete');
+        assert.deepEqual(complete.completionAction, { kind: 'study' });
         """
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_app_local_seda_frontend_contract.py
+++ b/tests/test_app_local_seda_frontend_contract.py
@@ -82,6 +82,73 @@ def test_seda_visible_prompt_drops_setup_log_lines() -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_seda_surface_maps_outer_repair_bridge_and_transfer_beats() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { sedaSurfaceFromResponse } from './public/js/seda-visible-prompt.js';
+
+        const events = [
+          { type: 'cold_attempt', text: 'The query compares with keys.' },
+          {
+            type: 'gap_identified',
+            repair_scaffold: { socratic_question: 'What turns that comparison into a weighted result?' },
+          },
+        ];
+        const repair = sedaSurfaceFromResponse({
+          events,
+          awaiting: { key: 'repair', ctaText: 'What turns that comparison into a weighted result?' },
+        });
+        assert.equal(repair.mode, 'repair');
+        assert.equal(repair.originalText, 'The query compares with keys.');
+        assert.equal(repair.gapText, 'What turns that comparison into a weighted result?');
+
+        const bridgeEvents = [...events, { type: 'repair', text: 'Similarity becomes a weight.' }, {
+            type: 'model_bridge', text: 'Attention normalizes similarities into weights.'
+          }];
+        const ready = sedaSurfaceFromResponse({
+          events: [...events, { type: 'repair', text: 'Similarity becomes a weight.' }],
+          awaiting: { key: 'continue' },
+        });
+        assert.equal(ready.mode, 'repair-ready');
+        assert.equal(ready.repairText, 'Similarity becomes a weight.');
+
+        const bridge = sedaSurfaceFromResponse({
+          events: bridgeEvents,
+          awaiting: { key: 'run_gap_drill' },
+        });
+        assert.equal(bridge.mode, 'bridge');
+        assert.equal(bridge.repairText, 'Similarity becomes a weight.');
+        assert.equal(bridge.bridgeText, 'Attention normalizes similarities into weights.');
+
+        assert.equal(sedaSurfaceFromResponse({
+          events: bridgeEvents,
+          awaiting: { key: 'gap_attempt' },
+        }).mode, 'transfer');
+        assert.equal(sedaSurfaceFromResponse({
+          awaiting: { key: 'spaced_attempt' },
+        }).mode, 'settle');
+
+        const recovery = sedaSurfaceFromResponse({
+          awaiting: {
+            key: 'repair_recovery',
+            ctaText: 'Name only the first cause you can see.',
+          },
+        });
+        assert.equal(recovery.mode, 'recovery');
+        assert.equal(recovery.prompt, 'Name only the first cause you can see.');
+
+        const complete = sedaSurfaceFromResponse({
+          caseComplete: true,
+          awaiting: null,
+        });
+        assert.equal(complete.mode, 'complete');
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_auth_entry_session_redirect_contract() -> None:
     result = run_node_module(
         """

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -46,6 +46,7 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
             classList: {
               add() {},
               remove() {},
+              toggle() {},
             },
             appendChild(child) {
               this.appended = this.appended || [];
@@ -118,6 +119,15 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
           'chamber-send',
           'chamber-exit',
           'chamber-chat-log',
+          'chamber-hint',
+          'chamber-verdict',
+          'chamber-beat-label',
+          'chamber-beat-note',
+          'chamber-anchor',
+          'chamber-anchor-label',
+          'chamber-anchor-text',
+          'chamber-bridge',
+          'chamber-bridge-text',
         ]) {
           nodes.set(id, makeNode(id));
         }
@@ -143,6 +153,31 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
         assert.equal(nodes.get('drill-chamber-view').hidden, false);
         assert.equal(nodes.get('chamber-question').textContent, 'Question?');
 
+        for (const mode of [
+          'challenge',
+          'gap',
+          'repair',
+          'recovery',
+          'repair-ready',
+          'bridge',
+          'transfer',
+          'settle',
+          'complete',
+        ]) {
+          window.DrillChamber.setSurface(mode);
+          assert.equal(
+            nodes.get('drill-chamber-view')['data-loop-surface'],
+            mode,
+            `chamber must render emitted ${mode} surface`,
+          );
+        }
+        window.DrillChamber.setSurface('recovery');
+        assert.equal(nodes.get('chamber-beat-label').textContent, 'One smaller step');
+        assert.equal(nodes.get('chamber-send').textContent, 'Try this step');
+        window.DrillChamber.setSurface('complete');
+        assert.equal(nodes.get('chamber-beat-label').textContent, 'Loop complete');
+        assert.equal(nodes.get('chamber-send').textContent, 'Return to concept');
+
         const sent = [];
         window.DrillChamber.onSend((text) => sent.push(text));
         nodes.get('chamber-composer').value = '  learner answer  ';
@@ -159,7 +194,7 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
           question: 'Question?',
         });
         window.DrillChamber.setLoading(true);
-        assert.equal(nodes.get('chamber-hint').textContent, 'A sentence is enough.');
+        assert.equal(nodes.get('chamber-hint').textContent, 'One clear connection is enough.');
         window.DrillChamber.setLoading(true, { checkingAnswer: true });
         assert.equal(nodes.get('chamber-hint').textContent, 'Checking your answer…');
         const pendingTimer = scheduledTimers.at(-1);
@@ -175,7 +210,7 @@ def test_drill_chamber_noops_when_required_nodes_are_missing() -> None:
           'Checking the link you wrote.'
         );
         window.DrillChamber.setLoading(false);
-        assert.equal(nodes.get('chamber-hint').textContent, 'A sentence is enough.');
+        assert.equal(nodes.get('chamber-hint').textContent, 'One clear connection is enough.');
         assert.equal(nodes.get('chamber-verdict').hidden, true);
         window.DrillChamber.setLoading(true, { checkingAnswer: true });
         scheduledTimers.at(-1).callback();

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1424,7 +1424,11 @@ def test_concept_constellation_renderer_redacts_locked_source_content() -> None:
     result = run_node_module(
         """
         import assert from 'node:assert/strict';
-        import { renderConceptConstellationHtml } from './public/js/concept-constellation-view.js';
+        import {
+          derivePostRepairBridge,
+          renderConceptConstellationHtml,
+        } from './public/js/concept-constellation-view.js';
+        import { deriveRepairPhase } from './public/js/concept-page-view.js';
 
         const data = {
           metadata: {
@@ -1485,6 +1489,7 @@ def test_concept_constellation_renderer_redacts_locked_source_content() -> None:
         assert.doesNotMatch(activeHtml, /role="img"/);
         assert.match(activeHtml, /class="concept-constellation__node[^"]*"\\s+data-entry-id="gate"/);
         assert.match(activeHtml, /class="concept-constellation__node is-active"/);
+        assert.match(activeHtml, /class="concept-constellation__node is-active"[\\s\\S]*?role="listitem"[\\s\\S]*?tabindex="-1"/);
         assert.match(activeHtml, /data-state="primed"/);
         assert.match(activeHtml, /role="button"/);
         assert.match(activeHtml, /tabindex="0"/);
@@ -1521,6 +1526,103 @@ def test_concept_constellation_renderer_redacts_locked_source_content() -> None:
         assert.match(coldHtml, /data-entry-id="gate"[\\s\\S]*data-state="ready"/);
         assert.match(coldHtml, /Entry 02/);
         assert.doesNotMatch(coldHtml, /Signal spread/);
+        const repairTraining = {
+          node_records: {
+            gate: {
+              attempts: [{
+                at: '2026-05-21T00:00:00Z',
+                classification: 'partial',
+                user_text: 'Sodium moves inward.',
+                gaps: [{ description: 'Name what opens the gate.' }],
+              }],
+              study_revealed_at: '2026-05-21T00:02:00Z',
+              repairs: [{
+                id: 'repair-1',
+                at: '2026-05-21T00:03:00Z',
+                text: 'Threshold opens the gate before the gradient can act.',
+              }],
+            },
+          },
+        };
+        const bridge = derivePostRepairBridge(data, repairTraining, 'gate');
+        assert.deepEqual(bridge, {
+          repairedEntryId: 'gate',
+          targetEntryId: 'spread',
+        });
+        const bridgeHtml = renderConceptConstellationHtml(data, {
+          activeEntryId: 'gate',
+          training: repairTraining,
+          postRepairBridge: bridge,
+        });
+        assert.match(bridgeHtml, /concept-constellation__shell--bridge/);
+        assert.match(bridgeHtml, /Your map is unchanged\\./);
+        assert.match(bridgeHtml, /Reconstruct this link later to test it\\./);
+        assert.match(bridgeHtml, /Suggested next/);
+        assert.match(bridgeHtml, /Signal spread/);
+        assert.match(bridgeHtml, /data-edge-recommendation="true"/);
+        assert.match(bridgeHtml, /concept-constellation__edge is-suggested/);
+        assert.match(bridgeHtml, /data-post-repair-action="next-entry"/);
+        assert.match(bridgeHtml, /Enter this room/);
+        assert.match(bridgeHtml, /aria-label="Enter this room: Signal spread"/);
+        assert.match(bridgeHtml, /concept-constellation__entries" role="group" aria-label="Concept rooms"/);
+        assert.match(bridgeHtml, /aria-label="02, Signal spread, Suggested next, ready to reconstruct"/);
+        assert.match(bridgeHtml, /Take a short break/);
+        assert.match(bridgeHtml, /<details class="concept-post-repair__options">/);
+        assert.match(bridgeHtml, /Pressure-check this link/);
+        assert.match(bridgeHtml, /Correction kept\\. No new reconstruction evidence\\./);
+        assert.match(bridgeHtml, /class="concept-constellation__node is-active"[\\s\\S]*?role="listitem"[\\s\\S]*?tabindex="-1"/);
+        assert.match(bridgeHtml, /data-entry-id="spread"[\\s\\S]*data-bridge-target="true"[\\s\\S]*role="button"[\\s\\S]*tabindex="0"/);
+        assert.doesNotMatch(bridgeHtml, /Reset phase/);
+        assert.match(bridgeHtml, /Entry 03/);
+
+        const noCandidateData = {
+          ...data,
+          clusters: [{ ...data.clusters[0], subnodes: [data.clusters[0].subnodes[0]] }],
+        };
+        const noCandidateBridge = derivePostRepairBridge(noCandidateData, repairTraining, 'gate');
+        assert.deepEqual(noCandidateBridge, {
+          repairedEntryId: 'gate',
+          targetEntryId: null,
+        });
+        const noCandidateHtml = renderConceptConstellationHtml(noCandidateData, {
+          activeEntryId: 'gate',
+          training: repairTraining,
+          postRepairBridge: noCandidateBridge,
+        });
+        assert.match(noCandidateHtml, /Take a short break\\./);
+        assert.match(noCandidateHtml, /No nearby room is ready\\./);
+        assert.match(noCandidateHtml, /No nearby room is ready, so the repaired link stays on the route\\./);
+        assert.doesNotMatch(noCandidateHtml, /One eligible room is suggested/);
+        assert.doesNotMatch(noCandidateHtml, /data-post-repair-action="next-entry"/);
+
+        const checkedTraining = structuredClone(repairTraining);
+        checkedTraining.node_records.gate.repair_checked_at = '2026-05-21T00:04:00Z';
+        assert.equal(deriveRepairPhase(checkedTraining.node_records.gate), 'checked');
+        assert.equal(derivePostRepairBridge(data, checkedTraining, 'gate'), null);
+
+        const failedAfterCheck = structuredClone(checkedTraining);
+        failedAfterCheck.node_records.gate.attempts.push({
+          at: '2026-05-21T00:05:00Z', classification: 'partial',
+        });
+        assert.equal(deriveRepairPhase(failedAfterCheck.node_records.gate), 'write');
+
+        const repairedAgain = structuredClone(failedAfterCheck);
+        repairedAgain.node_records.gate.repairs.push({
+          at: '2026-05-21T00:06:00Z', text: 'A newer correction.',
+        });
+        assert.equal(deriveRepairPhase(repairedAgain.node_records.gate), 'saved');
+        assert.equal(
+          deriveRepairPhase(repairedAgain.node_records.gate, { repairCheckedThisSession: true }),
+          'checked',
+        );
+        assert.equal(
+          derivePostRepairBridge(data, repairTraining, 'gate', { repairCheckedThisSession: true }),
+          null,
+        );
+        assert.equal(
+          derivePostRepairBridge(data, repairTraining, 'gate', { isDrilling: true }),
+          null,
+        );
         assert.match(coldHtml, /data-entry-id="legacy"[\\s\\S]*data-state="primed"/);
 
         for (const forbidden of [
@@ -1718,6 +1820,8 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(coldHtml.includes('Study stays hidden until you save a draft. This is not a grade.'));
         assert.ok(coldHtml.includes('What do you think makes the sodium channel open?'));
         assert.ok(coldHtml.includes('Sodium gate'));
+        assert.ok(!coldHtml.includes('Start from memory'));
+        assert.ok(!coldHtml.includes('Name the trigger without reading the note.'));
         assert.ok(coldHtml.includes('Save draft'));
         assert.ok(coldHtml.includes('Your reconstruction'));
         assert.ok(coldHtml.includes('data-attempt-status'));
@@ -1777,6 +1881,9 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(savedHtml.includes('concept-page-b2__evidence--study-gate'));
         assert.ok(!savedHtml.includes('Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.'));
         assert.ok(savedHtml.includes('The gate probably opens when the voltage gets high enough.'));
+        assert.ok(savedHtml.includes('Your draft'));
+        assert.ok(!savedHtml.includes('Draft saved'));
+        assert.ok(!savedHtml.includes('You wrote first. Now socratink can compare'));
         assert.ok(savedHtml.includes('Reveal notes and compare'));
         assert.ok(!savedHtml.includes('Missing piece'));
         assert.ok(!savedHtml.includes('threshold as the opening condition'));
@@ -1814,12 +1921,11 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
         assert.ok(compareHtml.includes('Compare notes'));
         assert.ok(compareHtml.includes('The channel opens when voltage reaches threshold.'));
         assert.ok(compareHtml.includes('Voltage-gated sodium channels open at threshold'));
-        assert.ok(compareHtml.includes('Continue'));
+        assert.ok(compareHtml.includes('Continue route'));
         assert.ok(compareHtml.includes('data-active-entry-action="next-entry"'));
         assert.ok(compareHtml.includes('data-active-entry-id="spread"'));
-        assert.ok(compareHtml.includes('Rate this moment'));
-        assert.ok(compareHtml.includes('data-feedback-rating'));
-        assert.ok(compareHtml.includes('data-feedback-moment="compare notes"'));
+        assert.ok(!compareHtml.includes('Rate this moment'));
+        assert.ok(!compareHtml.includes('data-feedback-rating'));
         assert.ok(!compareHtml.includes('No missing piece recorded for this draft.'));
         assert.ok(!compareHtml.includes('concept-page-b2__route-item'));
         assert.ok(compareHtml.includes('concept-page-b2__gestalt--single-column'));
@@ -1836,12 +1942,11 @@ def test_source_less_gestalt_hybrid_stage_contracts() -> None:
           { comparisonAcknowledged: false, now: '2026-05-21T11:00:00.000Z' }
         );
         assert.ok(autoCompareHtml.includes('Compare notes'));
-        assert.ok(autoCompareHtml.includes('Continue'));
+        assert.ok(autoCompareHtml.includes('Continue route'));
         assert.ok(autoCompareHtml.includes('data-active-entry-action="next-entry"'));
         assert.ok(autoCompareHtml.includes('data-active-entry-id="spread"'));
-        assert.ok(autoCompareHtml.includes('Rate this moment'));
-        assert.ok(autoCompareHtml.includes('data-feedback-rating'));
-        assert.ok(autoCompareHtml.includes('data-feedback-moment="compare notes"'));
+        assert.ok(!autoCompareHtml.includes('Rate this moment'));
+        assert.ok(!autoCompareHtml.includes('data-feedback-rating'));
         assert.ok(autoCompareHtml.includes('concept-page-b2__gestalt--single-column'));
         assert.ok(!autoCompareHtml.includes('concept-page-b2__nearby'));
         assert.ok(!autoCompareHtml.includes('concept-page-b2__route-item'));
@@ -2053,7 +2158,8 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
           {},
           { metadata: {} }
         );
-        assert.ok(legacyStudyHtml.includes('Draft saved'));
+        assert.ok(legacyStudyHtml.includes('Your draft'));
+        assert.ok(!legacyStudyHtml.includes('Draft saved'));
         assert.ok(!legacyStudyHtml.includes('study required entry 1 of 1'));
         assert.ok(legacyStudyHtml.includes('data-active-entry-action="study"'));
         assert.ok(legacyStudyHtml.includes('Reveal notes and compare'));
@@ -2208,7 +2314,7 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(readyHtml.includes('concept-page-b2__gestalt'));
         assert.ok(readyHtml.includes('concept-page-b2__route'));
         assert.ok(!readyHtml.includes('Write first. Compare after.'));
-        assert.ok(readyHtml.includes('Start from memory'));
+        assert.ok(!readyHtml.includes('Start from memory'));
         assert.ok(!readyHtml.includes('first reconstruction entry 2 of 3'));
         assert.ok(readyHtml.includes('Save draft'));
         assert.ok(readyHtml.includes('Need a cue?'));
@@ -2418,12 +2524,13 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         );
         assert.ok(primedHtml.includes('concept-page-b2__threshold--empty'));
         assert.ok(primedHtml.includes('add context'));
-        assert.ok(primedHtml.includes('Draft saved'));
+        assert.ok(primedHtml.includes('Your draft'));
+        assert.ok(!primedHtml.includes('Draft saved'));
         assert.ok(!primedHtml.includes('study required entry 1 of 1'));
         assert.ok(primedHtml.includes('Your memory draft'));
         assert.ok(primedHtml.includes('concept-page-b2__evidence--study-gate'));
         assert.ok(!primedHtml.includes('Draft recorded. Having your own words fresh in mind makes it easier to notice the differences when you read the notes.'));
-        assert.ok(primedHtml.includes('Draft saved'));
+        assert.ok(!primedHtml.includes('Draft saved'));
         assert.ok(primedHtml.includes('A strong first attempt.'));
         assert.ok(!primedHtml.includes('Missing piece'));
         assert.ok(!primedHtml.includes('Hidden reference note.'));
@@ -2646,8 +2753,11 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
         assert.ok(repairHtml.includes('Save repair'));
         assert.ok(repairHtml.includes('Your repaired link'));
         assert.ok(repairHtml.includes('data-repair-status'));
-        assert.ok(repairHtml.includes('Study note stays hidden while you repair.'));
-        assert.ok(repairHtml.includes('Show study note'));
+        assert.ok(repairHtml.includes('data-active-entry-action="write-repair"'));
+        assert.ok(repairHtml.includes('Write the repair'));
+        assert.ok(repairHtml.includes('aria-expanded="true"'));
+        assert.ok(repairHtml.includes('Hide study note'));
+        assert.match(repairHtml, /concept-page-b2__repair[^>]+hidden/);
         const fallbackRepairHtml = renderActiveEntryHtml(
           { label: 'Fallback repair', study_note: 'Study the unnamed entry.' },
           1,
@@ -2703,18 +2813,21 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
             },
           }
         );
-        assert.ok(repairedHtml.includes('Needs repair'));
+        assert.ok(!repairedHtml.includes('Needs repair'));
         assert.ok(!repairedHtml.includes('repair the gap entry 1 of 1'));
         assert.ok(!repairedHtml.includes('Write it again'));
         assert.ok(repairedHtml.includes('Repair saved'));
-        assert.ok(repairedHtml.includes('Pressure-check the repaired link.'));
+        assert.ok(repairedHtml.includes('Explain the link again from memory.'));
         assert.ok(repairedHtml.includes('concept-page-b2__repair'));
         assert.ok(repairedHtml.includes('Pressure-check this link'));
-        assert.ok(repairedHtml.includes('Your saved repair'));
-        assert.ok(repairedHtml.includes('Voltage-gated channels open at threshold.'));
+        assert.ok(!repairedHtml.includes('Your draft'));
+        assert.ok(!repairedHtml.includes('Your repair'));
+        assert.ok(!repairedHtml.includes('Voltage-gated channels open at threshold.'));
         assert.ok(repairedHtml.includes('data-active-entry-action="drill-gap"'));
         assert.ok(!repairedHtml.includes('concept-page-b2__repair-input'));
         assert.ok(!repairedHtml.includes('concept-page-b2__repair-save'));
+        assert.ok(!repairedHtml.includes('Study note stays hidden while you repair.'));
+        assert.ok(!repairedHtml.includes('Your words shape the path.'));
         assert.ok(!repairedHtml.includes('Save this repair before you try from memory again.'));
 
         const checkedRepairHtml = renderActiveEntryHtml(
@@ -2741,17 +2854,16 @@ def test_concept_page_view_renders_active_entry_html_contract() -> None:
                   at: '2026-05-15T10:10:00.000Z',
                   text: 'Voltage-gated channels open at threshold.',
                 }],
+                repair_checked_at: '2026-05-15T10:20:00.000Z',
               },
             },
-          },
-          { repairCheckedThisSession: true }
+          }
         );
         assert.ok(checkedRepairHtml.includes('Repair checked'));
         assert.ok(checkedRepairHtml.includes('Repair checked for now.'));
         assert.ok(checkedRepairHtml.includes('Study note stays hidden for later reconstruction.'));
-        assert.ok(checkedRepairHtml.includes('Rate this moment'));
-        assert.ok(checkedRepairHtml.includes('data-feedback-rating'));
-        assert.ok(checkedRepairHtml.includes('data-feedback-moment="repair checked"'));
+        assert.ok(!checkedRepairHtml.includes('Rate this moment'));
+        assert.ok(!checkedRepairHtml.includes('data-feedback-rating'));
         assert.ok(!checkedRepairHtml.includes('Pressure-check this link'));
         assert.ok(!checkedRepairHtml.includes('Study note stays hidden while you repair.'));
 

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1488,10 +1488,10 @@ def test_concept_constellation_renderer_redacts_locked_source_content() -> None:
         assert.match(activeHtml, /Draft structure only\\./);
         assert.match(activeHtml, /Overview first\\./);
         assert.match(activeHtml, /concept-constellation__return/);
-        assert.doesNotMatch(activeHtml, /role="img"/);
+        assert.doesNotMatch(activeHtml, /<svg[^>]*role="img"/);
         assert.match(activeHtml, /class="concept-constellation__node[^"]*"\\s+data-entry-id="gate"/);
         assert.match(activeHtml, /class="concept-constellation__node is-active"/);
-        assert.match(activeHtml, /class="concept-constellation__node is-active"[\\s\\S]*?role="listitem"[\\s\\S]*?tabindex="-1"/);
+        assert.match(activeHtml, /class="concept-constellation__node is-active"[\\s\\S]*?role="img"[\\s\\S]*?tabindex="-1"/);
         assert.match(activeHtml, /data-state="primed"/);
         assert.match(activeHtml, /role="button"/);
         assert.match(activeHtml, /tabindex="0"/);
@@ -1572,7 +1572,7 @@ def test_concept_constellation_renderer_redacts_locked_source_content() -> None:
         assert.match(bridgeHtml, /<details class="concept-post-repair__options">/);
         assert.match(bridgeHtml, /Pressure-check this link/);
         assert.match(bridgeHtml, /Correction kept\\. No new reconstruction evidence\\./);
-        assert.match(bridgeHtml, /class="concept-constellation__node is-active"[\\s\\S]*?role="listitem"[\\s\\S]*?tabindex="-1"/);
+        assert.match(bridgeHtml, /class="concept-constellation__node is-active"[\\s\\S]*?role="img"[\\s\\S]*?tabindex="-1"/);
         assert.match(bridgeHtml, /data-entry-id="spread"[\\s\\S]*data-bridge-target="true"[\\s\\S]*role="button"[\\s\\S]*tabindex="0"/);
         assert.doesNotMatch(bridgeHtml, /Reset phase/);
         assert.match(bridgeHtml, /Entry 03/);

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1577,6 +1577,18 @@ def test_concept_constellation_renderer_redacts_locked_source_content() -> None:
         assert.doesNotMatch(bridgeHtml, /Reset phase/);
         assert.match(bridgeHtml, /Entry 03/);
 
+        const peripheralHtml = renderConceptConstellationHtml({
+          backbone: [
+            { id: 'repair', label: 'Repair room' },
+            { id: 'target', label: 'Target room' },
+            { id: 'peripheral', label: 'Peripheral room' },
+          ],
+        }, {
+          activeEntryId: 'repair',
+          postRepairBridge: { repairedEntryId: 'repair', targetEntryId: 'target' },
+        });
+        assert.match(peripheralHtml, /data-entry-id="peripheral"/);
+
         const noCandidateData = {
           ...data,
           clusters: [{ ...data.clusters[0], subnodes: [data.clusters[0].subnodes[0]] }],

--- a/tests/test_frontend_app_helper_modules.py
+++ b/tests/test_frontend_app_helper_modules.py
@@ -1300,13 +1300,15 @@ def test_app_shell_ui_preserves_drawer_settings_and_concept_list_contracts() -> 
 def test_new_concept_field_has_unique_accessible_label() -> None:
     index_html = (REPO_ROOT / "public" / "index.html").read_text()
 
-    assert '<h1 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
+    assert '<h2 class="ig-title" id="ignition-title" tabindex="-1">' in index_html
     assert "What are you trying to explain?" in index_html
     assert "Write what you remember first. We'll show what to study" in index_html
-    assert "You'll write first. Answers come after." in index_html
+    assert "Add your first model to start." in index_html
     assert 'id="ignition-boundary"' in index_html
     assert 'class="ig-eyebrow">New session</p>' in index_html
     assert "socratink will ask for your first model" not in index_html
+    assert 'for="hero-single-input-field">Topic or question</label>' in index_html
+    assert 'for="hero-cold-guess-field">Your first model</label>' in index_html
     assert 'id="hero-single-input-field"' in index_html
     assert 'id="hero-cold-guess-field"' in index_html
     assert 'aria-label="Learning goal"' in index_html

--- a/tests/test_learner_state_sync.py
+++ b/tests/test_learner_state_sync.py
@@ -17,7 +17,19 @@ def test_merge_learner_state_unions_evidence_without_dropping_attempts() -> None
     result = run_node_module(
         """
         import assert from 'node:assert/strict';
-        import { mergeLearnerState } from './public/js/learner-state-sync.js';
+        import {
+          mergeLearnerState,
+          mergeTrainingRecords,
+        } from './public/js/learner-state-sync.js';
+
+        const checkedOnlyLocally = mergeTrainingRecords(
+          { concept_id: 'checked', node_records: { n1: { repair_checked_at: '2026-07-08T11:00:00.000Z' } } },
+          { concept_id: 'checked', node_records: { n1: {} } },
+        );
+        assert.equal(
+          checkedOnlyLocally.node_records.n1.repair_checked_at,
+          '2026-07-08T11:00:00.000Z',
+        );
 
         const local = {
           concepts: [{ id: 'c1', name: 'Local', updated_at: '2026-07-08T12:00:00.000Z' }],

--- a/tests/test_learner_state_sync.py
+++ b/tests/test_learner_state_sync.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import shutil
+from pathlib import Path
 
 import pytest
 
 from tests._helpers.node_runner import run_node_module
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
@@ -74,6 +77,111 @@ def test_merge_learner_state_unions_evidence_without_dropping_attempts() -> None
         """
     )
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_identified_hydration_preserves_repair_check_round_trip() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import {
+          CONCEPTS_STORE_KEY,
+          hydrateAndSyncLearnerState,
+        } from './public/js/learner-state-sync.js';
+
+        const trainingKey = 'socratink:training:v1:c1';
+        const checkedAt = '2026-07-08T10:20:00.000Z';
+        const mem = new Map([
+          [CONCEPTS_STORE_KEY, JSON.stringify([{ id: 'c1', name: 'Local concept' }])],
+          [trainingKey, JSON.stringify({
+            concept_id: 'c1',
+            schema_version: 1,
+            grounding: 'ungrounded',
+            node_records: {
+              n1: {
+                attempts: [{
+                  id: 'a1',
+                  at: '2026-07-08T10:00:00.000Z',
+                  user_text: 'local attempt',
+                  classification: 'partial',
+                  gaps: [],
+                  grader_version: 'test',
+                }],
+                repairs: [{
+                  id: 'r1',
+                  at: '2026-07-08T10:10:00.000Z',
+                  text: 'local repair',
+                }],
+                study_revealed_at: '2026-07-08T10:05:00.000Z',
+                repair_checked_at: checkedAt,
+              },
+            },
+          })],
+        ]);
+        const storage = {
+          getItem(key) { return mem.has(key) ? mem.get(key) : null; },
+          setItem(key, value) { mem.set(key, String(value)); },
+          key(index) { return [...mem.keys()][index] || null; },
+          get length() { return mem.size; },
+        };
+
+        let remote = {
+          concepts: [{ id: 'c1', name: 'Remote concept' }],
+          training: {
+            c1: {
+              concept_id: 'c1',
+              schema_version: 1,
+              grounding: 'ungrounded',
+              node_records: {
+                n1: {
+                  attempts: [],
+                  repairs: [],
+                  study_revealed_at: null,
+                },
+              },
+            },
+          },
+        };
+        const fetchImpl = async (_url, options = {}) => {
+          if (!options.method || options.method === 'GET') {
+            return { status: 200, ok: true, async json() { return remote; } };
+          }
+          remote = JSON.parse(options.body);
+          return { status: 200, ok: true, async json() { return remote; } };
+        };
+
+        const first = await hydrateAndSyncLearnerState({
+          storage,
+          fetchImpl,
+          isIdentified: true,
+        });
+        assert.equal(first.state.training.c1.node_records.n1.repair_checked_at, checkedAt);
+        assert.equal(JSON.parse(mem.get(trainingKey)).node_records.n1.repair_checked_at, checkedAt);
+        assert.equal(remote.training.c1.node_records.n1.repair_checked_at, checkedAt);
+
+        const second = await hydrateAndSyncLearnerState({
+          storage,
+          fetchImpl,
+          isIdentified: true,
+        });
+        assert.equal(second.state.training.c1.node_records.n1.repair_checked_at, checkedAt);
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_evidence_writes_schedule_identified_state_push() -> None:
+    app_js = (REPO_ROOT / "public" / "js" / "app.js").read_text(encoding="utf-8")
+    for method in (
+        "appendAttempt",
+        "setStudyRevealed",
+        "appendRepair",
+        "saveTraining",
+        "markRepairChecked",
+    ):
+        start = app_js.index(f"trainingStore.{method} = async")
+        end = app_js.index("\n  };", start)
+        assert "scheduleLearnerStatePush();" in app_js[start:end], method
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")

--- a/tests/test_seda_evidence_projection.py
+++ b/tests/test_seda_evidence_projection.py
@@ -185,6 +185,58 @@ def test_latest_seda_attempt_event_projects_before_case_complete() -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_seda_progress_projects_reveal_and_repair_but_not_transfer() -> None:
+    result = run_node_module(
+        """
+        import assert from 'node:assert/strict';
+        import { projectLatestSedaAttemptEvent } from './public/js/seda-evidence-projection.js';
+
+        const data = { events: [
+          {
+            type: 'cold_attempt',
+            text: 'The query compares with keys.',
+            evaluation: { classification: 'shallow', gap_description: 'Explain the weighting.' },
+          },
+          { type: 'gap_identified', graph_neutral: true },
+          { type: 'repair_dialogue_turn', text: 'Similarity becomes a weight.', graph_neutral: true },
+          { type: 'repair', text: 'Similarity becomes a normalized weight.', graph_neutral: true },
+          { type: 'model_bridge', text: 'Similarities are normalized into weights.', graph_neutral: true },
+          {
+            type: 'post_bridge_transfer_check',
+            text: 'The weights select relevant values.',
+            graph_neutral: true,
+            score_eligible: false,
+          },
+        ] };
+        const projected = projectLatestSedaAttemptEvent({
+          training: null,
+          conceptId: 'c',
+          nodeId: 'n',
+          sessionId: 'sess-nested',
+          now: '2026-07-15T12:00:00.000Z',
+          data,
+        });
+        const record = projected.node_records.n;
+        assert.equal(record.attempts.length, 1);
+        assert.equal(record.study_revealed_at, '2026-07-15T12:00:00.000Z');
+        assert.deepEqual(record.repairs.map(({ text }) => text), [
+          'Similarity becomes a normalized weight.',
+        ]);
+        assert.equal(
+          record.attempts.some((attempt) => attempt.user_text === 'The weights select relevant values.'),
+          false,
+          'graph-neutral transfer must not become mastery evidence',
+        );
+        assert.equal(projectLatestSedaAttemptEvent({
+          training: projected,
+          conceptId: 'c', nodeId: 'n', sessionId: 'sess-nested', data,
+        }), null, 'same progress must be idempotent');
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_completed_record_reconciles_early_cold_event_without_duplicate() -> None:
     result = run_node_module(
         """


### PR DESCRIPTION
Context & Intent
- What problem does this solve? The post-repair flow previously ended in a visually heavy, ambiguous CTA and could imply closure without new reconstruction evidence. This slice makes the unchanged graph explicit, recommends only a genuinely ready room, preserves a break path, and carries completed SEDA work into study without losing its verdict.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Codex flawless-loop stabilization, with hard-code-review and Khan-Hassabis product review gates.

Implementation Details
- Brief overview of technical changes (files touched, key logic). Adds an interactive post-repair constellation and progressive action rail; centralizes SEDA surface presentation; preserves repair-check state through learner sync; routes room entry through the shared controller; tightens typography, color, focus, responsive, and accessibility behavior; and adds unit and Playwright regressions.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). SEDA remains the pedagogical route owner, evidence projection remains graph-neutral, training derivation remains the graph-truth owner, and the room UI only renders and routes those states. No schema, dependency, or backend trust-boundary change.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; the change is frontend state projection and rendering, with existing APIs unchanged.
- [x] Are there SSRF or error-leakage risks in new external calls? No new external calls were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable; ingestion is unchanged.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Yes; the destination opens on a blank reconstruction field before study.
- [x] Does the graph still tell the truth (no faking mastery)? Yes; repair and pressure checks remain graph-neutral, and recommendation edges are distinct from evidence edges.
- [x] Is the active cognitive target explicitly clear to the user? Yes; the ready room, current correction, and next reconstruction action are named in the graph and action rail.

Branch: feat/reveal-repair-coherence
Base: main
Diff summary: 29 files changed, 2,669 insertions, 430 deletions across post-repair UI, nested SEDA surfaces, learner-state sync, visual polish, and regression proof.
