### PR TITLE
[codex] Restore compact desktop Desk board width

### DIFF
--- a/public/css/board-first.css
+++ b/public/css/board-first.css
@@ -9,6 +9,7 @@
 /* Remove the giant card feel while preserving the same Desk view container. */
 .hero-card {
   box-sizing: border-box;
+  flex-direction: column;
   width: 100%;
   max-width: 960px;
   min-height: 100dvh;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=177'     layer(components);
+@import '../styles.css?v=178'     layer(components);
 @import '../antigravity.css?v=41' layer(legacy);
 @import 'paper.css?v=22'          layer(paper);

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=196">
+  <link rel="stylesheet" href="/css/index.css?v=197">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=21">
 </head>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,7 +3,7 @@
 @import './css/crystal.css?v=71';
 @import './css/components.css?v=103';
 @import './css/layout.css?v=112';
-@import './css/board-first.css?v=9';
+@import './css/board-first.css?v=10';
 @import './css/approach-reveals.css?v=6';
 @import './css/iso-board-state-surface.css?v=8';
 @import './css/concept-page.css?v=61';

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -6143,12 +6143,15 @@ def test_desk_board_expands_after_first_saved_session(
                          w: Math.round(b.width), h: Math.round(b.height) } : null;
         };
         const heroCard = document.querySelector('.hero-card.intro-page');
+        const deskFrame = document.querySelector('.desk-frame');
         const gridContainer = document.getElementById('grid-container');
         const grid = document.getElementById('grid-svg');
         const tiles = Array.from(document.querySelectorAll('#grid-svg .tile-group'));
         const gridBox = grid?.getBoundingClientRect();
         return {
             heroCard: r(heroCard),
+            heroDirection: heroCard ? getComputedStyle(heroCard).flexDirection : null,
+            deskFrame: r(deskFrame),
             gridContainer: r(gridContainer),
             gridContainerDisplay: gridContainer
                 ? window.getComputedStyle(gridContainer).display : null,
@@ -6302,6 +6305,24 @@ def test_desk_board_expands_after_first_saved_session(
     assert narrow["panel"]["x"] >= 0
     assert narrow["panel"]["x"] + narrow["panel"]["w"] <= 320
     assert 254 <= narrow["svg"]["w"] <= 262
+    assert clean_page.evaluate(
+        "document.documentElement.scrollWidth <= window.innerWidth"
+    )
+
+    # The user's compact desktop viewport still has enough room for the
+    # canonical board. Keep the Desk frame stacked so the header cannot split
+    # the panel into a narrow second column.
+    clean_page.set_viewport_size({"width": 1012, "height": 1114})
+    clean_page.wait_for_function("window.innerWidth === 1012")
+    compact_desktop = clean_page.evaluate(sample_script)
+    assert compact_desktop["heroDirection"] == "column"
+    assert compact_desktop["deskFrame"]["x"] == compact_desktop["panel"]["x"]
+    assert compact_desktop["deskFrame"]["w"] == compact_desktop["panel"]["w"]
+    assert compact_desktop["panel"]["w"] >= 520
+    assert 400 <= compact_desktop["svg"]["w"] <= 420
+    panel_center = compact_desktop["panel"]["x"] + compact_desktop["panel"]["w"] / 2
+    board_center = compact_desktop["svg"]["x"] + compact_desktop["svg"]["w"] / 2
+    assert abs(panel_center - board_center) <= 1
     assert clean_page.evaluate(
         "document.documentElement.scrollWidth <= window.innerWidth"
     )


### PR DESCRIPTION
Context & Intent
- What problem does this solve? The Desk inherited a row layout at compact desktop widths, narrowing the canonical board and making the 1012x1114 desktop viewport look incorrectly mobile-sized.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Desktop Desk sizing stabilization.
Implementation Details
- Brief overview of technical changes (files touched, key logic). Stack the Desk hero vertically in board-first CSS, advance the stylesheet cache-pin chain, and add a 1012x1114 Chromium geometry regression.
- Note any specific architectural boundaries crossed (e.g., frontend graph logic vs. backend drill routing). Frontend layout and browser-test coverage only; graph, evidence, persistence, and backend routing are unchanged. Verification: cache-pin checker, doctor, 62-scenario local browser smoke, and responsive visual proof from 320 to 1600 pixels.
MVP / Deployment Risk Check
- [ ] Does this logic rely on local behavior that might fail in Vercel serverless?
- [ ] Are there SSRF or error-leakage risks in new external calls?
- [ ] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved?
UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"?
- [x] Does the graph still tell the truth (no faking mastery)?
- [x] Is the active cognitive target explicitly clear to the user?
Branch: feat/desk-desktop-sizing
Base: main
Diff summary: 5 files changed; Desk layout direction fixed, cache pins advanced, and one compact-desktop browser regression added.