### PR TITLE
[codex] Consolidate Desk state CSS ownership

### DIFF
--- a/public/antigravity.css
+++ b/public/antigravity.css
@@ -991,11 +991,6 @@ body.antigravity-theme .desk-index-count {
   font-variant-numeric: tabular-nums;
 }
 
-body.antigravity-theme[data-desk-first-use="false"] #grid-container {
-  width: min(420px, calc(100% - 24px));
-  margin: var(--space-8) auto var(--space-6);
-}
-
 body.antigravity-theme[data-desk-first-use="false"] .desk-ready-filter-host {
   padding: 0 var(--space-4);
 }
@@ -1081,71 +1076,11 @@ body.antigravity-theme .desk-ready-filter.is-active .desk-ready-filter__count {
   background: rgba(144, 103, 198, 0.22);
 }
 
-/* ── Due marks on the board ────────────────────────────────── */
+/* This stays in the legacy layer until selected-state specificity is simplified. */
 body.antigravity-theme .tile-group.is-due .tile-highlight {
   stroke: var(--ag-violet);
   stroke-width: 1.75;
   opacity: 0.98;
-}
-
-body.antigravity-theme .concept-pin-due-ring {
-  fill: none;
-  stroke: rgba(144, 103, 198, 0.55);
-  stroke-width: 1.4;
-  opacity: 0.7;
-  transform-box: fill-box;
-  transform-origin: center;
-}
-
-/* Motion is opt-in with the Due filter — ambient breathe/ring off by default. */
-body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-due-ring {
-  animation: desk-due-ring 2.8s ease-in-out infinite;
-}
-
-body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-crystal {
-  animation: desk-due-breathe 2.8s ease-in-out infinite;
-}
-
-body.antigravity-theme .tile-group.is-due .cp-glow {
-  fill: rgba(144, 103, 198, 0.28);
-}
-
-body.antigravity-theme .tile-group.is-filtered-out {
-  opacity: 0.16;
-  filter: grayscale(0.45);
-  transition: opacity 260ms ease, filter 260ms ease;
-  pointer-events: none;
-}
-
-body.antigravity-theme .tile-group:not(.is-filtered-out) {
-  transition: opacity 260ms ease, filter 260ms ease;
-}
-
-body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due {
-  filter: drop-shadow(0 10px 18px rgba(144, 103, 198, 0.22));
-}
-
-@keyframes desk-due-breathe {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-2.5px); }
-}
-
-@keyframes desk-due-ring {
-  0%, 100% {
-    opacity: 0.55;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.95;
-    transform: scale(1.06);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-crystal,
-  body.antigravity-theme #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-due-ring {
-    animation: none;
-  }
 }
 
 /* ── Selection strip under the board ───────────────────────── */

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -19,6 +19,6 @@
 
 @layer components, legacy, paper;
 
-@import '../styles.css?v=178'     layer(components);
-@import '../antigravity.css?v=41' layer(legacy);
+@import '../styles.css?v=179'     layer(components);
+@import '../antigravity.css?v=42' layer(legacy);
 @import 'paper.css?v=22'          layer(paper);

--- a/public/css/iso-board-state-surface.css
+++ b/public/css/iso-board-state-surface.css
@@ -10,6 +10,11 @@
   width: min(420px, calc(100vw - 20px));
 }
 
+body.antigravity-theme[data-desk-first-use="false"] #grid-container {
+  width: min(420px, calc(100% - 24px));
+  margin: var(--space-8) auto var(--space-6);
+}
+
 #grid-container.is-first-use {
   width: clamp(11.5rem, 50vw, 12.5rem);
 }
@@ -43,6 +48,59 @@
 .tile-group[data-board-state="fractured"] {
   --iso-board-state-color: var(--danger);
   --iso-board-state-rgb: var(--danger-rgb);
+}
+
+.concept-pin-due-ring {
+  fill: none;
+  stroke: rgba(144, 103, 198, 0.55);
+  stroke-width: 1.4;
+  opacity: 0.7;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+/* Motion is opt-in with the Ready filter. */
+#grid-container.is-ready-filtered .tile-group.is-due .concept-pin-due-ring {
+  animation: desk-due-ring 2.8s ease-in-out infinite;
+}
+
+#grid-container.is-ready-filtered .tile-group.is-due .concept-pin-crystal {
+  animation: desk-due-breathe 2.8s ease-in-out infinite;
+}
+
+.tile-group.is-due .cp-glow {
+  fill: rgba(144, 103, 198, 0.28);
+}
+
+#grid-container .tile-group.is-filtered-out {
+  opacity: 0.16;
+  filter: grayscale(0.45);
+  transition: opacity 260ms ease, filter 260ms ease;
+  pointer-events: none;
+}
+
+.tile-group:not(.is-filtered-out) {
+  transition: opacity 260ms ease, filter 260ms ease;
+}
+
+#grid-container.is-ready-filtered .tile-group.is-due {
+  filter: drop-shadow(0 10px 18px rgba(144, 103, 198, 0.22));
+}
+
+@keyframes desk-due-breathe {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2.5px); }
+}
+
+@keyframes desk-due-ring {
+  0%, 100% {
+    opacity: 0.55;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.95;
+    transform: scale(1.06);
+  }
 }
 
 /* Top-front-left light: bright top, calmer left wall, deeper right wall. */
@@ -387,6 +445,11 @@ body.night #grid-container.is-first-use .empty-tile-affordance__line {
 
   .room-label {
     transform: none !important;
+  }
+
+  #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-crystal,
+  #grid-container.is-ready-filtered .tile-group.is-due .concept-pin-due-ring {
+    animation: none;
   }
 }
 html[data-motion="reduced"] .concept-pin,

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=6">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=6">
   <link rel="shortcut icon" href="/favicon-32x32.png?v=6">
-  <link rel="stylesheet" href="/css/index.css?v=197">
+  <link rel="stylesheet" href="/css/index.css?v=198">
   <link rel="stylesheet" href="/css/drill-chamber.css?v=21">
 </head>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,5 +5,5 @@
 @import './css/layout.css?v=112';
 @import './css/board-first.css?v=10';
 @import './css/approach-reveals.css?v=6';
-@import './css/iso-board-state-surface.css?v=8';
+@import './css/iso-board-state-surface.css?v=9';
 @import './css/concept-page.css?v=61';

--- a/tests/e2e/test_learner_state_due_desk.py
+++ b/tests/e2e/test_learner_state_due_desk.py
@@ -260,6 +260,16 @@ def test_learner_state_and_due_desk_browser_contracts(
               ],
               clusters: [],
             }),
+          }, {
+            id: 'fresh-c2',
+            name: 'Fresh Session',
+            state: 'growing',
+            createdAt: now,
+            graphData: JSON.stringify({
+              metadata: { id: 'core', label: 'Fresh model' },
+              backbone: [{ id: 'fresh-node', label: 'Fresh node' }],
+              clusters: [],
+            }),
           }]));
           localStorage.setItem('learnops_active', 'due-c1');
           localStorage.setItem('socratink:training:v1:due-c1', JSON.stringify({
@@ -292,6 +302,25 @@ def test_learner_state_and_due_desk_browser_contracts(
     clean_page.locator("#desk-ready-filter").click()
     expect(clean_page.locator("#desk-ready-filter")).to_have_attribute("aria-pressed", "true")
     expect(clean_page.locator("#grid-container")).to_have_class(re.compile(r"is-ready-filtered"))
+
+    clean_page.evaluate(
+        """() => {
+          document.documentElement.dataset.theme = 'dark';
+          document.body.dataset.theme = 'dark';
+          document.body.classList.add('night');
+        }"""
+    )
+    filtered_occupied = clean_page.locator(
+        "#grid-container .tile-group.is-filtered-out:not(.empty)"
+    )
+    expect(filtered_occupied).to_have_count(1)
+    expect(filtered_occupied).to_have_css("filter", "grayscale(0.45)")
+    expect(filtered_occupied).to_have_css("opacity", "0.16")
+
+    clean_page.emulate_media(reduced_motion="reduce")
+    expect(
+        clean_page.locator("#grid-container .tile-group.is-due .concept-pin-due-ring")
+    ).to_have_css("animation-name", "none")
 
     # Filtered empty tiles must no-op selectTile.
     clean_page.evaluate("window.App.selectTile(8)")


### PR DESCRIPTION
Context & Intent
- What problem does this solve? Desk state styles were split between the legacy overlay and the dedicated board-state surface, making ownership ambiguous and allowing future edits to drift.
- Which agent or track does this stem from (e.g., Theta research, MVP stabilization)? Supervised repository cleanup and CSS ownership stabilization.

Implementation Details
- Move Ready and due-state rules into public/css/iso-board-state-surface.css, retain the selected-state exception in the legacy layer, and advance the full static cache-pin chain.
- Preserve dark-theme filter precedence with a canonical state selector and add browser regression coverage for occupied filtered tiles and reduced motion. This crosses only the frontend CSS and browser-contract boundary.

MVP / Deployment Risk Check
- [x] Does this logic rely on local behavior that might fail in Vercel serverless? No; this is static CSS plus browser coverage.
- [x] Are there SSRF or error-leakage risks in new external calls? No external calls were added.
- [x] If dealing with ingestion (e.g., YouTube), is the manual fallback preserved? Not applicable.

UX Framework Alignment (For UI/Drill changes)
- [x] Does this strictly enforce "Generation Before Recognition"? The learner flow is unchanged.
- [x] Does the graph still tell the truth (no faking mastery)? Training evidence and graph semantics are unchanged.
- [x] Is the active cognitive target explicitly clear to the user? The Due filter and reconstruction action remain evidence-derived and unchanged.

Branch: feat/desk-css-ownership
Base: main
Diff summary: 6 files changed, 97 insertions, 70 deletions; consolidates Desk state CSS, advances cache pins, and adds dark/reduced-motion browser regression coverage.