### PR TITLE
[codex] Recover slow-loaded room labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -438,7 +438,7 @@ I'm fuzzy on…
 
   <script src="/js/drill-chamber.js?v=20"></script>
   <script type="module" src="/js/app.js?v=213"></script>
-  <script type="module" src="/js/floating-room-label.js?v=10"></script>
+  <script type="module" src="/js/floating-room-label.js?v=11"></script>
   <script type="module" src="/js/iso-board-state-surface.js?v=10"></script>
   <script type="module" src="/js/feedback.js?v=6"></script>
 

--- a/public/js/floating-room-label.js
+++ b/public/js/floating-room-label.js
@@ -176,6 +176,7 @@ import { Bus } from './bus.js';
       return;
     }
     refresh();
+    requestAnimationFrame(showFocusedTile);
     Bus.on('grid:rendered', refresh);
     Bus.on('dashboard:shown', () => {
       refresh();


### PR DESCRIPTION
Context & Intent
- What problem does this solve? Production latency can let a keyboard learner focus a Desk tile before the asynchronously loaded room-label positioning module is ready, leaving valid focus with no visible label.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Production-smoke follow-up to Codex flawless-loop stabilization in PR #307.

Implementation Details
- Brief overview of technical changes (files touched, key logic). Reconciles the currently focused tile once after the room-label module binds, and bumps the frontend cache pin from v10 to v11.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Frontend Desk presentation only; no graph, training, SEDA, backend, schema, or dependency boundary changes.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; the fix was prompted by and reproduced under slow production-style asset loading.
- [x] Are there SSRF or error-leakage risks in new external calls? No new calls were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? Unchanged; this fixes only the Desk focus label.
- [x] Does the graph still tell the truth (no faking mastery)? Unchanged; no learner evidence or graph state is mutated.
- [x] Is the active cognitive target explicitly clear to the user? Yes; the already-focused room now regains its visible label after async bootstrap.

Branch: feat/room-label-focus-race
Base: main
Diff summary: 2 files changed, 2 insertions, 1 deletion; one focus reconciliation frame and one asset cache-pin bump.
